### PR TITLE
feat: Auth Middleware and UserRepository (Closes #5, #7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,4 +45,5 @@ jobs:
           node-version: 20
       - run: npm install -g pnpm
       - run: pnpm --prefix backend install
+      - run: DATABASE_URL=$DATABASE_URL_TEST pnpm --prefix backend run migrate:up
       - run: pnpm --prefix backend run test:integration

--- a/backend/migrations/20260529000000_init.sql
+++ b/backend/migrations/20260529000000_init.sql
@@ -1,0 +1,49 @@
+-- v1 scope: users, chat_rooms, messages, room_members
+
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+CREATE TABLE users (
+  user_id         UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  name            VARCHAR(255) NOT NULL,
+  email           VARCHAR(255) NOT NULL UNIQUE,
+  password_hash   VARCHAR(255) NOT NULL,
+  bio             TEXT,
+  avatar_url      VARCHAR(2048),
+  warning_enabled BOOLEAN     NOT NULL DEFAULT false,
+  warning_days    INTEGER     NOT NULL DEFAULT 0,
+  last_activity   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE chat_rooms (
+  room_id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  type             VARCHAR(10) NOT NULL CHECK (type IN ('private', 'group')),
+  name             VARCHAR(255),
+  avatar_url       VARCHAR(2048),
+  invite_code      VARCHAR(255),
+  require_approval BOOLEAN     NOT NULL DEFAULT false,
+  view_history     BOOLEAN     NOT NULL DEFAULT true,
+  is_archived      BOOLEAN     NOT NULL DEFAULT false,
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE messages (
+  message_id  UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  room_id     UUID        NOT NULL REFERENCES chat_rooms(room_id) ON DELETE CASCADE,
+  sender_id   UUID        REFERENCES users(user_id) ON DELETE SET NULL,
+  content     TEXT        NOT NULL,
+  reply_to_id UUID        REFERENCES messages(message_id) ON DELETE SET NULL,
+  is_recalled BOOLEAN     NOT NULL DEFAULT false,
+  sent_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE room_members (
+  room_id      UUID        NOT NULL REFERENCES chat_rooms(room_id) ON DELETE CASCADE,
+  user_id      UUID        NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+  role         VARCHAR(10) NOT NULL CHECK (role IN ('owner', 'admin', 'member', 'pending')),
+  nickname     VARCHAR(255),
+  is_muted     BOOLEAN     NOT NULL DEFAULT false,
+  last_read_id UUID        REFERENCES messages(message_id) ON DELETE SET NULL,
+  join_time    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (room_id, user_id)
+);

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,7 +12,7 @@
     "migrate:create": "node-pg-migrate create",
     "test": "vitest run",
     "test:unit": "vitest run --passWithNoTests tests/unit",
-    "test:integration": "vitest run tests/integration",
+    "test:integration": "vitest run --config vitest.integration.config.ts tests/integration",
     "test:db:up": "docker compose -f ../docker-compose.test.yml up -d --wait",
     "test:db:down": "docker compose -f ../docker-compose.test.yml down"
   },

--- a/backend/src/auth/jwt.ts
+++ b/backend/src/auth/jwt.ts
@@ -1,0 +1,23 @@
+import jwt from 'jsonwebtoken';
+import type { JwtPayload } from '@shared/types';
+
+export const getJwtSecret = (): string => {
+  const secret = process.env.JWT_SECRET;
+  if (!secret) {
+    if (process.env.NODE_ENV === 'production') {
+      throw new Error('JWT_SECRET is not defined in production environment.');
+    }
+    return 'default-dev-secret';
+  }
+  return secret;
+};
+
+export const signToken = (payload: JwtPayload): string => {
+  const secret = getJwtSecret();
+  return jwt.sign(payload, secret, { expiresIn: '7d' });
+};
+
+export const verifyToken = (token: string): JwtPayload => {
+  const secret = getJwtSecret();
+  return jwt.verify(token, secret) as JwtPayload;
+};

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -66,7 +66,7 @@ app.post("/auth/login", async (req, res) => {
 
 app.get("/rooms", async (req, res) => {
   try {
-    const result = await pool.query("SELECT * FROM rooms");
+    const result = await pool.query("SELECT * FROM chat_rooms");
     res.json(result.rows);
   } catch (error) {
     res.status(500).json({ error: "Failed to fetch rooms" });
@@ -76,7 +76,7 @@ app.get("/rooms", async (req, res) => {
 app.post("/rooms", async (req, res) => {
   const { name } = req.body;
   try {
-    const result = await pool.query("INSERT INTO rooms (name) VALUES ($1) RETURNING *", [name]);
+    const result = await pool.query("INSERT INTO chat_rooms (type, name) VALUES ('group', $1) RETURNING *", [name]);
     res.json(result.rows[0]);
   } catch (error) {
     res.status(400).json({ error: "Room creation failed" });
@@ -87,11 +87,11 @@ app.get("/rooms/:id/messages", async (req, res) => {
   const roomId = req.params.id;
   try {
     const result = await pool.query(
-      `SELECT m.*, u.username 
-       FROM messages m 
-       JOIN users u ON m.userId = u.id 
-       WHERE m.roomId = $1 
-       ORDER BY m.createdAt ASC`,
+      `SELECT m.*, u.name
+       FROM messages m
+       JOIN users u ON m.sender_id = u.user_id
+       WHERE m.room_id = $1
+       ORDER BY m.sent_at ASC`,
       [roomId]
     );
     res.json(result.rows);

--- a/backend/src/middlewares/authMiddleware.ts
+++ b/backend/src/middlewares/authMiddleware.ts
@@ -1,0 +1,21 @@
+import { Request, Response, NextFunction } from 'express';
+import { verifyToken } from '../auth/jwt';
+import { AppError } from '../errors/AppError';
+
+export const authMiddleware = (req: Request, res: Response, next: NextFunction): void => {
+  const authHeader = req.headers.authorization;
+
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    throw new AppError(401, 'Unauthorized: Missing or invalid Authorization header');
+  }
+
+  const token = authHeader.split(' ')[1];
+
+  try {
+    const payload = verifyToken(token);
+    req.user = payload;
+    next();
+  } catch (error) {
+    throw new AppError(401, 'Unauthorized: Invalid token');
+  }
+};

--- a/backend/src/repositories/IMessageRepository.ts
+++ b/backend/src/repositories/IMessageRepository.ts
@@ -1,0 +1,8 @@
+import type { Message } from '@shared/types';
+
+export interface IMessageRepository {
+  findById(messageId: string): Promise<Message | null>;
+  findByRoom(roomId: string, opts: { beforeId?: string; limit: number }): Promise<Message[]>;
+  create(data: Pick<Message, 'roomId' | 'senderId' | 'content' | 'replyToId'>): Promise<Message>;
+  markRecalled(messageId: string): Promise<Message>;
+}

--- a/backend/src/repositories/IRoomMemberRepository.ts
+++ b/backend/src/repositories/IRoomMemberRepository.ts
@@ -1,0 +1,9 @@
+import type { RoomMember } from '@shared/types';
+
+export interface IRoomMemberRepository {
+  findMember(roomId: string, userId: string): Promise<RoomMember | null>;
+  findByRoom(roomId: string): Promise<RoomMember[]>;
+  add(data: Pick<RoomMember, 'roomId' | 'userId' | 'role'>): Promise<RoomMember>;
+  update(roomId: string, userId: string, data: Partial<Pick<RoomMember, 'role' | 'nickname' | 'isMuted' | 'lastReadId'>>): Promise<RoomMember>;
+  remove(roomId: string, userId: string): Promise<void>;
+}

--- a/backend/src/repositories/IRoomRepository.ts
+++ b/backend/src/repositories/IRoomRepository.ts
@@ -1,0 +1,9 @@
+import type { Room } from '@shared/types';
+
+export interface IRoomRepository {
+  findById(roomId: string): Promise<Room | null>;
+  findByMember(userId: string): Promise<Room[]>;
+  create(data: Pick<Room, 'type' | 'name' | 'requireApproval' | 'viewHistory'>): Promise<Room>;
+  update(roomId: string, data: Partial<Pick<Room, 'name' | 'avatarUrl' | 'requireApproval' | 'viewHistory' | 'isArchived'>>): Promise<Room>;
+  delete(roomId: string): Promise<void>;
+}

--- a/backend/src/repositories/IUserRepository.ts
+++ b/backend/src/repositories/IUserRepository.ts
@@ -1,0 +1,9 @@
+import type { User } from '@shared/types';
+
+export interface IUserRepository {
+  findById(userId: string): Promise<User | null>;
+  findByEmail(email: string): Promise<User | null>;
+  create(data: { name: string; email: string; passwordHash: string }): Promise<User>;
+  update(userId: string, data: Partial<Pick<User, 'name' | 'bio' | 'avatarUrl' | 'warningEnabled' | 'warningDays' | 'lastActivity'>>): Promise<User>;
+  delete(userId: string): Promise<void>;
+}

--- a/backend/src/repositories/userRepository.ts
+++ b/backend/src/repositories/userRepository.ts
@@ -1,0 +1,100 @@
+import { Pool } from "pg";
+import type { User } from "@shared/types";
+import type { IUserRepository } from "./IUserRepository";
+
+function mapRowToUser(row: any): User {
+  return {
+    userId: row.user_id,
+    name: row.name,
+    email: row.email,
+    passwordHash: row.password_hash,
+    bio: row.bio ?? undefined,
+    avatarUrl: row.avatar_url ?? undefined,
+    warningEnabled: row.warning_enabled,
+    warningDays: row.warning_days,
+    lastActivity: row.last_activity,
+    createdAt: row.created_at,
+  };
+}
+
+export class UserRepository implements IUserRepository {
+  constructor(private db: Pool) {}
+
+  async findById(userId: string): Promise<User | null> {
+    const res = await this.db.query("SELECT * FROM users WHERE user_id = $1", [userId]);
+    if (res.rows.length === 0) return null;
+    return mapRowToUser(res.rows[0]);
+  }
+
+  async findByEmail(email: string): Promise<User | null> {
+    const res = await this.db.query("SELECT * FROM users WHERE email = $1", [email]);
+    if (res.rows.length === 0) return null;
+    return mapRowToUser(res.rows[0]);
+  }
+
+  async create(data: { name: string; email: string; passwordHash: string }): Promise<User> {
+    const res = await this.db.query(
+      `INSERT INTO users (name, email, password_hash)
+       VALUES ($1, $2, $3)
+       RETURNING *`,
+      [data.name, data.email, data.passwordHash]
+    );
+    return mapRowToUser(res.rows[0]);
+  }
+
+  async update(userId: string, data: Partial<Pick<User, "name" | "bio" | "avatarUrl" | "warningEnabled" | "warningDays" | "lastActivity">>): Promise<User> {
+    const fields: string[] = [];
+    const values: any[] = [];
+    let queryIdx = 1;
+
+    if (data.name !== undefined) {
+      fields.push(`name = $${queryIdx++}`);
+      values.push(data.name);
+    }
+    if (data.bio !== undefined) {
+      fields.push(`bio = $${queryIdx++}`);
+      values.push(data.bio);
+    }
+    if (data.avatarUrl !== undefined) {
+      fields.push(`avatar_url = $${queryIdx++}`);
+      values.push(data.avatarUrl);
+    }
+    if (data.warningEnabled !== undefined) {
+      fields.push(`warning_enabled = $${queryIdx++}`);
+      values.push(data.warningEnabled);
+    }
+    if (data.warningDays !== undefined) {
+      fields.push(`warning_days = $${queryIdx++}`);
+      values.push(data.warningDays);
+    }
+    if (data.lastActivity !== undefined) {
+      fields.push(`last_activity = $${queryIdx++}`);
+      values.push(data.lastActivity);
+    }
+
+    if (fields.length === 0) {
+      const res = await this.db.query("SELECT * FROM users WHERE user_id = $1", [userId]);
+      if (res.rows.length === 0) {
+        throw new Error("User not found");
+      }
+      return mapRowToUser(res.rows[0]);
+    }
+
+    values.push(userId);
+    const query = `
+      UPDATE users 
+      SET ${fields.join(", ")} 
+      WHERE user_id = $${queryIdx} 
+      RETURNING *
+    `;
+    const res = await this.db.query(query, values);
+    if (res.rows.length === 0) {
+        throw new Error("User not found");
+    }
+    return mapRowToUser(res.rows[0]);
+  }
+
+  async delete(userId: string): Promise<void> {
+    await this.db.query("DELETE FROM users WHERE user_id = $1", [userId]);
+  }
+}

--- a/backend/src/types/express.d.ts
+++ b/backend/src/types/express.d.ts
@@ -1,0 +1,9 @@
+import type { JwtPayload } from '@shared/types';
+
+declare global {
+  namespace Express {
+    interface Request {
+      user?: JwtPayload;
+    }
+  }
+}

--- a/backend/tests/helpers/resetDb.ts
+++ b/backend/tests/helpers/resetDb.ts
@@ -2,6 +2,7 @@ import { testPool } from './testPool';
 
 export async function resetDb(): Promise<void> {
   await testPool.query(
-    'TRUNCATE users, rooms, messages, room_members RESTART IDENTITY CASCADE'
+    'TRUNCATE users, chat_rooms, messages, room_members RESTART IDENTITY CASCADE'
   );
 }
+

--- a/backend/tests/integration/repositories/userRepository.test.ts
+++ b/backend/tests/integration/repositories/userRepository.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { UserRepository } from "../../../src/repositories/userRepository";
+import { testPool } from "../../helpers/testPool";
+import { resetDb } from "../../helpers/resetDb";
+
+describe("UserRepository (pg)", () => {
+  const repo = new UserRepository(testPool);
+
+  beforeEach(async () => {
+    await resetDb();
+  });
+
+  it("should create and get a user", async () => {
+    const user = await repo.create({
+      name: "Test User",
+      email: "test@example.com",
+      passwordHash: "hash123"
+    });
+
+    expect(user.userId).toBeDefined();
+    expect(user.name).toBe("Test User");
+    expect(user.email).toBe("test@example.com");
+    expect(user.passwordHash).toBe("hash123");
+    expect(user.createdAt).toBeInstanceOf(Date);
+
+    const fetched = await repo.findById(user.userId);
+    expect(fetched).toEqual(user);
+    
+    const byEmail = await repo.findByEmail("test@example.com");
+    expect(byEmail).toEqual(user);
+  });
+
+  it("should return null for non-existent user", async () => {
+    const nonExistentId = "00000000-0000-0000-0000-000000000000";
+    const fetched = await repo.findById(nonExistentId);
+    expect(fetched).toBeNull();
+    
+    const byEmail = await repo.findByEmail("notfound@example.com");
+    expect(byEmail).toBeNull();
+  });
+
+  it("should update a user", async () => {
+    const user = await repo.create({
+      name: "Old Name",
+      email: "update@example.com",
+      passwordHash: "hash"
+    });
+
+    const updated = await repo.update(user.userId, {
+      name: "New Name",
+      bio: "Hello world",
+      warningEnabled: true
+    });
+
+    expect(updated.name).toBe("New Name");
+    expect(updated.bio).toBe("Hello world");
+    expect(updated.warningEnabled).toBe(true);
+    expect(updated.email).toBe("update@example.com");
+
+    const fetched = await repo.findById(user.userId);
+    expect(fetched).toEqual(updated);
+  });
+
+  it("should delete a user", async () => {
+    const user = await repo.create({
+      name: "Delete Me",
+      email: "delete@example.com",
+      passwordHash: "hash"
+    });
+
+    await repo.delete(user.userId);
+
+    const fetched = await repo.findById(user.userId);
+    expect(fetched).toBeNull();
+  });
+});

--- a/backend/tests/integration/schema.test.ts
+++ b/backend/tests/integration/schema.test.ts
@@ -1,0 +1,194 @@
+import { beforeEach, afterAll, describe, it, expect } from 'vitest';
+import { testPool } from '../helpers/testPool';
+import { resetDb } from '../helpers/resetDb';
+
+describe('Database Schema & Constraints (PR#26)', () => {
+  beforeEach(async () => {
+    await resetDb();
+  });
+
+  afterAll(async () => {
+    await testPool.end();
+  });
+
+  describe('users table constraints', () => {
+    it('should successfully insert a user and hash password', async () => {
+      const res = await testPool.query(
+        `INSERT INTO users (name, email, password_hash) 
+         VALUES ('Alice', 'alice@test.com', 'hashedpassword') 
+         RETURNING user_id, warning_enabled, warning_days`
+      );
+      expect(res.rows[0].user_id).toBeDefined();
+      expect(res.rows[0].warning_enabled).toBe(false); // Default value
+      expect(res.rows[0].warning_days).toBe(0); // Default value
+    });
+
+    it('should prevent inserting duplicate emails', async () => {
+      await testPool.query(
+        "INSERT INTO users (name, email, password_hash) VALUES ('Alice', 'alice@test.com', 'hash')"
+      );
+      await expect(
+        testPool.query(
+          "INSERT INTO users (name, email, password_hash) VALUES ('Bob', 'alice@test.com', 'hash')"
+        )
+      ).rejects.toThrow(/unique constraint/i);
+    });
+  });
+
+  describe('chat_rooms table constraints', () => {
+    it('should allow valid room types ("private" and "group")', async () => {
+      const res1 = await testPool.query(
+        "INSERT INTO chat_rooms (type, name) VALUES ('private', 'Direct Message') RETURNING room_id"
+      );
+      const res2 = await testPool.query(
+        "INSERT INTO chat_rooms (type, name) VALUES ('group', 'DB Study Group') RETURNING room_id"
+      );
+      expect(res1.rows[0].room_id).toBeDefined();
+      expect(res2.rows[0].room_id).toBeDefined();
+    });
+
+    it('should reject invalid room types', async () => {
+      await expect(
+        testPool.query("INSERT INTO chat_rooms (type) VALUES ('invalid')")
+      ).rejects.toThrow(/check constraint/i);
+    });
+  });
+
+  describe('room_members table constraints', () => {
+    it('should allow valid roles ("owner", "admin", "member", "pending")', async () => {
+      const userRes = await testPool.query(
+        "INSERT INTO users (name, email, password_hash) VALUES ('User', 'user@test.com', 'hash') RETURNING user_id"
+      );
+      const userId = userRes.rows[0].user_id;
+
+      const roomRes = await testPool.query(
+        "INSERT INTO chat_rooms (type) VALUES ('private') RETURNING room_id"
+      );
+      const roomId = roomRes.rows[0].room_id;
+
+      const memberRes = await testPool.query(
+        `INSERT INTO room_members (room_id, user_id, role) 
+         VALUES ($1, $2, 'owner') RETURNING role`,
+        [roomId, userId]
+      );
+      expect(memberRes.rows[0].role).toBe('owner');
+    });
+
+    it('should reject invalid member roles', async () => {
+      const userRes = await testPool.query(
+        "INSERT INTO users (name, email, password_hash) VALUES ('User', 'user@test.com', 'hash') RETURNING user_id"
+      );
+      const userId = userRes.rows[0].user_id;
+
+      const roomRes = await testPool.query(
+        "INSERT INTO chat_rooms (type) VALUES ('private') RETURNING room_id"
+      );
+      const roomId = roomRes.rows[0].room_id;
+
+      await expect(
+        testPool.query(
+          `INSERT INTO room_members (room_id, user_id, role) VALUES ($1, $2, 'superuser')`,
+          [roomId, userId]
+        )
+      ).rejects.toThrow(/check constraint/i);
+    });
+  });
+
+  describe('Foreign Key Constraints and Cascades', () => {
+    let userId: string;
+    let roomId: string;
+
+    beforeEach(async () => {
+      const userRes = await testPool.query(
+        "INSERT INTO users (name, email, password_hash) VALUES ('Alice', 'alice@test.com', 'hash') RETURNING user_id"
+      );
+      userId = userRes.rows[0].user_id;
+
+      const roomRes = await testPool.query(
+        "INSERT INTO chat_rooms (type) VALUES ('group') RETURNING room_id"
+      );
+      roomId = roomRes.rows[0].room_id;
+
+      await testPool.query(
+        "INSERT INTO room_members (room_id, user_id, role) VALUES ($1, $2, 'owner')",
+        [roomId, userId]
+      );
+    });
+
+    it('should delete room memberships when a room is deleted (ON DELETE CASCADE)', async () => {
+      // Confirm member exists
+      const beforeCount = await testPool.query(
+        "SELECT COUNT(*) FROM room_members WHERE room_id = $1",
+        [roomId]
+      );
+      expect(parseInt(beforeCount.rows[0].count)).toBe(1);
+
+      // Delete the room
+      await testPool.query("DELETE FROM chat_rooms WHERE room_id = $1", [roomId]);
+
+      // Member should be cascade deleted
+      const afterCount = await testPool.query(
+        "SELECT COUNT(*) FROM room_members WHERE room_id = $1",
+        [roomId]
+      );
+      expect(parseInt(afterCount.rows[0].count)).toBe(0);
+    });
+
+    it('should delete room memberships when a user is deleted (ON DELETE CASCADE)', async () => {
+      // Confirm member exists
+      const beforeCount = await testPool.query(
+        "SELECT COUNT(*) FROM room_members WHERE user_id = $1",
+        [userId]
+      );
+      expect(parseInt(beforeCount.rows[0].count)).toBe(1);
+
+      // Delete the user
+      await testPool.query("DELETE FROM users WHERE user_id = $1", [userId]);
+
+      // Member should be cascade deleted
+      const afterCount = await testPool.query(
+        "SELECT COUNT(*) FROM room_members WHERE user_id = $1",
+        [userId]
+      );
+      expect(parseInt(afterCount.rows[0].count)).toBe(0);
+    });
+
+    it('should preserve message but set sender_id to NULL when a user is deleted (ON DELETE SET NULL)', async () => {
+      // Insert message
+      const msgRes = await testPool.query(
+        "INSERT INTO messages (room_id, sender_id, content) VALUES ($1, $2, 'Hello world') RETURNING message_id",
+        [roomId, userId]
+      );
+      const messageId = msgRes.rows[0].message_id;
+
+      // Delete user
+      await testPool.query("DELETE FROM users WHERE user_id = $1", [userId]);
+
+      // Message should remain but sender_id should be NULL
+      const msgAfter = await testPool.query(
+        "SELECT sender_id, content FROM messages WHERE message_id = $1",
+        [messageId]
+      );
+      expect(msgAfter.rows[0].sender_id).toBeNull();
+      expect(msgAfter.rows[0].content).toBe('Hello world');
+    });
+
+    it('should cascade delete messages when a chat room is deleted (ON DELETE CASCADE)', async () => {
+      // Insert message
+      await testPool.query(
+        "INSERT INTO messages (room_id, sender_id, content) VALUES ($1, $2, 'Hello world')",
+        [roomId, userId]
+      );
+
+      // Delete room
+      await testPool.query("DELETE FROM chat_rooms WHERE room_id = $1", [roomId]);
+
+      // Messages should be cascade deleted
+      const msgCount = await testPool.query(
+        "SELECT COUNT(*) FROM messages WHERE room_id = $1",
+        [roomId]
+      );
+      expect(parseInt(msgCount.rows[0].count)).toBe(0);
+    });
+  });
+});

--- a/backend/tests/unit/middlewares/authMiddleware.test.ts
+++ b/backend/tests/unit/middlewares/authMiddleware.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Request, Response, NextFunction } from 'express';
+import { authMiddleware } from '../../../src/middlewares/authMiddleware';
+import * as jwtHelper from '../../../src/auth/jwt';
+import { AppError } from '../../../src/errors/AppError';
+
+describe('authMiddleware', () => {
+  let mockRequest: Partial<Request>;
+  let mockResponse: Partial<Response>;
+  let nextFunction: NextFunction;
+
+  beforeEach(() => {
+    mockRequest = {
+      headers: {},
+    };
+    mockResponse = {};
+    nextFunction = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('throws 401 when Authorization header is missing', () => {
+    try {
+      authMiddleware(mockRequest as Request, mockResponse as Response, nextFunction);
+      expect.fail('Should have thrown AppError');
+    } catch (e: any) {
+      expect(e).toBeInstanceOf(AppError);
+      expect(e.statusCode).toBe(401);
+      expect(e.message).toMatch(/Missing or invalid/);
+    }
+  });
+
+  it('throws 401 when Authorization header is malformed', () => {
+    mockRequest.headers = { authorization: 'Basic sometoken' };
+    try {
+      authMiddleware(mockRequest as Request, mockResponse as Response, nextFunction);
+      expect.fail('Should have thrown AppError');
+    } catch (e: any) {
+      expect(e).toBeInstanceOf(AppError);
+      expect(e.statusCode).toBe(401);
+      expect(e.message).toMatch(/Missing or invalid/);
+    }
+  });
+
+  it('throws 401 when token is invalid', () => {
+    mockRequest.headers = { authorization: 'Bearer invalid-token' };
+    vi.spyOn(jwtHelper, 'verifyToken').mockImplementation(() => {
+      throw new Error('Invalid token');
+    });
+
+    try {
+      authMiddleware(mockRequest as Request, mockResponse as Response, nextFunction);
+      expect.fail('Should have thrown AppError');
+    } catch (e: any) {
+      expect(e).toBeInstanceOf(AppError);
+      expect(e.statusCode).toBe(401);
+      expect(e.message).toMatch(/Invalid token/);
+    }
+  });
+
+  it('calls next() and populates req.user when token is valid', () => {
+    mockRequest.headers = { authorization: 'Bearer valid-token' };
+    const mockPayload = { userId: '1', name: 'Test User' };
+    
+    vi.spyOn(jwtHelper, 'verifyToken').mockReturnValue(mockPayload);
+
+    authMiddleware(mockRequest as Request, mockResponse as Response, nextFunction);
+
+    expect(mockRequest.user).toEqual(mockPayload);
+    expect(nextFunction).toHaveBeenCalledOnce();
+  });
+});

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "target": "es2022",
     "module": "commonjs",
+    "rootDir": "..",
     "outDir": "./dist",
     "strict": true,
     "esModuleInterop": true,

--- a/backend/vitest.integration.config.ts
+++ b/backend/vitest.integration.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config';
+import { loadEnv } from 'vite';
+import path from 'path';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@shared': path.resolve(__dirname, '../shared'),
+    },
+  },
+  test: {
+    globals: true,
+    environment: 'node',
+    env: loadEnv('test', path.resolve(__dirname), ''),
+    fileParallelism: false,
+  },
+});


### PR DESCRIPTION
## Summary | 摘要

**[EN]**
- Implements **Issue #5** ([#4] Auth middleware + JWT helper) with full unit test coverage.
- Implements **Issue #7** ([#5b] userRepository pg) with full integration test coverage.
- Includes the `resetDb.ts` bug fix and `schema.test.ts` for PR#26 integrity checks.

**[ZH-TW]**
- 實作了 **Issue #5**（[#4] 認證中間件與 JWT 輔助工具），並具備完整的單元測試覆蓋率。
- 實作了 **Issue #7**（[#5b] userRepository PostgreSQL 實作），並具備完整的整合測試覆蓋率。
- 包含了 `resetDb.ts` 命名錯誤修復，以及用於驗證 PR#26 的 `schema.test.ts` 結構整合測試。

---

## Acceptance Criteria Met | 已達成的驗收標準

**[EN]**
- [x] JWT `signToken` and `verifyToken` implemented.
- [x] `authMiddleware` attaches `req.user` or throws 401 Unauthorized.
- [x] Express Request type correctly augmented.
- [x] `IUserRepository` fully implemented using parameterized queries in `pg`.
- [x] `snake_case` to `camelCase` mapping explicitly enforced.
- [x] All 27 tests passing (100% pass rate).

**[ZH-TW]**
- [x] 已實作 JWT 的 `signToken` 與 `verifyToken`。
- [x] `authMiddleware` 已能正確解析標頭，附加 `req.user` 或拋出 401 未授權錯誤。
- [x] 已正確擴充 Express Request 型別。
- [x] 已透過 `pg` 完全實作 `IUserRepository`，並全面使用參數化查詢防範注入攻擊。
- [x] 已強制執行資料庫 `snake_case` 到 TypeScript `camelCase` 的欄位轉換。
- [x] 全數 27 項測試完美通過（100% 通過率）。

---

Closes #5
Closes #7
