### PR TITLE
feat(#6): repository interfaces + init migration SQL

### DIFF
--- a/backend/migrations/20260529000000_init.sql
+++ b/backend/migrations/20260529000000_init.sql
@@ -1,0 +1,49 @@
+-- v1 scope: users, chat_rooms, messages, room_members
+
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+CREATE TABLE users (
+  user_id         UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  name            VARCHAR(255) NOT NULL,
+  email           VARCHAR(255) NOT NULL UNIQUE,
+  password_hash   VARCHAR(255) NOT NULL,
+  bio             TEXT,
+  avatar_url      VARCHAR(2048),
+  warning_enabled BOOLEAN     NOT NULL DEFAULT false,
+  warning_days    INTEGER     NOT NULL DEFAULT 0,
+  last_activity   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE chat_rooms (
+  room_id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  type             VARCHAR(10) NOT NULL CHECK (type IN ('private', 'group')),
+  name             VARCHAR(255),
+  avatar_url       VARCHAR(2048),
+  invite_code      VARCHAR(255),
+  require_approval BOOLEAN     NOT NULL DEFAULT false,
+  view_history     BOOLEAN     NOT NULL DEFAULT true,
+  is_archived      BOOLEAN     NOT NULL DEFAULT false,
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE messages (
+  message_id  UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  room_id     UUID        NOT NULL REFERENCES chat_rooms(room_id) ON DELETE CASCADE,
+  sender_id   UUID        REFERENCES users(user_id) ON DELETE SET NULL,
+  content     TEXT        NOT NULL,
+  reply_to_id UUID        REFERENCES messages(message_id) ON DELETE SET NULL,
+  is_recalled BOOLEAN     NOT NULL DEFAULT false,
+  sent_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE room_members (
+  room_id      UUID        NOT NULL REFERENCES chat_rooms(room_id) ON DELETE CASCADE,
+  user_id      UUID        NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+  role         VARCHAR(10) NOT NULL CHECK (role IN ('owner', 'admin', 'member', 'pending')),
+  nickname     VARCHAR(255),
+  is_muted     BOOLEAN     NOT NULL DEFAULT false,
+  last_read_id UUID        REFERENCES messages(message_id) ON DELETE SET NULL,
+  join_time    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (room_id, user_id)
+);

--- a/backend/src/repositories/IMessageRepository.ts
+++ b/backend/src/repositories/IMessageRepository.ts
@@ -1,0 +1,8 @@
+import type { Message } from '@shared/types';
+
+export interface IMessageRepository {
+  findById(messageId: string): Promise<Message | null>;
+  findByRoom(roomId: string, opts: { beforeId?: string; limit: number }): Promise<Message[]>;
+  create(data: Pick<Message, 'roomId' | 'senderId' | 'content' | 'replyToId'>): Promise<Message>;
+  markRecalled(messageId: string): Promise<Message>;
+}

--- a/backend/src/repositories/IRoomMemberRepository.ts
+++ b/backend/src/repositories/IRoomMemberRepository.ts
@@ -1,0 +1,9 @@
+import type { RoomMember } from '@shared/types';
+
+export interface IRoomMemberRepository {
+  findMember(roomId: string, userId: string): Promise<RoomMember | null>;
+  findByRoom(roomId: string): Promise<RoomMember[]>;
+  add(data: Pick<RoomMember, 'roomId' | 'userId' | 'role'>): Promise<RoomMember>;
+  update(roomId: string, userId: string, data: Partial<Pick<RoomMember, 'role' | 'nickname' | 'isMuted' | 'lastReadId'>>): Promise<RoomMember>;
+  remove(roomId: string, userId: string): Promise<void>;
+}

--- a/backend/src/repositories/IRoomRepository.ts
+++ b/backend/src/repositories/IRoomRepository.ts
@@ -1,0 +1,9 @@
+import type { Room } from '@shared/types';
+
+export interface IRoomRepository {
+  findById(roomId: string): Promise<Room | null>;
+  findByMember(userId: string): Promise<Room[]>;
+  create(data: Pick<Room, 'type' | 'name' | 'requireApproval' | 'viewHistory'>): Promise<Room>;
+  update(roomId: string, data: Partial<Pick<Room, 'name' | 'avatarUrl' | 'requireApproval' | 'viewHistory' | 'isArchived'>>): Promise<Room>;
+  delete(roomId: string): Promise<void>;
+}

--- a/backend/src/repositories/IUserRepository.ts
+++ b/backend/src/repositories/IUserRepository.ts
@@ -1,0 +1,9 @@
+import type { User } from '@shared/types';
+
+export interface IUserRepository {
+  findById(userId: string): Promise<User | null>;
+  findByEmail(email: string): Promise<User | null>;
+  create(data: { name: string; email: string; passwordHash: string }): Promise<User>;
+  update(userId: string, data: Partial<Pick<User, 'name' | 'bio' | 'avatarUrl' | 'warningEnabled' | 'warningDays' | 'lastActivity'>>): Promise<User>;
+  delete(userId: string): Promise<void>;
+}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "target": "es2022",
     "module": "commonjs",
+    "rootDir": "..",
     "outDir": "./dist",
     "strict": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary
- Add 4 TypeScript repository interfaces (`IUserRepository`, `IRoomRepository`, `IMessageRepository`, `IRoomMemberRepository`) aligned with `@shared/types`
- Add `backend/migrations/20260529000000_init.sql` — creates `users`, `chat_rooms`, `messages`, `room_members` with correct FK constraints
- Fix `backend/tsconfig.json`: add `rootDir: ".."` so `@shared/types` imports compile without TS6059

## Acceptance criteria checklist
- [x] `pnpm --prefix backend exec tsc --noEmit` passes
- [x] All IDs are `string` (UUID) — no `number`
- [x] `IUserRepository` uses `findByEmail` — no `findByUsername`
- [x] `IMessageRepository` fields: `senderId`, `sentAt` — not `userId`/`createdAt`
- [x] `IRoomMemberRepository` timestamp: `joinTime` — not `joinedAt`
- [x] Migration uses snake_case columns exclusively
- [x] `room_members.role` CHECK includes all four: `'owner'`, `'admin'`, `'member'`, `'pending'`
- [x] `messages.sender_id` uses `ON DELETE SET NULL`
- [x] v1 scope locked: exactly `users`, `chat_rooms`, `messages`, `room_members`
- [x] No pg implementations in this PR

## Test plan
- [x] Run `pnpm --prefix backend exec tsc --noEmit` — must exit 0
- [x] Apply migration to a fresh Postgres instance and verify all 4 tables create without error
- [x] Verify `messages.sender_id` allows NULL (DELETE a user and confirm row stays with NULL sender)

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)