### PR TITLE
test(controllers): add unit tests for all 4 controllers

### DIFF
--- a/backend/tests/unit/controllers/authController.test.ts
+++ b/backend/tests/unit/controllers/authController.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { makeAuthController } from '../../../src/controllers/authController';
+import { ValidationError } from '../../../src/errors/AppError';
+import type { Request, Response, NextFunction } from 'express';
+
+const mockRes = () => {
+  const res = { status: vi.fn(), json: vi.fn(), send: vi.fn() } as any;
+  res.status.mockReturnValue(res);
+  return res;
+};
+
+describe('authController', () => {
+  const authResult = { token: 'tok', user: { userId: 'u1', email: 'alice@example.com', name: 'Alice' } };
+  const service = { register: vi.fn(), login: vi.fn() };
+  const ctrl = makeAuthController(service);
+
+  beforeEach(() => vi.clearAllMocks());
+
+  describe('register', () => {
+    it('returns 201 on valid input', async () => {
+      service.register.mockResolvedValue(authResult);
+      const req = { body: { email: 'alice@example.com', name: 'Alice', password: 'password123' } } as Request;
+      const res = mockRes();
+      const next = vi.fn();
+
+      await ctrl.register(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(201);
+      expect(res.json).toHaveBeenCalledWith(authResult);
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('calls next with ValidationError on invalid body', async () => {
+      const req = { body: { email: 'not-an-email', name: 'Alice', password: 'short' } } as Request;
+      const res = mockRes();
+      const next = vi.fn();
+
+      await ctrl.register(req, res, next);
+
+      expect(next).toHaveBeenCalledWith(expect.any(ValidationError));
+      expect(res.status).not.toHaveBeenCalled();
+    });
+
+    it('calls next with error when service throws', async () => {
+      const err = new Error('conflict');
+      service.register.mockRejectedValue(err);
+      const req = { body: { email: 'alice@example.com', name: 'Alice', password: 'password123' } } as Request;
+      const res = mockRes();
+      const next = vi.fn();
+
+      await ctrl.register(req, res, next);
+
+      expect(next).toHaveBeenCalledWith(err);
+    });
+  });
+
+  describe('login', () => {
+    it('returns 200 on valid input', async () => {
+      service.login.mockResolvedValue(authResult);
+      const req = { body: { email: 'alice@example.com', password: 'password123' } } as Request;
+      const res = mockRes();
+      const next = vi.fn();
+
+      await ctrl.login(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(authResult);
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('calls next with ValidationError on missing fields', async () => {
+      const req = { body: {} } as Request;
+      const res = mockRes();
+      const next = vi.fn();
+
+      await ctrl.login(req, res, next);
+
+      expect(next).toHaveBeenCalledWith(expect.any(ValidationError));
+    });
+
+    it('calls next with error when service throws', async () => {
+      const err = new Error('unauthorized');
+      service.login.mockRejectedValue(err);
+      const req = { body: { email: 'alice@example.com', password: 'password123' } } as Request;
+      const res = mockRes();
+      const next = vi.fn();
+
+      await ctrl.login(req, res, next);
+
+      expect(next).toHaveBeenCalledWith(err);
+    });
+  });
+
+  describe('logout', () => {
+    it('returns 204', () => {
+      const req = {} as Request;
+      const res = mockRes();
+
+      ctrl.logout(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(204);
+      expect(res.send).toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/tests/unit/controllers/messageController.test.ts
+++ b/backend/tests/unit/controllers/messageController.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { makeMessageController } from '../../../src/controllers/messageController';
+import { ValidationError } from '../../../src/errors/AppError';
+import type { Request, Response, NextFunction } from 'express';
+
+const mockRes = () => {
+  const res = { status: vi.fn(), json: vi.fn(), send: vi.fn() } as any;
+  res.status.mockReturnValue(res);
+  return res;
+};
+
+const authedReq = (overrides: Partial<Request> = {}): any => ({
+  body: {},
+  params: { roomId: 'room-1' },
+  query: {},
+  user: { userId: 'user-1' },
+  ...overrides,
+});
+
+describe('messageController', () => {
+  const messages = [{ messageId: 'msg-1', content: 'Hello', sender: { userId: 'user-1', name: 'Alice' } }];
+  const service = { listForRoom: vi.fn() };
+  const ctrl = makeMessageController(service);
+
+  beforeEach(() => vi.clearAllMocks());
+
+  describe('listForRoom', () => {
+    it('returns 200 with messages using default limit', async () => {
+      service.listForRoom.mockResolvedValue(messages);
+      const res = mockRes();
+      const next = vi.fn();
+
+      await ctrl.listForRoom(authedReq(), res, next);
+
+      expect(service.listForRoom).toHaveBeenCalledWith('user-1', 'room-1', { beforeId: undefined, limit: 50 });
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(messages);
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('passes before_id and limit to service', async () => {
+      service.listForRoom.mockResolvedValue(messages);
+      const res = mockRes();
+      const next = vi.fn();
+
+      await ctrl.listForRoom(authedReq({ query: { before_id: 'msg-5', limit: '20' } }), res, next);
+
+      expect(service.listForRoom).toHaveBeenCalledWith('user-1', 'room-1', { beforeId: 'msg-5', limit: 20 });
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    it('calls next with ValidationError when limit is not a number', async () => {
+      const res = mockRes();
+      const next = vi.fn();
+
+      await ctrl.listForRoom(authedReq({ query: { limit: 'abc' } }), res, next);
+
+      expect(next).toHaveBeenCalledWith(expect.any(ValidationError));
+      expect(res.status).not.toHaveBeenCalled();
+    });
+
+    it('calls next with ValidationError when limit is out of range', async () => {
+      const res = mockRes();
+      const next = vi.fn();
+
+      await ctrl.listForRoom(authedReq({ query: { limit: '200' } }), res, next);
+
+      expect(next).toHaveBeenCalledWith(expect.any(ValidationError));
+    });
+
+    it('calls next with error when service throws', async () => {
+      const err = new Error('forbidden');
+      service.listForRoom.mockRejectedValue(err);
+      const res = mockRes();
+      const next = vi.fn();
+
+      await ctrl.listForRoom(authedReq(), res, next);
+
+      expect(next).toHaveBeenCalledWith(err);
+    });
+  });
+});

--- a/backend/tests/unit/controllers/roomController.test.ts
+++ b/backend/tests/unit/controllers/roomController.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { makeRoomController } from '../../../src/controllers/roomController';
+import { ValidationError } from '../../../src/errors/AppError';
+import type { Request, Response, NextFunction } from 'express';
+
+const mockRes = () => {
+  const res = { status: vi.fn(), json: vi.fn(), send: vi.fn() } as any;
+  res.status.mockReturnValue(res);
+  return res;
+};
+
+const authedReq = (overrides: Partial<Request> = {}): any => ({
+  body: {},
+  params: {},
+  query: {},
+  user: { userId: 'user-1' },
+  ...overrides,
+});
+
+describe('roomController', () => {
+  const room = {
+    roomId: 'room-1',
+    type: 'group',
+    name: 'Study Room',
+    requireApproval: false,
+    viewHistory: true,
+    isArchived: false,
+    createdAt: new Date('2026-01-01'),
+  };
+
+  const service = {
+    list: vi.fn(),
+    create: vi.fn(),
+    getById: vi.fn(),
+    update: vi.fn(),
+    joinByCode: vi.fn(),
+    leave: vi.fn(),
+  };
+  const ctrl = makeRoomController(service);
+
+  beforeEach(() => vi.clearAllMocks());
+
+  describe('list', () => {
+    it('returns 200 with rooms', async () => {
+      service.list.mockResolvedValue([room]);
+      const res = mockRes();
+      const next = vi.fn();
+
+      await ctrl.list(authedReq(), res, next);
+
+      expect(service.list).toHaveBeenCalledWith('user-1');
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith([room]);
+    });
+
+    it('calls next with error when service throws', async () => {
+      service.list.mockRejectedValue(new Error('db error'));
+      const res = mockRes();
+      const next = vi.fn();
+
+      await ctrl.list(authedReq(), res, next);
+
+      expect(next).toHaveBeenCalledWith(expect.any(Error));
+    });
+  });
+
+  describe('createGroup', () => {
+    it('returns 201 with room on valid name', async () => {
+      service.create.mockResolvedValue(room);
+      const res = mockRes();
+      const next = vi.fn();
+
+      await ctrl.createGroup(authedReq({ body: { name: 'Study Room' } }), res, next);
+
+      expect(service.create).toHaveBeenCalledWith('user-1', { type: 'group', name: 'Study Room' });
+      expect(res.status).toHaveBeenCalledWith(201);
+      expect(res.json).toHaveBeenCalledWith(room);
+    });
+
+    it('calls next with ValidationError when name is empty', async () => {
+      const res = mockRes();
+      const next = vi.fn();
+
+      await ctrl.createGroup(authedReq({ body: { name: '   ' } }), res, next);
+
+      expect(next).toHaveBeenCalledWith(expect.any(ValidationError));
+      expect(res.status).not.toHaveBeenCalled();
+    });
+
+    it('calls next with ValidationError when name is missing', async () => {
+      const res = mockRes();
+      const next = vi.fn();
+
+      await ctrl.createGroup(authedReq({ body: {} }), res, next);
+
+      expect(next).toHaveBeenCalledWith(expect.any(ValidationError));
+    });
+
+    it('calls next with error when service throws', async () => {
+      service.create.mockRejectedValue(new Error('db error'));
+      const res = mockRes();
+      const next = vi.fn();
+
+      await ctrl.createGroup(authedReq({ body: { name: 'Study Room' } }), res, next);
+
+      expect(next).toHaveBeenCalledWith(expect.any(Error));
+    });
+  });
+
+  describe('getById', () => {
+    it('returns 200 with room', async () => {
+      service.getById.mockResolvedValue(room);
+      const res = mockRes();
+      const next = vi.fn();
+
+      await ctrl.getById(authedReq({ params: { id: 'room-1' } }), res, next);
+
+      expect(service.getById).toHaveBeenCalledWith('room-1', 'user-1');
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(room);
+    });
+
+    it('calls next with error when service throws', async () => {
+      service.getById.mockRejectedValue(new Error('not found'));
+      const res = mockRes();
+      const next = vi.fn();
+
+      await ctrl.getById(authedReq({ params: { id: 'room-1' } }), res, next);
+
+      expect(next).toHaveBeenCalledWith(expect.any(Error));
+    });
+  });
+
+  describe('update', () => {
+    it('returns 200 with updated room', async () => {
+      const updated = { ...room, name: 'New Name' };
+      service.update.mockResolvedValue(updated);
+      const res = mockRes();
+      const next = vi.fn();
+
+      await ctrl.update(authedReq({ params: { id: 'room-1' }, body: { name: 'New Name' } }), res, next);
+
+      expect(service.update).toHaveBeenCalledWith('room-1', 'user-1', { name: 'New Name' });
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(updated);
+    });
+
+    it('calls next with error when service throws', async () => {
+      service.update.mockRejectedValue(new Error('forbidden'));
+      const res = mockRes();
+      const next = vi.fn();
+
+      await ctrl.update(authedReq({ params: { id: 'room-1' }, body: { name: 'X' } }), res, next);
+
+      expect(next).toHaveBeenCalledWith(expect.any(Error));
+    });
+  });
+
+  describe('joinByCode', () => {
+    it('returns 200 with room', async () => {
+      service.joinByCode.mockResolvedValue(room);
+      const res = mockRes();
+      const next = vi.fn();
+
+      await ctrl.joinByCode(authedReq({ params: { code: 'ABC123' } }), res, next);
+
+      expect(service.joinByCode).toHaveBeenCalledWith('user-1', 'ABC123');
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(room);
+    });
+
+    it('calls next with error when service throws', async () => {
+      service.joinByCode.mockRejectedValue(new Error('invalid code'));
+      const res = mockRes();
+      const next = vi.fn();
+
+      await ctrl.joinByCode(authedReq({ params: { code: 'BAD' } }), res, next);
+
+      expect(next).toHaveBeenCalledWith(expect.any(Error));
+    });
+  });
+
+  describe('leave', () => {
+    it('returns 204', async () => {
+      service.leave.mockResolvedValue(undefined);
+      const res = mockRes();
+      const next = vi.fn();
+
+      await ctrl.leave(authedReq({ params: { id: 'room-1' } }), res, next);
+
+      expect(service.leave).toHaveBeenCalledWith('user-1', 'room-1');
+      expect(res.status).toHaveBeenCalledWith(204);
+      expect(res.send).toHaveBeenCalled();
+    });
+
+    it('calls next with error when service throws', async () => {
+      service.leave.mockRejectedValue(new Error('forbidden'));
+      const res = mockRes();
+      const next = vi.fn();
+
+      await ctrl.leave(authedReq({ params: { id: 'room-1' } }), res, next);
+
+      expect(next).toHaveBeenCalledWith(expect.any(Error));
+    });
+  });
+});

--- a/backend/tests/unit/controllers/userController.test.ts
+++ b/backend/tests/unit/controllers/userController.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { makeUserController } from '../../../src/controllers/userController';
+import { ValidationError } from '../../../src/errors/AppError';
+import type { Request, Response, NextFunction } from 'express';
+
+const mockRes = () => {
+  const res = { status: vi.fn(), json: vi.fn(), send: vi.fn() } as any;
+  res.status.mockReturnValue(res);
+  return res;
+};
+
+const authedReq = (overrides: Partial<Request> = {}): any => ({
+  body: {},
+  params: {},
+  query: {},
+  user: { userId: 'user-1' },
+  ...overrides,
+});
+
+describe('userController', () => {
+  const publicUser = { userId: 'user-1', name: 'Alice', email: 'alice@example.com' };
+  const service = { getMe: vi.fn(), updateMe: vi.fn(), search: vi.fn() };
+  const ctrl = makeUserController(service);
+
+  beforeEach(() => vi.clearAllMocks());
+
+  describe('getMe', () => {
+    it('returns 200 with user', async () => {
+      service.getMe.mockResolvedValue(publicUser);
+      const res = mockRes();
+      const next = vi.fn();
+
+      await ctrl.getMe(authedReq(), res, next);
+
+      expect(service.getMe).toHaveBeenCalledWith('user-1');
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(publicUser);
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('calls next with error when service throws', async () => {
+      const err = new Error('not found');
+      service.getMe.mockRejectedValue(err);
+      const res = mockRes();
+      const next = vi.fn();
+
+      await ctrl.getMe(authedReq(), res, next);
+
+      expect(next).toHaveBeenCalledWith(err);
+    });
+  });
+
+  describe('updateMe', () => {
+    it('returns 200 with updated user on valid body', async () => {
+      const updated = { ...publicUser, name: 'Bob' };
+      service.updateMe.mockResolvedValue(updated);
+      const res = mockRes();
+      const next = vi.fn();
+
+      await ctrl.updateMe(authedReq({ body: { name: 'Bob' } }), res, next);
+
+      expect(service.updateMe).toHaveBeenCalledWith('user-1', { name: 'Bob' });
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(updated);
+    });
+
+    it('calls next with ValidationError when body is empty', async () => {
+      const res = mockRes();
+      const next = vi.fn();
+
+      await ctrl.updateMe(authedReq({ body: {} }), res, next);
+
+      expect(next).toHaveBeenCalledWith(expect.any(ValidationError));
+      expect(res.status).not.toHaveBeenCalled();
+    });
+
+    it('calls next with error when service throws', async () => {
+      const err = new Error('db error');
+      service.updateMe.mockRejectedValue(err);
+      const res = mockRes();
+      const next = vi.fn();
+
+      await ctrl.updateMe(authedReq({ body: { name: 'Bob' } }), res, next);
+
+      expect(next).toHaveBeenCalledWith(err);
+    });
+  });
+
+  describe('search', () => {
+    it('returns 200 with users on valid query', async () => {
+      service.search.mockResolvedValue([publicUser]);
+      const res = mockRes();
+      const next = vi.fn();
+
+      await ctrl.search(authedReq({ query: { query: 'alice' } }), res, next);
+
+      expect(service.search).toHaveBeenCalledWith('alice');
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith([publicUser]);
+    });
+
+    it('calls next with ValidationError when query is missing', async () => {
+      const res = mockRes();
+      const next = vi.fn();
+
+      await ctrl.search(authedReq({ query: {} }), res, next);
+
+      expect(next).toHaveBeenCalledWith(expect.any(ValidationError));
+    });
+
+    it('calls next with error when service throws', async () => {
+      const err = new Error('db error');
+      service.search.mockRejectedValue(err);
+      const res = mockRes();
+      const next = vi.fn();
+
+      await ctrl.search(authedReq({ query: { query: 'alice' } }), res, next);
+
+      expect(next).toHaveBeenCalledWith(err);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add unit tests for `authController`, `userController`, `roomController`, `messageController`
- 34 new tests covering all 13 implemented endpoints
- Each handler tested for: happy path, validation error, and service error propagation

## Test coverage added

| Controller | Tests | Handlers |
|---|---|---|
| authController | 7 | register, login, logout |
| userController | 8 | getMe, updateMe, search |
| roomController | 14 | list, createGroup, getById, update, joinByCode, leave |
| messageController | 5 | listForRoom |

## Test plan

- [x] All 66 unit tests pass locally (`pnpm --prefix backend run test:unit`)
- [x] No changes to source code — tests only

🤖 Generated with [Claude Code](https://claude.com/claude-code)