### PR TITLE
[#3] Error model — AppError hierarchy + Express error handler

### DIFF
--- a/backend/src/errors/AppError.ts
+++ b/backend/src/errors/AppError.ts
@@ -1,0 +1,40 @@
+export class AppError extends Error {
+  statusCode: number;
+  code?: string;
+
+  constructor(statusCode: number, message: string, code?: string) {
+    super(message);
+    this.name = 'AppError';
+    this.statusCode = statusCode;
+    this.code = code;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+export class NotFoundError extends AppError {
+  constructor(resource: string, id: string | number) {
+    super(404, `${resource} with id ${id} not found`, 'NOT_FOUND');
+    this.name = 'NotFoundError';
+  }
+}
+
+export class ForbiddenError extends AppError {
+  constructor(message = 'Forbidden') {
+    super(403, message, 'FORBIDDEN');
+    this.name = 'ForbiddenError';
+  }
+}
+
+export class ValidationError extends AppError {
+  constructor(message: string) {
+    super(400, message, 'VALIDATION_ERROR');
+    this.name = 'ValidationError';
+  }
+}
+
+export class ConflictError extends AppError {
+  constructor(message: string) {
+    super(409, message, 'CONFLICT');
+    this.name = 'ConflictError';
+  }
+}

--- a/backend/src/middlewares/errorHandler.ts
+++ b/backend/src/middlewares/errorHandler.ts
@@ -1,0 +1,26 @@
+import { Request, Response, NextFunction } from 'express';
+import { AppError } from '../errors/AppError';
+
+export function errorHandler(
+  err: unknown,
+  _req: Request,
+  res: Response,
+  _next: NextFunction,
+): void {
+  if (err instanceof AppError) {
+    const body: { statusCode: number; message: string; code?: string } = {
+      statusCode: err.statusCode,
+      message: err.message,
+      ...(err.code !== undefined && { code: err.code }),
+    };
+    res.status(err.statusCode).json(body);
+    return;
+  }
+
+  // Unknown / unexpected errors — never leak stack traces in production
+  res.status(500).json({
+    statusCode: 500,
+    message: 'Internal Server Error',
+    code: 'INTERNAL_ERROR',
+  });
+}

--- a/backend/tests/middlewares/errorHandler.test.ts
+++ b/backend/tests/middlewares/errorHandler.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Request, Response, NextFunction } from 'express';
+import { errorHandler } from '../../src/middlewares/errorHandler';
+import {
+  AppError,
+  NotFoundError,
+  ForbiddenError,
+  ValidationError,
+  ConflictError,
+} from '../../src/errors/AppError';
+
+function makeRes() {
+  const res = {
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn().mockReturnThis(),
+  } as unknown as Response;
+  return res;
+}
+
+const req = {} as Request;
+const next = vi.fn() as unknown as NextFunction;
+
+describe('errorHandler middleware', () => {
+  it('maps NotFoundError → 404 with ApiError body', () => {
+    const res = makeRes();
+    const err = new NotFoundError('user', 42);
+    errorHandler(err, req, res, next);
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({
+      statusCode: 404,
+      message: 'user with id 42 not found',
+      code: 'NOT_FOUND',
+    });
+  });
+
+  it('maps ForbiddenError → 403 with ApiError body', () => {
+    const res = makeRes();
+    const err = new ForbiddenError();
+    errorHandler(err, req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({
+      statusCode: 403,
+      message: 'Forbidden',
+      code: 'FORBIDDEN',
+    });
+  });
+
+  it('maps ForbiddenError with custom message → 403', () => {
+    const res = makeRes();
+    const err = new ForbiddenError('You shall not pass');
+    errorHandler(err, req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect((res.json as ReturnType<typeof vi.fn>).mock.calls[0][0].message).toBe('You shall not pass');
+  });
+
+  it('maps ValidationError → 400 with ApiError body', () => {
+    const res = makeRes();
+    const err = new ValidationError('username is required');
+    errorHandler(err, req, res, next);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      statusCode: 400,
+      message: 'username is required',
+      code: 'VALIDATION_ERROR',
+    });
+  });
+
+  it('maps ConflictError → 409 with ApiError body', () => {
+    const res = makeRes();
+    const err = new ConflictError('username already taken');
+    errorHandler(err, req, res, next);
+    expect(res.status).toHaveBeenCalledWith(409);
+    expect(res.json).toHaveBeenCalledWith({
+      statusCode: 409,
+      message: 'username already taken',
+      code: 'CONFLICT',
+    });
+  });
+
+  it('maps generic AppError → correct statusCode', () => {
+    const res = makeRes();
+    const err = new AppError(418, "I'm a teapot", 'TEAPOT');
+    errorHandler(err, req, res, next);
+    expect(res.status).toHaveBeenCalledWith(418);
+    expect(res.json).toHaveBeenCalledWith({
+      statusCode: 418,
+      message: "I'm a teapot",
+      code: 'TEAPOT',
+    });
+  });
+
+  it('maps unknown Error → 500 without stack', () => {
+    const res = makeRes();
+    const err = new Error('something exploded');
+    errorHandler(err, req, res, next);
+    expect(res.status).toHaveBeenCalledWith(500);
+    const body = (res.json as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(body.statusCode).toBe(500);
+    expect(body.message).toBe('Internal Server Error');
+    expect(body.stack).toBeUndefined();
+  });
+
+  it('maps non-Error unknown → 500', () => {
+    const res = makeRes();
+    errorHandler('string error', req, res, next);
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect((res.json as ReturnType<typeof vi.fn>).mock.calls[0][0].statusCode).toBe(500);
+  });
+});


### PR DESCRIPTION
## Summary

- `AppError` base class with `statusCode`, `message`, `code` fields
- `NotFoundError` (404), `ForbiddenError` (403), `ValidationError` (400), `ConflictError` (409) subclasses
- Express 5 `errorHandler` middleware: maps `AppError` → status + `ApiError`-shaped JSON; unknown errors → 500, no stack leak
- 8 Vitest unit tests — all pass ✅, TypeScript clean ✅

## Test plan

- [x] `NotFoundError('user', 42)` → 404 with `ApiError` body
- [x] `ForbiddenError` → 403
- [x] `ValidationError` → 400
- [x] `ConflictError` → 409
- [x] Unknown `Error` → 500, no stack exposed
- [x] Non-`Error` unknown → 500
- [x] Generic `AppError` → correct statusCode passthrough
- [x] TypeScript: `tsc --noEmit` passes

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)