### PR TITLE
feat(#9): MessageRepository pg implementation + integration tests

### DIFF
--- a/backend/src/repositories/IMessageRepository.ts
+++ b/backend/src/repositories/IMessageRepository.ts
@@ -1,8 +1,8 @@
-import type { Message } from '@shared/types';
+import type { Message, MessageWithSender } from '@shared/types';
 
 export interface IMessageRepository {
   findById(messageId: string): Promise<Message | null>;
-  findByRoom(roomId: string, opts: { beforeId?: string; limit: number }): Promise<Message[]>;
+  findByRoom(roomId: string, opts: { beforeId?: string; limit: number }): Promise<MessageWithSender[]>;
   create(data: Pick<Message, 'roomId' | 'senderId' | 'content' | 'replyToId'>): Promise<Message>;
   markRecalled(messageId: string): Promise<Message>;
 }

--- a/backend/src/repositories/messageRepository.ts
+++ b/backend/src/repositories/messageRepository.ts
@@ -1,0 +1,86 @@
+import { Pool } from 'pg';
+import type { Message, MessageWithSender, PublicUser } from '@shared/types';
+import type { IMessageRepository } from './IMessageRepository';
+
+function mapRowToMessage(row: any): Message {
+  return {
+    messageId: row.message_id,
+    roomId:    row.room_id,
+    senderId:  row.sender_id ?? null,
+    content:   row.content,
+    replyToId: row.reply_to_id ?? undefined,
+    isRecalled: row.is_recalled,
+    sentAt:    row.sent_at,
+  };
+}
+
+function mapRowToMessageWithSender(row: any): MessageWithSender {
+  const sender: PublicUser | null = row.sender_id
+    ? { userId: row.sender_id, name: row.sender_name, avatarUrl: row.sender_avatar_url ?? undefined }
+    : null;
+  return { ...mapRowToMessage(row), sender };
+}
+
+const WITH_SENDER_JOIN = `
+  SELECT m.*, u.name AS sender_name, u.avatar_url AS sender_avatar_url
+  FROM messages m
+  LEFT JOIN users u ON m.sender_id = u.user_id
+`;
+
+export class MessageRepository implements IMessageRepository {
+  constructor(private db: Pool) {}
+
+  async findById(messageId: string): Promise<Message | null> {
+    const res = await this.db.query(
+      'SELECT * FROM messages WHERE message_id = $1',
+      [messageId]
+    );
+    return res.rows.length === 0 ? null : mapRowToMessage(res.rows[0]);
+  }
+
+  async findByRoom(
+    roomId: string,
+    opts: { beforeId?: string; limit: number }
+  ): Promise<MessageWithSender[]> {
+    if (opts.beforeId) {
+      const res = await this.db.query(
+        `${WITH_SENDER_JOIN}
+         WHERE m.room_id = $1
+           AND m.sent_at < (SELECT sent_at FROM messages WHERE message_id = $2)
+         ORDER BY m.sent_at DESC
+         LIMIT $3`,
+        [roomId, opts.beforeId, opts.limit]
+      );
+      return res.rows.map(mapRowToMessageWithSender);
+    }
+    const res = await this.db.query(
+      `${WITH_SENDER_JOIN}
+       WHERE m.room_id = $1
+       ORDER BY m.sent_at DESC
+       LIMIT $2`,
+      [roomId, opts.limit]
+    );
+    return res.rows.map(mapRowToMessageWithSender);
+  }
+
+  async create(
+    data: Pick<Message, 'roomId' | 'senderId' | 'content' | 'replyToId'>
+  ): Promise<Message> {
+    const res = await this.db.query(
+      `INSERT INTO messages (room_id, sender_id, content, reply_to_id)
+       VALUES ($1, $2, $3, $4)
+       RETURNING *`,
+      [data.roomId, data.senderId ?? null, data.content, data.replyToId ?? null]
+    );
+    return mapRowToMessage(res.rows[0]);
+  }
+
+  async markRecalled(messageId: string): Promise<Message> {
+    const res = await this.db.query(
+      'UPDATE messages SET is_recalled = TRUE WHERE message_id = $1 RETURNING *',
+      [messageId]
+    );
+    if (res.rows.length === 0) throw new Error('Message not found');
+    return mapRowToMessage(res.rows[0]);
+  }
+}

--- a/backend/tests/integration/repositories/messageRepository.int.test.ts
+++ b/backend/tests/integration/repositories/messageRepository.int.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach, afterAll } from 'vitest';
+import { MessageRepository } from '../../../src/repositories/messageRepository';
+import { testPool } from '../../helpers/testPool';
+import { resetDb } from '../../helpers/resetDb';
+
+describe('MessageRepository (pg)', () => {
+  const repo = new MessageRepository(testPool);
+
+  beforeEach(async () => {
+    await resetDb();
+  });
+
+  afterAll(async () => {
+    await testPool.end();
+  });
+
+  it('create → findById → findByRoom (cursor) → markRecalled', async () => {
+    const userRes = await testPool.query(
+      "INSERT INTO users (name, email, password_hash) VALUES ('Alice', 'alice@test.com', 'hash') RETURNING user_id"
+    );
+    const userId: string = userRes.rows[0].user_id;
+
+    const roomRes = await testPool.query(
+      "INSERT INTO chat_rooms (type, name) VALUES ('group', 'Test Room') RETURNING room_id"
+    );
+    const roomId: string = roomRes.rows[0].room_id;
+
+    // Insert with explicit timestamps so cursor ordering is deterministic
+    const [r1, r2, r3] = await Promise.all([
+      testPool.query(
+        `INSERT INTO messages (room_id, sender_id, content, sent_at)
+         VALUES ($1, $2, 'First', NOW() - INTERVAL '2 seconds') RETURNING message_id`,
+        [roomId, userId]
+      ),
+      testPool.query(
+        `INSERT INTO messages (room_id, sender_id, content, sent_at)
+         VALUES ($1, $2, 'Second', NOW() - INTERVAL '1 second') RETURNING message_id`,
+        [roomId, userId]
+      ),
+      testPool.query(
+        `INSERT INTO messages (room_id, sender_id, content, sent_at)
+         VALUES ($1, $2, 'Third', NOW()) RETURNING message_id`,
+        [roomId, userId]
+      ),
+    ]);
+    const [id1, id2, id3] = [r1.rows[0].message_id, r2.rows[0].message_id, r3.rows[0].message_id];
+
+    // create via repo
+    const created = await repo.create({ roomId, senderId: userId, content: 'Hello', replyToId: undefined });
+    expect(typeof created.messageId).toBe('string');
+    expect(created.roomId).toBe(roomId);
+    expect(created.senderId).toBe(userId);
+    expect(created.content).toBe('Hello');
+    expect(created.isRecalled).toBe(false);
+    expect(created.sentAt).toBeInstanceOf(Date);
+
+    // findById
+    const fetched = await repo.findById(id1);
+    expect(fetched).not.toBeNull();
+    expect(fetched!.messageId).toBe(id1);
+    expect(fetched!.content).toBe('First');
+
+    // findByRoom — all messages reverse-chronological; sender is joined
+    const all = await repo.findByRoom(roomId, { limit: 10 });
+    expect(all.length).toBeGreaterThanOrEqual(3);
+    // Most recent first
+    const ids = all.map((m) => m.messageId);
+    expect(ids.indexOf(id3)).toBeLessThan(ids.indexOf(id2));
+    expect(ids.indexOf(id2)).toBeLessThan(ids.indexOf(id1));
+    // Sender profile is populated
+    expect(all[0].sender).not.toBeNull();
+    expect(all[0].sender!.userId).toBe(userId);
+    expect(all[0].sender!.name).toBe('Alice');
+
+    // findByRoom — cursor: messages before id3
+    const page = await repo.findByRoom(roomId, { beforeId: id3, limit: 10 });
+    const pageIds = page.map((m) => m.messageId);
+    expect(pageIds).not.toContain(id3);
+    expect(pageIds).toContain(id2);
+    expect(pageIds).toContain(id1);
+
+    // markRecalled
+    const recalled = await repo.markRecalled(id1);
+    expect(recalled.isRecalled).toBe(true);
+    expect(recalled.messageId).toBe(id1);
+    const afterRecall = await repo.findById(id1);
+    expect(afterRecall!.isRecalled).toBe(true);
+  });
+
+  it('findById returns null for non-existent message', async () => {
+    const result = await repo.findById('00000000-0000-0000-0000-000000000000');
+    expect(result).toBeNull();
+  });
+
+  it('findByRoom returns empty array when room has no messages', async () => {
+    const roomRes = await testPool.query(
+      "INSERT INTO chat_rooms (type, name) VALUES ('group', 'Empty Room') RETURNING room_id"
+    );
+    const result = await repo.findByRoom(roomRes.rows[0].room_id, { limit: 10 });
+    expect(result).toEqual([]);
+  });
+
+  it('create with null senderId (deleted-user scenario)', async () => {
+    const roomRes = await testPool.query(
+      "INSERT INTO chat_rooms (type, name) VALUES ('group', 'Room') RETURNING room_id"
+    );
+    const msg = await repo.create({
+      roomId: roomRes.rows[0].room_id,
+      senderId: null,
+      content: 'System message',
+      replyToId: undefined,
+    });
+    expect(msg.senderId).toBeNull();
+  });
+
+  it('replyToId is mapped correctly', async () => {
+    const userRes = await testPool.query(
+      "INSERT INTO users (name, email, password_hash) VALUES ('Bob', 'bob@test.com', 'hash') RETURNING user_id"
+    );
+    const roomRes = await testPool.query(
+      "INSERT INTO chat_rooms (type, name) VALUES ('group', 'Room') RETURNING room_id"
+    );
+    const parent = await repo.create({
+      roomId: roomRes.rows[0].room_id,
+      senderId: userRes.rows[0].user_id,
+      content: 'parent',
+      replyToId: undefined,
+    });
+    const reply = await repo.create({
+      roomId: roomRes.rows[0].room_id,
+      senderId: userRes.rows[0].user_id,
+      content: 'reply',
+      replyToId: parent.messageId,
+    });
+    expect(reply.replyToId).toBe(parent.messageId);
+  });
+});


### PR DESCRIPTION
## Summary
- Implements `MessageRepository` satisfying `IMessageRepository` with parameterised queries and `snake_case→camelCase` mapping
- Updates `IMessageRepository.findByRoom` return type to `MessageWithSender[]` (LEFT JOIN to `users` for sender's `PublicUser` profile)
- Cursor-based pagination via `beforeId` using `sent_at` subquery comparison, results in reverse-chronological order
- 5 integration tests: create, findById, findByRoom (cursor), markRecalled, null senderId, replyToId mapping

## Test plan
- [x] `create → findById → findByRoom (cursor) → markRecalled` happy path
- [x] `findById` returns null for non-existent message
- [x] `findByRoom` returns empty array for room with no messages
- [x] `create` with `senderId: null` (deleted-user scenario)
- [x] `replyToId` is correctly mapped to/from `reply_to_id`

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)