### PR TITLE
test: improve roomService coverage and fix db deadlocks

### DIFF
--- a/backend/tests/unit/services/roomService.test.ts
+++ b/backend/tests/unit/services/roomService.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, type Mocked } from 'vitest';
 import { makeRoomService } from '../../../src/services/roomService';
-import { ForbiddenError, NotFoundError, ValidationError } from '../../../src/errors/AppError';
+import { ConflictError, ForbiddenError, NotFoundError, ValidationError } from '../../../src/errors/AppError';
 import type { IRoomRepository } from '../../../src/repositories/IRoomRepository';
 import type { IRoomMemberRepository } from '../../../src/repositories/IRoomMemberRepository';
 import type { Room, RoomMember } from '../../../../shared/types';
@@ -138,5 +138,54 @@ describe('roomService', () => {
 
     await expect(roomService.createPrivate('user-1', 'user-2')).rejects.toThrow(ForbiddenError);
     expect(mockRepo.create).not.toHaveBeenCalled();
+  });
+  describe('joinByCode', () => {
+    it('joins room using invite code', async () => {
+      mockRepo.findByInviteCode.mockResolvedValue(room);
+      mockMemberRepo.findMember.mockResolvedValue(null);
+      await roomService.joinByCode('user-2', 'ABCDEF');
+      expect(mockMemberRepo.add).toHaveBeenCalledWith({ roomId: 'room-1', userId: 'user-2', role: 'member' });
+    });
+    it('throws ConflictError if already a member', async () => {
+      mockRepo.findByInviteCode.mockResolvedValue(room);
+      mockMemberRepo.findMember.mockResolvedValue({} as RoomMember);
+      await expect(roomService.joinByCode('user-2', 'ABCDEF')).rejects.toThrow(ConflictError);
+    });
+  });
+
+  describe('leave', () => {
+    it('allows normal member to leave', async () => {
+      mockRepo.findById.mockResolvedValue(room);
+      mockMemberRepo.findMember.mockResolvedValue({ role: 'member' } as RoomMember);
+      await roomService.leave('user-2', 'room-1');
+      expect(mockMemberRepo.remove).toHaveBeenCalledWith('room-1', 'user-2');
+    });
+    it('throws ForbiddenError if owner tries to leave', async () => {
+      mockRepo.findById.mockResolvedValue(room);
+      mockMemberRepo.findMember.mockResolvedValue(ownerMember);
+      await expect(roomService.leave('user-1', 'room-1')).rejects.toThrow(ForbiddenError);
+    });
+  });
+
+  describe('kickMember', () => {
+    it('allows owner to kick member', async () => {
+      mockRepo.findById.mockResolvedValue(room);
+      mockMemberRepo.findMember.mockImplementation(async (roomId, userId) => {
+        if (userId === 'user-1') return ownerMember;
+        if (userId === 'user-2') return { role: 'member' } as RoomMember;
+        return null;
+      });
+      await roomService.kickMember('room-1', 'user-1', 'user-2');
+      expect(mockMemberRepo.remove).toHaveBeenCalledWith('room-1', 'user-2');
+    });
+    it('prevents kicking the owner', async () => {
+      mockRepo.findById.mockResolvedValue(room);
+      mockMemberRepo.findMember.mockImplementation(async (roomId, userId) => {
+        if (userId === 'user-1') return { role: 'admin' } as RoomMember;
+        if (userId === 'user-2') return ownerMember;
+        return null;
+      });
+      await expect(roomService.kickMember('room-1', 'user-1', 'user-2')).rejects.toThrow(ForbiddenError);
+    });
   });
 });

--- a/backend/tests/unit/services/userService.test.ts
+++ b/backend/tests/unit/services/userService.test.ts
@@ -149,6 +149,54 @@ describe('userService', () => {
     });
   });
 
+  describe('getMe', () => {
+    it('should return public user if found', async () => {
+      mockRepo.findById.mockResolvedValue({ userId: 'u1', name: 'Test User', avatarUrl: 'http://img.com' } as User);
+      const res = await userService.getMe('u1');
+      expect(res).toEqual({ userId: 'u1', name: 'Test User', avatarUrl: 'http://img.com' });
+      expect(mockRepo.findById).toHaveBeenCalledWith('u1');
+    });
+
+    it('should throw NotFoundError if user not found', async () => {
+      mockRepo.findById.mockResolvedValue(null);
+      await expect(userService.getMe('unknown')).rejects.toThrow();
+    });
+  });
+
+  describe('updateMe', () => {
+    it('should update user and return public profile', async () => {
+      mockRepo.update.mockResolvedValue({ userId: 'u1', name: 'New Name', avatarUrl: 'new.jpg' } as User);
+      const res = await userService.updateMe('u1', { name: 'New Name' });
+      expect(mockRepo.update).toHaveBeenCalledWith('u1', { name: 'New Name' });
+      expect(res).toEqual({ userId: 'u1', name: 'New Name', avatarUrl: 'new.jpg' });
+    });
+
+    it('should throw ValidationError on invalid payload', async () => {
+      await expect(userService.updateMe('u1', { name: '' })).rejects.toThrow();
+      expect(mockRepo.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('deleteMe', () => {
+    it('should set deletedAt', async () => {
+      await userService.deleteMe('u1');
+      expect(mockRepo.update).toHaveBeenCalledWith('u1', { deletedAt: expect.any(Date) });
+    });
+  });
+
+  describe('search', () => {
+    it('should return mapped public users', async () => {
+      mockRepo.search.mockResolvedValue([{ userId: 'u1', name: 'Test', avatarUrl: undefined } as User]);
+      const res = await userService.search('Test');
+      expect(res).toEqual([{ userId: 'u1', name: 'Test', avatarUrl: undefined }]);
+      expect(mockRepo.search).toHaveBeenCalledWith('Test');
+    });
+
+    it('should throw ValidationError if query is invalid', async () => {
+      await expect(userService.search('')).rejects.toThrow();
+    });
+  });
+
   describe('Zod schemas', () => {
     it('should validate registerSchema', () => {
       expect(registerSchema.safeParse({ email: 'valid@example.com', name: 'N', password: 'password123' }).success).toBe(true);

--- a/backend/uploads/2b62630e341111a9422f7eae83f9f739
+++ b/backend/uploads/2b62630e341111a9422f7eae83f9f739
@@ -1,0 +1,1 @@
+dummy file content

--- a/backend/vitest.config.ts
+++ b/backend/vitest.config.ts
@@ -16,5 +16,6 @@ export default defineConfig({
       provider: 'v8',
       include: ['src/**/*.ts'],
     },
+    fileParallelism: false,
   },
 });


### PR DESCRIPTION
Set fileParallelism: false in vitest config to avoid deadlocks. Added missing tests to roomService.