### PR TITLE
fix(migrations): add CREATE EXTENSION pg_trgm before trgm index

### DIFF
--- a/backend/migrations/2026060100000_db_optimization.sql
+++ b/backend/migrations/2026060100000_db_optimization.sql
@@ -17,6 +17,7 @@ CREATE INDEX IF NOT EXISTS idx_attachments_message_id ON attachments (message_id
 CREATE INDEX IF NOT EXISTS idx_messages_sender_id ON messages (sender_id);
 
 -- user search: pg_trgm GIN index for efficient ILIKE '%query%', partial for active users only
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
 CREATE INDEX IF NOT EXISTS idx_users_name_trgm ON users USING gin (name gin_trgm_ops) WHERE deleted_at IS NULL;
 
 --- Down migration


### PR DESCRIPTION
## Summary

- `2026060100000_db_optimization.sql` 的 `idx_users_name_trgm` 使用 `gin_trgm_ops`，依賴 `pg_trgm` extension
- 原本缺少 `CREATE EXTENSION IF NOT EXISTS pg_trgm;`，新環境從頭建表會失敗
- 補上一行即可，down migration 不需 DROP（extension 可能被其他物件共用）

Closes #157

## Test plan

- [ ] 確認全新環境跑 migration 不拋錯
- [ ] 確認 `idx_users_name_trgm` index 成功建立