### PR TITLE
feat(#10): RoomMemberRepository pg implementation + integration tests

### DIFF
--- a/backend/src/repositories/roomMemberRepository.ts
+++ b/backend/src/repositories/roomMemberRepository.ts
@@ -1,0 +1,86 @@
+import { Pool } from 'pg';
+import type { RoomMember } from '@shared/types';
+import type { IRoomMemberRepository } from './IRoomMemberRepository';
+
+function mapRowToRoomMember(row: any): RoomMember {
+  return {
+    roomId:     row.room_id,
+    userId:     row.user_id,
+    role:       row.role,
+    nickname:   row.nickname ?? undefined,
+    isMuted:    row.is_muted,
+    lastReadId: row.last_read_id ?? undefined,
+    joinTime:   row.join_time,
+  };
+}
+
+export class RoomMemberRepository implements IRoomMemberRepository {
+  constructor(private db: Pool) {}
+
+  async findMember(roomId: string, userId: string): Promise<RoomMember | null> {
+    const res = await this.db.query(
+      'SELECT * FROM room_members WHERE room_id = $1 AND user_id = $2',
+      [roomId, userId]
+    );
+    return res.rows.length === 0 ? null : mapRowToRoomMember(res.rows[0]);
+  }
+
+  async findByRoom(roomId: string): Promise<RoomMember[]> {
+    const res = await this.db.query(
+      'SELECT * FROM room_members WHERE room_id = $1',
+      [roomId]
+    );
+    return res.rows.map(mapRowToRoomMember);
+  }
+
+  async add(data: Pick<RoomMember, 'roomId' | 'userId' | 'role'>): Promise<RoomMember> {
+    const res = await this.db.query(
+      `INSERT INTO room_members (room_id, user_id, role)
+       VALUES ($1, $2, $3)
+       RETURNING *`,
+      [data.roomId, data.userId, data.role]
+    );
+    return mapRowToRoomMember(res.rows[0]);
+  }
+
+  async update(
+    roomId: string,
+    userId: string,
+    data: Partial<Pick<RoomMember, 'role' | 'nickname' | 'isMuted' | 'lastReadId'>>
+  ): Promise<RoomMember> {
+    const fields: string[] = [];
+    const values: any[] = [];
+    let idx = 1;
+
+    if (data.role !== undefined)       { fields.push(`role = $${idx++}`);         values.push(data.role); }
+    if (data.nickname !== undefined)   { fields.push(`nickname = $${idx++}`);     values.push(data.nickname); }
+    if (data.isMuted !== undefined)    { fields.push(`is_muted = $${idx++}`);     values.push(data.isMuted); }
+    if (data.lastReadId !== undefined) { fields.push(`last_read_id = $${idx++}`); values.push(data.lastReadId); }
+
+    if (fields.length === 0) {
+      const res = await this.db.query(
+        'SELECT * FROM room_members WHERE room_id = $1 AND user_id = $2',
+        [roomId, userId]
+      );
+      if (res.rows.length === 0) throw new Error('RoomMember not found');
+      return mapRowToRoomMember(res.rows[0]);
+    }
+
+    values.push(roomId, userId);
+    const res = await this.db.query(
+      `UPDATE room_members SET ${fields.join(', ')}
+       WHERE room_id = $${idx} AND user_id = $${idx + 1}
+       RETURNING *`,
+      values
+    );
+    if (res.rows.length === 0) throw new Error('RoomMember not found');
+    return mapRowToRoomMember(res.rows[0]);
+  }
+
+  async remove(roomId: string, userId: string): Promise<void> {
+    await this.db.query(
+      'DELETE FROM room_members WHERE room_id = $1 AND user_id = $2',
+      [roomId, userId]
+    );
+  }
+}

--- a/backend/tests/integration/repositories/roomMemberRepository.int.test.ts
+++ b/backend/tests/integration/repositories/roomMemberRepository.int.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach, afterAll } from 'vitest';
+import { RoomMemberRepository } from '../../../src/repositories/roomMemberRepository';
+import { testPool } from '../../helpers/testPool';
+import { resetDb } from '../../helpers/resetDb';
+
+describe('RoomMemberRepository (pg)', () => {
+  const repo = new RoomMemberRepository(testPool);
+
+  beforeEach(async () => {
+    await resetDb();
+  });
+
+  afterAll(async () => {
+    await testPool.end();
+  });
+
+  it('add (role=member) → findMember → update (role=admin, isMuted=true) → findByRoom → remove', async () => {
+    const userRes = await testPool.query(
+      "INSERT INTO users (name, email, password_hash) VALUES ('Alice', 'alice@test.com', 'hash') RETURNING user_id"
+    );
+    const userId: string = userRes.rows[0].user_id;
+
+    const roomRes = await testPool.query(
+      "INSERT INTO chat_rooms (type, name) VALUES ('group', 'Test Room') RETURNING room_id"
+    );
+    const roomId: string = roomRes.rows[0].room_id;
+
+    // add
+    const member = await repo.add({ roomId, userId, role: 'member' });
+    expect(member.roomId).toBe(roomId);
+    expect(member.userId).toBe(userId);
+    expect(member.role).toBe('member');
+    expect(member.isMuted).toBe(false);
+    expect(member.joinTime).toBeInstanceOf(Date);
+    expect(member.nickname).toBeUndefined();
+    expect(member.lastReadId).toBeUndefined();
+
+    // findMember
+    const found = await repo.findMember(roomId, userId);
+    expect(found).not.toBeNull();
+    expect(found!.userId).toBe(userId);
+    expect(found!.role).toBe('member');
+
+    // update role and isMuted
+    const updated = await repo.update(roomId, userId, { role: 'admin', isMuted: true });
+    expect(updated.role).toBe('admin');
+    expect(updated.isMuted).toBe(true);
+    expect(updated.roomId).toBe(roomId);
+    expect(updated.userId).toBe(userId);
+
+    // findByRoom — assert member count
+    const members = await repo.findByRoom(roomId);
+    expect(members).toHaveLength(1);
+    expect(members[0].role).toBe('admin');
+    expect(members[0].isMuted).toBe(true);
+
+    // remove
+    await repo.remove(roomId, userId);
+    const afterRemove = await repo.findMember(roomId, userId);
+    expect(afterRemove).toBeNull();
+
+    const afterRemoveList = await repo.findByRoom(roomId);
+    expect(afterRemoveList).toHaveLength(0);
+  });
+
+  it('findMember returns null for non-existent member', async () => {
+    const result = await repo.findMember(
+      '00000000-0000-0000-0000-000000000000',
+      '00000000-0000-0000-0000-000000000001'
+    );
+    expect(result).toBeNull();
+  });
+
+  it('findByRoom returns empty array when room has no members', async () => {
+    const roomRes = await testPool.query(
+      "INSERT INTO chat_rooms (type, name) VALUES ('group', 'Empty Room') RETURNING room_id"
+    );
+    const result = await repo.findByRoom(roomRes.rows[0].room_id);
+    expect(result).toEqual([]);
+  });
+
+  it('update nickname and lastReadId', async () => {
+    const userRes = await testPool.query(
+      "INSERT INTO users (name, email, password_hash) VALUES ('Bob', 'bob@test.com', 'hash') RETURNING user_id"
+    );
+    const roomRes = await testPool.query(
+      "INSERT INTO chat_rooms (type, name) VALUES ('group', 'Room') RETURNING room_id"
+    );
+    const { roomId, userId } = {
+      roomId: roomRes.rows[0].room_id,
+      userId: userRes.rows[0].user_id,
+    };
+
+    await repo.add({ roomId, userId, role: 'member' });
+
+    // Insert a message to use as lastReadId
+    const msgRes = await testPool.query(
+      'INSERT INTO messages (room_id, sender_id, content) VALUES ($1, $2, $3) RETURNING message_id',
+      [roomId, userId, 'hi']
+    );
+    const messageId: string = msgRes.rows[0].message_id;
+
+    const updated = await repo.update(roomId, userId, {
+      nickname: 'Bobby',
+      lastReadId: messageId,
+    });
+    expect(updated.nickname).toBe('Bobby');
+    expect(updated.lastReadId).toBe(messageId);
+  });
+
+  it('findByRoom returns all members in a multi-member room', async () => {
+    const [u1, u2] = await Promise.all([
+      testPool.query(
+        "INSERT INTO users (name, email, password_hash) VALUES ('U1', 'u1@test.com', 'hash') RETURNING user_id"
+      ),
+      testPool.query(
+        "INSERT INTO users (name, email, password_hash) VALUES ('U2', 'u2@test.com', 'hash') RETURNING user_id"
+      ),
+    ]);
+    const roomRes = await testPool.query(
+      "INSERT INTO chat_rooms (type, name) VALUES ('group', 'Multi') RETURNING room_id"
+    );
+    const roomId: string = roomRes.rows[0].room_id;
+
+    await Promise.all([
+      repo.add({ roomId, userId: u1.rows[0].user_id, role: 'owner' }),
+      repo.add({ roomId, userId: u2.rows[0].user_id, role: 'member' }),
+    ]);
+
+    const members = await repo.findByRoom(roomId);
+    expect(members).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary
- Implements `RoomMemberRepository` satisfying `IRoomMemberRepository` with parameterised queries and `snake_case→camelCase` mapping
- Partial `update` supports `role`, `nickname`, `isMuted`, `lastReadId` independently
- 5 integration tests covering the full `add → findMember → update → findByRoom → remove` lifecycle

## Test plan
- [x] `add (role=member) → findMember → update (role=admin, isMuted=true) → findByRoom → remove` with member count assertions
- [x] `findMember` returns null for non-existent member
- [x] `findByRoom` returns empty array for room with no members
- [x] `update` with `nickname` and `lastReadId` fields
- [x] `findByRoom` returns all members in a multi-member room

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)