### PR TITLE
feat(#133): invite member UI — copy code, send message, join by code

### DIFF
--- a/backend/src/routes/roomRoutes.ts
+++ b/backend/src/routes/roomRoutes.ts
@@ -9,6 +9,7 @@ export const makeRoomRoutes = (ctrl: ReturnType<typeof makeRoomController>): Rou
 
   router.get('/', ctrl.list.bind(ctrl));
   router.post('/', ctrl.create.bind(ctrl));
+  router.post('/join', ctrl.join.bind(ctrl));
   router.get('/:id/members', ctrl.listMembers.bind(ctrl));
   router.post('/:id/members', ctrl.join.bind(ctrl));
   router.delete('/:id/members/me', ctrl.leave.bind(ctrl));

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -25,6 +25,7 @@ export default function Sidebar() {
     handleCreateRoom,
     handleCreateFolder,
     handleCategorizeRoom,
+    handleJoinByInviteCode,
     handleLogout,
     friendRequests,
     uiLanguage,
@@ -38,6 +39,9 @@ export default function Sidebar() {
   const isChatPage = pathname === "/" || pathname.startsWith("/chat");
   const [isCreateRoomOpen, setIsCreateRoomOpen] = useState(false);
   const [isCreateFolderOpen, setIsCreateFolderOpen] = useState(false);
+  const [isJoinRoomOpen, setIsJoinRoomOpen] = useState(false);
+  const [joinInviteCode, setJoinInviteCode] = useState("");
+  const [joinError, setJoinError] = useState("");
   const [newRoomName, setNewRoomName] = useState("");
   const [newRoomType, setNewRoomType] = useState<"msg" | "group">("msg");
   const [newRoomFolder, setNewRoomFolder] = useState("");
@@ -80,6 +84,20 @@ export default function Sidebar() {
   };
 
 
+
+  const handleJoinRoomSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!joinInviteCode.trim()) return;
+    setJoinError("");
+    try {
+      const newId = await handleJoinByInviteCode(joinInviteCode);
+      setJoinInviteCode("");
+      setIsJoinRoomOpen(false);
+      router.push(`/chat/${newId}`);
+    } catch (error) {
+      setJoinError(error instanceof Error ? error.message : "加入失敗，請確認邀請碼是否正確");
+    }
+  };
 
   const pendingIncoming = friendRequests?.filter((request) => request.direction === "incoming").length || 0;
   const firstChatPath = rooms[0] ? `/chat/${rooms[0].id}` : "/";
@@ -171,6 +189,9 @@ export default function Sidebar() {
             </IconButton>
             <IconButton label={t("sidebar.newChat")} onClick={() => setIsCreateRoomOpen(true)}>
               <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
+            </IconButton>
+            <IconButton label="加入群組" onClick={() => { setJoinInviteCode(""); setJoinError(""); setIsJoinRoomOpen(true); }}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M11 16l-4-4m0 0l4-4m-4 4h14" />
             </IconButton>
           </div>
         </div>
@@ -318,6 +339,29 @@ export default function Sidebar() {
             </Button>
             <Button type="submit" variant="primary">
               {t("sidebar.create")}
+            </Button>
+          </div>
+        </form>
+      </Modal>
+
+      <Modal isOpen={isJoinRoomOpen} onClose={() => setIsJoinRoomOpen(false)} title="加入群組">
+        <form onSubmit={handleJoinRoomSubmit} className="flex flex-col gap-5">
+          <Input
+            label="邀請碼"
+            value={joinInviteCode}
+            onChange={(e) => setJoinInviteCode(e.target.value)}
+            required
+            placeholder="請輸入邀請碼…"
+          />
+          {joinError && (
+            <p className="text-xs text-red-600">{joinError}</p>
+          )}
+          <div className="border-t border-border-primary pt-5 flex items-center justify-end gap-3">
+            <Button type="button" variant="secondary" onClick={() => setIsJoinRoomOpen(false)}>
+              取消
+            </Button>
+            <Button type="submit" variant="primary">
+              加入
             </Button>
           </div>
         </form>

--- a/frontend/src/components/settings/GroupSettings.tsx
+++ b/frontend/src/components/settings/GroupSettings.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
+import type { PublicUser } from "@shared/types";
 import { useChat, getAvatarForUser, Member } from "@/context/ChatContext";
 import { Avatar } from "@/components/ui/Avatar";
 import { Button } from "@/components/ui/Button";
@@ -25,6 +26,7 @@ export default function GroupSettings({ roomId, onClose }: GroupSettingsProps) {
     kickGroupMember,
     transferGroupOwner,
     handleDeleteGroupRoom,
+    searchUsersForInvite,
   } = useChat();
 
   const activeRoom = rooms.find((room) => room.id === roomId);
@@ -34,6 +36,10 @@ export default function GroupSettings({ roomId, onClose }: GroupSettingsProps) {
   const [members, setMembers] = useState<Member[]>([]);
   const [feedback, setFeedback] = useState<string>("");
   const [isSaving, setIsSaving] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searchResults, setSearchResults] = useState<PublicUser[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const searchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const currentMember = useMemo(
     () => members.find((member) => member.userId === user.userId || member.name === user.username),
@@ -174,6 +180,49 @@ export default function GroupSettings({ roomId, onClose }: GroupSettingsProps) {
     }
   };
 
+  const handleCopyInviteCode = async () => {
+    const code = activeRoom.inviteCode;
+    if (!code) return;
+    try {
+      await navigator.clipboard.writeText(code);
+      setFeedback("邀請碼已複製到剪貼簿！");
+    } catch {
+      window.prompt("請手動複製以下邀請碼：", code);
+    }
+  };
+
+  const handleSearchQueryChange = (value: string) => {
+    setSearchQuery(value);
+    if (searchTimeoutRef.current) clearTimeout(searchTimeoutRef.current);
+    if (!value.trim()) {
+      setSearchResults([]);
+      return;
+    }
+    searchTimeoutRef.current = setTimeout(() => {
+      setIsSearching(true);
+      searchUsersForInvite(value)
+        .then((results) => {
+          const memberIds = new Set(members.map((m) => m.userId));
+          setSearchResults(results.filter((u) => !memberIds.has(u.userId)));
+        })
+        .catch((error) => {
+          setFeedback(error instanceof Error ? error.message : "搜尋失敗");
+        })
+        .finally(() => setIsSearching(false));
+    }, 400);
+  };
+
+  const handleCopyCodeForUser = async (userName: string) => {
+    const code = activeRoom.inviteCode;
+    if (!code) return;
+    try {
+      await navigator.clipboard.writeText(code);
+      setFeedback(`邀請碼已複製！請將邀請碼分享給 ${userName}`);
+    } catch {
+      window.prompt(`請將以下邀請碼分享給 ${userName}：`, code);
+    }
+  };
+
   return (
     <div className="flex-1 flex flex-col bg-background h-full overflow-hidden">
       <div className="h-14 border-b border-border-primary px-6 flex items-center justify-between select-none shrink-0 bg-surface-card z-10">
@@ -221,13 +270,56 @@ export default function GroupSettings({ roomId, onClose }: GroupSettingsProps) {
                 onChange={(event) => setViewHistory(event.target.checked)}
               />
             </div>
-            <div className="flex items-center justify-between border border-border-secondary bg-surface-muted px-3 py-2">
-              <div>
+            <div className="flex items-center justify-between border border-border-secondary bg-surface-muted px-3 py-2 gap-3">
+              <div className="min-w-0">
                 <p className="text-xs font-semibold text-foreground">邀請碼</p>
-                <p className="text-[10px] text-text-muted mt-1">使用 `POST /rooms/:id/members` 加入群組時需要。</p>
+                <p className="text-[10px] text-text-muted mt-1">
+                  將邀請碼分享給想加入的人，對方在加入群組時輸入此碼即可。
+                </p>
+                <code className="text-xs font-mono text-primary mt-1 block">{activeRoom.inviteCode ?? "尚未產生"}</code>
               </div>
-              <code className="text-xs font-mono text-primary">{activeRoom.inviteCode ?? "尚未產生"}</code>
+              {activeRoom.inviteCode && (
+                <Button type="button" variant="secondary" className="text-xs py-1 px-3 shrink-0" onClick={() => void handleCopyInviteCode()}>
+                  複製邀請碼
+                </Button>
+              )}
             </div>
+            {canManageMembers && (
+              <div className="flex flex-col gap-2 border border-border-secondary bg-surface-muted px-3 py-3">
+                <p className="text-xs font-semibold text-foreground">搜尋並邀請成員</p>
+                <p className="text-[10px] text-text-muted">輸入名稱搜尋用戶，將邀請碼複製後分享給對方。</p>
+                <div className="flex gap-2">
+                  <Input
+                    label=""
+                    value={searchQuery}
+                    onChange={(e) => handleSearchQueryChange(e.target.value)}
+                    placeholder="輸入名稱搜尋用戶…"
+                  />
+                </div>
+                {isSearching && <p className="text-[10px] text-text-muted">搜尋中…</p>}
+                {!isSearching && searchQuery.trim() && searchResults.length === 0 && (
+                  <p className="text-[10px] text-text-muted">找不到符合的用戶（已在群組中的成員不會顯示）</p>
+                )}
+                {searchResults.length > 0 && (
+                  <div className="flex flex-col divide-y divide-border-secondary border border-border-secondary rounded-sm overflow-hidden">
+                    {searchResults.map((u) => (
+                      <div key={u.userId} className="flex items-center justify-between px-3 py-2 text-xs bg-surface-card">
+                        <span className="font-medium text-foreground">{u.name}</span>
+                        <Button
+                          type="button"
+                          variant="secondary"
+                          className="text-[10px] py-1 px-2"
+                          onClick={() => void handleCopyCodeForUser(u.name)}
+                        >
+                          複製邀請碼給此用戶
+                        </Button>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
+
             <div className="flex justify-end">
               <Button type="submit" variant="primary" disabled={isSaving}>
                 {isSaving ? "儲存中..." : "儲存設定"}

--- a/frontend/src/components/settings/GroupSettings.tsx
+++ b/frontend/src/components/settings/GroupSettings.tsx
@@ -27,6 +27,8 @@ export default function GroupSettings({ roomId, onClose }: GroupSettingsProps) {
     transferGroupOwner,
     handleDeleteGroupRoom,
     searchUsersForInvite,
+    handleOpenPrivateRoom,
+    handleSendMessage,
   } = useChat();
 
   const activeRoom = rooms.find((room) => room.id === roomId);
@@ -212,14 +214,19 @@ export default function GroupSettings({ roomId, onClose }: GroupSettingsProps) {
     }, 400);
   };
 
-  const handleCopyCodeForUser = async (userName: string) => {
+  const handleSendInviteMessage = async (targetUser: PublicUser) => {
     const code = activeRoom.inviteCode;
-    if (!code) return;
+    if (!code) {
+      setFeedback("此群組尚未產生邀請碼，無法傳送邀請");
+      return;
+    }
     try {
-      await navigator.clipboard.writeText(code);
-      setFeedback(`邀請碼已複製！請將邀請碼分享給 ${userName}`);
-    } catch {
-      window.prompt(`請將以下邀請碼分享給 ${userName}：`, code);
+      const privateRoomId = await handleOpenPrivateRoom(targetUser.userId);
+      const msg = `【群組邀請】\n我邀請你加入群組「${activeRoom.name}」！\n邀請碼：${code}`;
+      handleSendMessage(privateRoomId, msg, null);
+      setFeedback(`已傳送邀請訊息給 ${targetUser.name}`);
+    } catch (error) {
+      setFeedback(error instanceof Error ? error.message : "傳送邀請失敗");
     }
   };
 
@@ -309,9 +316,9 @@ export default function GroupSettings({ roomId, onClose }: GroupSettingsProps) {
                           type="button"
                           variant="secondary"
                           className="text-[10px] py-1 px-2"
-                          onClick={() => void handleCopyCodeForUser(u.name)}
+                          onClick={() => void handleSendInviteMessage(u)}
                         >
-                          複製邀請碼給此用戶
+                          傳送邀請訊息
                         </Button>
                       </div>
                     ))}

--- a/frontend/src/context/ChatContext.tsx
+++ b/frontend/src/context/ChatContext.tsx
@@ -263,6 +263,7 @@ interface ChatContextType {
   handleDeleteGroupRoom: (roomId: string) => Promise<string | null>;
   getReadAvatarsForMessage: (room: ChatRoom, msg: Message) => string[];
 
+  searchUsersForInvite: (query: string) => Promise<PublicUser[]>;
   sendFriendRequest: (query: string) => Promise<void>;
   acceptFriendRequest: (requestId: string) => Promise<void>;
   rejectFriendRequest: (requestId: string) => Promise<void>;
@@ -1095,6 +1096,13 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
       .map(() => "");
   };
 
+  const searchUsersForInvite = async (query: string): Promise<PublicUser[]> => {
+    if (!token) throw new Error("Not authenticated");
+    const trimmed = query.trim();
+    if (!trimmed) return [];
+    return searchUsers(token, { query: trimmed });
+  };
+
   const sendFriendRequest = async (query: string) => {
     if (!token) throw new Error("Not authenticated");
     const trimmedQuery = query.trim();
@@ -1350,6 +1358,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
         transferGroupOwner,
         handleDeleteGroupRoom,
         getReadAvatarsForMessage,
+        searchUsersForInvite,
         sendFriendRequest,
         acceptFriendRequest,
         rejectFriendRequest,

--- a/frontend/src/context/ChatContext.tsx
+++ b/frontend/src/context/ChatContext.tsx
@@ -30,6 +30,7 @@ import {
   deleteFolder as deleteFolderApi,
   getBlockedUsers,
   getMe,
+  joinRoomByCode,
   getMySettings,
   getUserProfile,
   kickRoomMember,
@@ -264,6 +265,7 @@ interface ChatContextType {
   getReadAvatarsForMessage: (room: ChatRoom, msg: Message) => string[];
 
   searchUsersForInvite: (query: string) => Promise<PublicUser[]>;
+  handleJoinByInviteCode: (inviteCode: string) => Promise<string>;
   sendFriendRequest: (query: string) => Promise<void>;
   acceptFriendRequest: (requestId: string) => Promise<void>;
   rejectFriendRequest: (requestId: string) => Promise<void>;
@@ -1103,6 +1105,13 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
     return searchUsers(token, { query: trimmed });
   };
 
+  const handleJoinByInviteCode = async (inviteCode: string): Promise<string> => {
+    if (!token) throw new Error("Not authenticated");
+    const room = await joinRoomByCode(token, inviteCode.trim());
+    await refreshRoomsAndFolders(token);
+    return room.roomId;
+  };
+
   const sendFriendRequest = async (query: string) => {
     if (!token) throw new Error("Not authenticated");
     const trimmedQuery = query.trim();
@@ -1359,6 +1368,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
         handleDeleteGroupRoom,
         getReadAvatarsForMessage,
         searchUsersForInvite,
+        handleJoinByInviteCode,
         sendFriendRequest,
         acceptFriendRequest,
         rejectFriendRequest,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -241,6 +241,16 @@ export const createPrivateRoom = (token: string, data: CreatePrivateRequest): Pr
     { token },
   );
 
+export const joinRoomByCode = (token: string, inviteCode: string): Promise<Room> =>
+  requestJson<Room>(
+    '/rooms/join',
+    {
+      method: 'POST',
+      ...withJsonBody({ inviteCode }),
+    },
+    { token },
+  );
+
 export const updateRoom = (
   token: string,
   roomId: string,


### PR DESCRIPTION
## Summary

Completes issue #133 — full invite/join flow for group rooms.

**Backend**
- `POST /api/v1/rooms/join` — new route accepting only `{ inviteCode }` in body; no room ID required

**Frontend**
- `api.ts` → `joinRoomByCode(token, inviteCode)`
- `ChatContext` → `handleJoinByInviteCode`, `searchUsersForInvite` exposed to consumers
- `Sidebar` → new "加入群組" icon button opens a modal; paste invite code → join and navigate to room
- `GroupSettings` → invite code section: human-readable instructions + copy button
- `GroupSettings` → member search panel (owner/admin only): "傳送邀請訊息" opens a private room with the found user and sends `【群組邀請】\n我邀請你加入群組「{name}」！\n邀請碼：{code}`

Closes #133

## Test plan

- [x] Sidebar: "加入群組" button → modal → paste valid code → joins and navigates
- [x] Invalid code → error shown in modal
- [x] Group Settings: invite code copy button works (fallback to prompt if clipboard unavailable)
- [x] Group Settings (owner/admin): search user → "傳送邀請訊息" → private chat shows fixed-format invite
- [ ] Non-admin: search panel not visible