### PR TITLE
docs: Restore unimplemented member routes as planned

### DIFF
--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -37,7 +37,15 @@
 | 加入群組 (代碼) | POST | `/rooms/join/:code` | |
 | 退出聊天室 | DELETE | `/rooms/:id/leave` | |
 
-### D. 訊息與附件 (Messages & Attachments)
+### D. 成員管理 (Member Management) (Planned / 尚未實作)
+| 功能 | 方法 | 路徑 | 說明 |
+| :--- | :--- | :--- | :--- |
+| 列出成員 | GET | `/rooms/:id/members` | |
+| 審核成員 | PATCH | `/rooms/:id/members/:userId/approve` | |
+| 修改權限/暱稱 | PATCH | `/rooms/:id/members/:userId` | role, nickname, is_muted |
+| 踢出成員 | DELETE | `/rooms/:id/members/:userId` | |
+
+### E. 訊息與附件 (Messages & Attachments)
 | 功能 | 方法 | 路徑 | 說明 |
 | :--- | :--- | :--- | :--- |
 | 取得歷史訊息 | GET | `/rooms/:roomId/messages` | cursor pagination (before_id, limit) |

--- a/docs/frontend_integration_guide.md
+++ b/docs/frontend_integration_guide.md
@@ -41,6 +41,10 @@
   | PATCH | `/rooms/:id` | JWT (owner/admin) | 更新群組設定 |
   | POST | `/rooms/join/:code` | JWT | 透過邀請碼加入群組 |
   | DELETE | `/rooms/:id/leave` | JWT | 退出聊天室（owner 不得退出） |
+  | GET | `/rooms/:id/members` | JWT | 列出成員 (Planned / 尚未實作) |
+  | PATCH | `/rooms/:id/members/:userId/approve` | JWT | 審核成員 (Planned / 尚未實作) |
+  | PATCH | `/rooms/:id/members/:userId` | JWT | 修改權限/暱稱 (Planned / 尚未實作) |
+  | DELETE | `/rooms/:id/members/:userId` | JWT | 踢出成員 (Planned / 尚未實作) |
   | GET | `/rooms/:roomId/messages` | JWT | 取得歷史訊息，支援 `?before_id=&limit=` |
   | POST | `/attachments` | JWT | 上傳附件 |
   | GET | `/attachments/:id` | JWT | 下載附件 |


### PR DESCRIPTION
Restores the member routes in the API docs and marks them as planned per user request.