### PR TITLE
perf(db): indexes, soft-delete security, and schema hardening

### DIFF
--- a/backend/migrations/20260601000000_db_optimization.sql
+++ b/backend/migrations/20260601000000_db_optimization.sql
@@ -4,19 +4,25 @@
 ALTER TABLE attachments ALTER COLUMN uploaded_at TYPE TIMESTAMPTZ USING uploaded_at AT TIME ZONE 'UTC';
 
 -- 2. Self-reference prevention constraints
--- Remove any pre-existing self-referencing rows so ADD CONSTRAINT does not fail
+-- Remove any pre-existing self-referencing rows so VALIDATE CONSTRAINT succeeds
 DELETE FROM friendships WHERE requester_id = addressee_id;
 DELETE FROM blocks WHERE blocker_id = blocked_id;
 DELETE FROM emergency_contacts WHERE user_id = contact_id;
 
+-- Add constraints NOT VALID first: skips full-table scan, uses weaker lock
 ALTER TABLE friendships ADD CONSTRAINT friendships_no_self_friendship
-  CHECK (requester_id <> addressee_id);
+  CHECK (requester_id <> addressee_id) NOT VALID;
 
 ALTER TABLE blocks ADD CONSTRAINT blocks_no_self_block
-  CHECK (blocker_id <> blocked_id);
+  CHECK (blocker_id <> blocked_id) NOT VALID;
 
 ALTER TABLE emergency_contacts ADD CONSTRAINT emergency_contacts_no_self_contact
-  CHECK (user_id <> contact_id);
+  CHECK (user_id <> contact_id) NOT VALID;
+
+-- Validate separately: ShareUpdateExclusiveLock instead of AccessExclusiveLock
+ALTER TABLE friendships VALIDATE CONSTRAINT friendships_no_self_friendship;
+ALTER TABLE blocks VALIDATE CONSTRAINT blocks_no_self_block;
+ALTER TABLE emergency_contacts VALIDATE CONSTRAINT emergency_contacts_no_self_contact;
 
 -- 3. room_members: index on user_id for findByMember (PK is (room_id, user_id), unusable for user_id-only scans)
 CREATE INDEX IF NOT EXISTS idx_room_members_user_id ON room_members (user_id);
@@ -40,7 +46,7 @@ CREATE INDEX IF NOT EXISTS idx_users_name_trgm ON users USING gin (name gin_trgm
 
 --- Down migration
 DROP INDEX IF EXISTS idx_users_name_trgm;
-DROP EXTENSION IF EXISTS pg_trgm;
+-- pg_trgm extension is not dropped on rollback: it may be shared with other objects
 DROP INDEX IF EXISTS idx_messages_sender_id;
 DROP INDEX IF EXISTS idx_attachments_message_id;
 DROP INDEX IF EXISTS idx_blocks_blocked_id;

--- a/backend/src/middlewares/authMiddleware.ts
+++ b/backend/src/middlewares/authMiddleware.ts
@@ -2,13 +2,14 @@ import { Request, Response, NextFunction } from 'express';
 import { verifyToken } from '../auth/jwt';
 import { AUTH_COOKIE_NAME, readCookie } from '../auth/cookies';
 import { AppError } from '../errors/AppError';
+import pool from '../db';
 
 const getBearerToken = (authHeader: string | undefined): string | undefined => {
   if (!authHeader?.startsWith('Bearer ')) return undefined;
   return authHeader.split(' ')[1];
 };
 
-export const authMiddleware = (req: Request, res: Response, next: NextFunction): void => {
+export const authMiddleware = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   const token = readCookie(req.headers.cookie, AUTH_COOKIE_NAME) ?? getBearerToken(req.headers.authorization);
   if (!token) {
     return next(new AppError(401, 'Unauthorized: Missing authentication token'));
@@ -16,9 +17,19 @@ export const authMiddleware = (req: Request, res: Response, next: NextFunction):
 
   try {
     const payload = verifyToken(token);
+    const result = await pool.query(
+      'SELECT 1 FROM users WHERE user_id = $1 AND deleted_at IS NULL',
+      [payload.userId]
+    );
+    if (result.rows.length === 0) {
+      return next(new AppError(401, 'Unauthorized: Account not found or deleted'));
+    }
     req.user = payload;
     next();
   } catch (error) {
+    if (error instanceof AppError) {
+      return next(error);
+    }
     next(new AppError(401, 'Unauthorized: Invalid token'));
   }
 };

--- a/backend/src/realtime/authSocket.ts
+++ b/backend/src/realtime/authSocket.ts
@@ -1,6 +1,7 @@
 import type { Server } from 'socket.io';
 import type { ClientToServerEvents, JwtPayload, ServerToClientEvents } from '@shared/types';
 import { verifyToken } from '../auth/jwt';
+import pool from '../db';
 
 type SocketData = {
   user: JwtPayload;
@@ -9,7 +10,7 @@ type SocketData = {
 export type ChatServer = Server<ClientToServerEvents, ServerToClientEvents, never, SocketData>;
 
 export const attachSocketAuth = (io: ChatServer): void => {
-  io.use((socket, next) => {
+  io.use(async (socket, next) => {
     const token = socket.handshake.auth.token;
     if (typeof token !== 'string' || token.length === 0) {
       next(new Error('Authentication error'));
@@ -17,7 +18,16 @@ export const attachSocketAuth = (io: ChatServer): void => {
     }
 
     try {
-      socket.data.user = verifyToken(token);
+      const payload = verifyToken(token);
+      const result = await pool.query(
+        'SELECT 1 FROM users WHERE user_id = $1 AND deleted_at IS NULL',
+        [payload.userId]
+      );
+      if (result.rows.length === 0) {
+        next(new Error('Authentication error'));
+        return;
+      }
+      socket.data.user = payload;
       next();
     } catch {
       next(new Error('Authentication error'));

--- a/backend/src/repositories/userRepository.test.ts
+++ b/backend/src/repositories/userRepository.test.ts
@@ -1,0 +1,65 @@
+/// <reference types="vitest/globals" />
+import { Pool } from 'pg';
+import { UserRepository } from './userRepository';
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL_TEST || process.env.DATABASE_URL,
+});
+const repo = new UserRepository(pool);
+
+afterAll(async () => {
+  await pool.end();
+});
+
+describe('UserRepository soft-delete', () => {
+  it('findById returns null for a soft-deleted user', async () => {
+    const user = await repo.create({
+      name: 'Soft Delete Test',
+      email: `soft-delete-findbyid-${Date.now()}@test.example`,
+      passwordHash: 'testhash',
+    });
+
+    await repo.update(user.userId, { deletedAt: new Date() });
+
+    try {
+      const result = await repo.findById(user.userId);
+      expect(result).toBeNull();
+    } finally {
+      await repo.delete(user.userId);
+    }
+  });
+
+  it('findByEmail returns null for a soft-deleted user', async () => {
+    const email = `soft-delete-findbyemail-${Date.now()}@test.example`;
+    const user = await repo.create({
+      name: 'Soft Delete Test',
+      email,
+      passwordHash: 'testhash',
+    });
+
+    await repo.update(user.userId, { deletedAt: new Date() });
+
+    try {
+      const result = await repo.findByEmail(email);
+      expect(result).toBeNull();
+    } finally {
+      await repo.delete(user.userId);
+    }
+  });
+
+  it('findById returns the user when not soft-deleted', async () => {
+    const user = await repo.create({
+      name: 'Active User Test',
+      email: `active-findbyid-${Date.now()}@test.example`,
+      passwordHash: 'testhash',
+    });
+
+    try {
+      const result = await repo.findById(user.userId);
+      expect(result).not.toBeNull();
+      expect(result?.userId).toBe(user.userId);
+    } finally {
+      await repo.delete(user.userId);
+    }
+  });
+});

--- a/backend/tests/e2e/socket/socketEvents.e2e.test.ts
+++ b/backend/tests/e2e/socket/socketEvents.e2e.test.ts
@@ -9,6 +9,10 @@ import { attachSocketAuth, type ChatServer } from '../../../src/realtime/authSoc
 import { attachSockets } from '../../../src/realtime/socketServer';
 import type { ClientToServerEvents, MessageWithSender, ServerToClientEvents } from '../../../../shared/types';
 
+vi.mock('../../../src/db', () => ({
+  default: { query: vi.fn().mockResolvedValue({ rows: [{}] }) },
+}));
+
 type TestClient = ClientSocket<ServerToClientEvents, ClientToServerEvents>;
 
 const message: MessageWithSender = {

--- a/backend/tests/unit/middlewares/authMiddleware.test.ts
+++ b/backend/tests/unit/middlewares/authMiddleware.test.ts
@@ -3,9 +3,10 @@ import { Request, Response, NextFunction } from 'express';
 import { authMiddleware } from '../../../src/middlewares/authMiddleware';
 import * as jwtHelper from '../../../src/auth/jwt';
 import { AppError } from '../../../src/errors/AppError';
+import pool from '../../../src/db';
 
 vi.mock('../../../src/db', () => ({
-  default: { query: vi.fn().mockResolvedValue({ rows: [{}] }) },
+  default: { query: vi.fn() },
 }));
 
 describe('authMiddleware', () => {
@@ -19,6 +20,8 @@ describe('authMiddleware', () => {
     };
     mockResponse = {};
     nextFunction = vi.fn();
+    // vi.restoreAllMocks() resets vi.fn() implementations, so re-apply after each test
+    vi.mocked(pool.query).mockResolvedValue({ rows: [{}] } as any);
   });
 
   afterEach(() => {

--- a/backend/tests/unit/middlewares/authMiddleware.test.ts
+++ b/backend/tests/unit/middlewares/authMiddleware.test.ts
@@ -4,6 +4,10 @@ import { authMiddleware } from '../../../src/middlewares/authMiddleware';
 import * as jwtHelper from '../../../src/auth/jwt';
 import { AppError } from '../../../src/errors/AppError';
 
+vi.mock('../../../src/db', () => ({
+  default: { query: vi.fn().mockResolvedValue({ rows: [{}] }) },
+}));
+
 describe('authMiddleware', () => {
   let mockRequest: Partial<Request>;
   let mockResponse: Partial<Response>;

--- a/backend/tests/unit/realtime/authSocket.test.ts
+++ b/backend/tests/unit/realtime/authSocket.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, it, vi } from 'vitest';
 import { signToken } from '../../../src/auth/jwt';
 import { attachSocketAuth, type ChatServer } from '../../../src/realtime/authSocket';
 
+vi.mock('../../../src/db', () => ({
+  default: { query: vi.fn().mockResolvedValue({ rows: [{}] }) },
+}));
+
 describe('attachSocketAuth', () => {
   it('rejects connections without a token', () => {
     let middleware: any;
@@ -14,7 +18,7 @@ describe('attachSocketAuth', () => {
     expect(next).toHaveBeenCalledWith(expect.any(Error));
   });
 
-  it('verifies tokens with the shared JWT helper and stores socket data user', () => {
+  it('verifies tokens with the shared JWT helper and stores socket data user', async () => {
     let middleware: any;
     const io = { use: vi.fn((fn) => { middleware = fn; }) } as unknown as ChatServer;
     const socket = {
@@ -24,7 +28,7 @@ describe('attachSocketAuth', () => {
     attachSocketAuth(io);
 
     const next = vi.fn();
-    middleware(socket, next);
+    await middleware(socket, next);
 
     expect(next).toHaveBeenCalledWith();
     expect(socket.data).toMatchObject({


### PR DESCRIPTION
## Summary

- Adds missing PostgreSQL indexes for `room_members`, `friendships`, `blocks`, `attachments`, `messages`, and a pg_trgm GIN index for user name search
- Hardens soft-delete: `UserRepository.findById`/`findByEmail` filter `deleted_at IS NULL`; auth middleware (HTTP + Socket.IO) now rejects soft-deleted accounts even with a valid JWT
- Fixes schema issues: `attachments.uploaded_at` standardized to `TIMESTAMPTZ`; self-reference CHECK constraints on `friendships`, `blocks`, `emergency_contacts`
- Service guards: `friendService.blockUser` and `userService.upsertEmergencyContact` reject self-targeting with 4xx before hitting the DB
- Migration uses `NOT VALID` + `VALIDATE CONSTRAINT` to reduce lock impact; down migration no longer drops the shared `pg_trgm` extension

## Test plan

- [ ] Run `npm test` inside the backend container — `userRepository.test.ts` covers `findById`/`findByEmail` returning `null` for soft-deleted users
- [ ] Verify migration applies cleanly: `npm run migrate:up`
- [ ] Verify soft-deleted user JWT returns 401 on an authenticated endpoint
- [ ] Verify Socket.IO handshake with a soft-deleted user's token is rejected
- [ ] Verify self-block and self-emergency-contact requests return 400