### PR TITLE
Fix: Blocked user not appearing in Blocked users list

### DIFF
--- a/backend/.omc/state/last-tool-error.json
+++ b/backend/.omc/state/last-tool-error.json
@@ -1,7 +1,7 @@
 {
   "tool_name": "Bash",
-  "tool_input_preview": "{\"command\":\"git add docs/frontend_integration_guide.md && git commit -m \\\"$(cat <<'EOF'\\ndocs: update frontend integration guide to reflect completed controller layer (#14 #15 #16)\\n\\nCo-Authored-By: ...",
-  "error": "Exit code 128\nwarning: could not open directory 'backend/docs/': No such file or directory\nfatal: pathspec 'docs/frontend_integration_guide.md' did not match any files",
-  "timestamp": "2026-05-30T11:26:11.060Z",
+  "tool_input_preview": "{\"command\":\"gh -R ray0520/1142-ntnu-db-app run list --branch dev --limit 5\",\"description\":\"List recent CI runs on dev branch\"}",
+  "error": "Exit code 1\nfailed to get runs: HTTP 404: Not Found (https://api.github.com/repos/ray0520/1142-ntnu-db-app/actions/runs?per_page=5&exclude_pull_requests=true&branch=dev)",
+  "timestamp": "2026-06-02T14:50:28.823Z",
   "retry_count": 1
 }

--- a/backend/.omc/state/subagent-tracking.json
+++ b/backend/.omc/state/subagent-tracking.json
@@ -3,5 +3,5 @@
   "total_spawned": 0,
   "total_completed": 0,
   "total_failed": 0,
-  "last_updated": "2026-05-25T12:18:32.157Z"
+  "last_updated": "2026-06-02T14:51:34.744Z"
 }

--- a/backend/src/controllers/friendController.ts
+++ b/backend/src/controllers/friendController.ts
@@ -111,6 +111,16 @@ export const makeFriendController = (
       } catch (err) {
         next(err);
       }
+    },
+
+    async getBlockedUsers(req: Request, res: Response, next: NextFunction) {
+      try {
+        const userId = req.user!.userId;
+        const blockedUsers = await service.getBlockedUsers(userId);
+        res.status(200).json(blockedUsers);
+      } catch (err) {
+        next(err);
+      }
     }
   };
 };

--- a/backend/src/repositories/friendRepository.ts
+++ b/backend/src/repositories/friendRepository.ts
@@ -138,6 +138,22 @@ export const makeFriendRepository = (db: Pool) => {
       );
     },
 
+    async getBlockedUsers(userId: string): Promise<any[]> {
+      const res = await db.query(
+        `SELECT u.user_id, u.name, u.email, u.avatar_url
+         FROM blocks b
+         JOIN users u ON u.user_id = b.blocked_id AND u.deleted_at IS NULL
+         WHERE b.blocker_id = $1`,
+        [userId]
+      );
+      return res.rows.map(row => ({
+        id: row.user_id,
+        name: row.name,
+        email: row.email,
+        avatarUrl: row.avatar_url ?? undefined
+      }));
+    },
+
     async isBlocked(user1: string, user2: string): Promise<boolean> {
       const res = await db.query(
         `SELECT 1 FROM blocks

--- a/backend/src/repositories/friendRepository.ts
+++ b/backend/src/repositories/friendRepository.ts
@@ -147,7 +147,7 @@ export const makeFriendRepository = (db: Pool) => {
         [userId]
       );
       return res.rows.map(row => ({
-        id: row.user_id,
+        userId: row.user_id,
         name: row.name,
         email: row.email,
         avatarUrl: row.avatar_url ?? undefined

--- a/backend/src/routes/friendRoutes.ts
+++ b/backend/src/routes/friendRoutes.ts
@@ -19,6 +19,7 @@ export const makeBlockRoutes = (ctrl: ReturnType<typeof makeFriendController>): 
 
   router.use(authMiddleware);
 
+  router.get('/', ctrl.getBlockedUsers.bind(ctrl));
   router.post('/', ctrl.blockUser.bind(ctrl));
   router.delete('/:id', ctrl.unblockUser.bind(ctrl));
 

--- a/backend/src/services/friendService.ts
+++ b/backend/src/services/friendService.ts
@@ -87,6 +87,10 @@ export function makeFriendService(
 
     async unblockUser(userId: string, blockedId: string) {
       return repo.unblockUser(userId, blockedId);
+    },
+
+    async getBlockedUsers(userId: string) {
+      return repo.getBlockedUsers(userId);
     }
   };
 }

--- a/backend/tests/e2e/routes/friend.e2e.test.ts
+++ b/backend/tests/e2e/routes/friend.e2e.test.ts
@@ -232,5 +232,24 @@ describe('Friendships & Blocks E2E', () => {
       const row = await testPool.query('SELECT is_archived FROM chat_rooms WHERE room_id = $1', [privateRoom.body.roomId]);
       expect(row.rows[0].is_archived).toBe(true);
     });
+
+    it('should list blocked users', async () => {
+      // A blocks C (done in earlier test, but tests might not be perfectly isolated, let's block C if not blocked or use B)
+      await request(app)
+        .post('/api/v1/blocks')
+        .set('Authorization', `Bearer ${tokenA}`)
+        .send({ target_user_id: userC.userId });
+
+      const listRes = await request(app)
+        .get('/api/v1/blocks')
+        .set('Authorization', `Bearer ${tokenA}`);
+
+      expect(listRes.status).toBe(200);
+      expect(Array.isArray(listRes.body)).toBe(true);
+      expect(listRes.body.length).toBeGreaterThan(0);
+      expect(listRes.body[0]).toHaveProperty('userId');
+      expect(listRes.body[0]).toHaveProperty('name');
+      expect(listRes.body[0]).toHaveProperty('email');
+    });
   });
 });

--- a/frontend/src/context/ChatContext.tsx
+++ b/frontend/src/context/ChatContext.tsx
@@ -27,6 +27,7 @@ import {
   createPrivateRoom,
   deleteEmergencyContact,
   deleteFriend,
+  getBlockedUsers,
   getMe,
   getMySettings,
   getUserProfile,
@@ -480,16 +481,18 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
   };
 
   const refreshSocialData = async (authToken: string, settings?: UserSettings) => {
-    const [apiFriends, apiRequests, apiEmergencyContacts] = await Promise.all([
+    const [apiFriends, apiRequests, apiEmergencyContacts, apiBlockedUsers] = await Promise.all([
       listFriends(authToken),
       listFriendRequests(authToken),
       listEmergencyContacts(authToken),
+      getBlockedUsers(authToken),
     ]);
     const contacts = apiEmergencyContacts.map(mapEmergencyContact);
     const emergencyContactIds = new Set(contacts.map((contact) => contact.contactId));
 
     setFriends(apiFriends.map((friend) => mapFriend(friend, emergencyContactIds)));
     setFriendRequests(apiRequests.map(mapFriendRequest));
+    setBlockedUsers(apiBlockedUsers);
     setEmergencySettings({
       warningEnabled: settings?.warningEnabled ?? user.warningEnabled ?? false,
       warningDays: settings?.warningDays ?? user.warningDays ?? 0,

--- a/frontend/src/context/ChatContext.tsx
+++ b/frontend/src/context/ChatContext.tsx
@@ -492,7 +492,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
 
     setFriends(apiFriends.map((friend) => mapFriend(friend, emergencyContactIds)));
     setFriendRequests(apiRequests.map(mapFriendRequest));
-    setBlockedUsers(apiBlockedUsers);
+    setBlockedUsers(apiBlockedUsers.map(u => ({ id: u.userId, name: u.name, email: u.email })));
     setEmergencySettings({
       warningEnabled: settings?.warningEnabled ?? user.warningEnabled ?? false,
       warningDays: settings?.warningDays ?? user.warningDays ?? 0,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -202,8 +202,8 @@ export const respondFriendRequest = (
     { token },
   );
 
-export const getBlockedUsers = (token: string): Promise<{id: string, name: string, email: string, avatarUrl?: string}[]> =>
-  requestJson<{id: string, name: string, email: string, avatarUrl?: string}[]>('/blocks', { method: 'GET' }, { token });
+export const getBlockedUsers = (token: string): Promise<{userId: string, name: string, email: string, avatarUrl?: string}[]> =>
+  requestJson<{userId: string, name: string, email: string, avatarUrl?: string}[]>('/blocks', { method: 'GET' }, { token });
 
 export const blockUser = (token: string, targetUserId: string): Promise<{ status: 'blocked' }> =>
   requestJson<{ status: 'blocked' }>(

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -202,6 +202,9 @@ export const respondFriendRequest = (
     { token },
   );
 
+export const getBlockedUsers = (token: string): Promise<{id: string, name: string, email: string, avatarUrl?: string}[]> =>
+  requestJson<{id: string, name: string, email: string, avatarUrl?: string}[]>('/blocks', { method: 'GET' }, { token });
+
 export const blockUser = (token: string, targetUserId: string): Promise<{ status: 'blocked' }> =>
   requestJson<{ status: 'blocked' }>(
     '/blocks',

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -28,7 +28,9 @@
       "@/*": [
         "./src/*"
       ],
-      "@shared/*": ["../shared/*"]
+      "@shared/*": [
+        "../shared/*"
+      ]
     }
   },
   "include": [
@@ -36,7 +38,8 @@
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts",
-    "**/*.mts"
+    "**/*.mts",
+    ".next/dev/types/**/*.ts"
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
## 原因
1. **後端 API 缺失**：原本後端並沒有實作 `GET /api/v1/blocks` 來提供封鎖名單的資料。
2. **前端未同步拉取資料**：前端在初始載入時（`refreshSocialData`）並未向後端請求被封鎖的用戶清單，導致 `blockedUsers` 狀態為空。
3. **前端介面要求 email**：前端的 `BlockedUser` 介面包含必填的 `email` 屬性，而原本後端的封鎖查詢沒有包含該欄位。

## 修改內容
- **後端 (Backend)**:
  - `friendRepository.ts`: 新增 `getBlockedUsers(userId)` 方法，並使用 `JOIN` 結合 `users` 表來選取使用者的 `user_id`, `name`, `email` 及 `avatar_url`。
  - `friendService.ts`: 新增 `getBlockedUsers(userId)` 方法。
  - `friendController.ts`: 新增 `getBlockedUsers(req, res, next)` 處理請求，回傳 JSON 格式名單。
  - `friendRoutes.ts`: 新增 `GET /` 路由至封鎖名單管理模組 (`/api/v1/blocks`)。
- **前端 (Frontend)**:
  - `api.ts`: 補齊 `getBlockedUsers` API 呼叫，並更新回傳的物件型別包含 `id, name, email, avatarUrl`。
  - `ChatContext.tsx`: 修改 `refreshSocialData`，在同步使用者資料時一併發送 `getBlockedUsers` 請求，並使用 `setBlockedUsers` 更新 context 的封鎖狀態。

此修復確保了在網頁重整、重新載入時，皆會同步資料庫中的最新封鎖名單。

Closes #122