### PR TITLE
Fix: Issue #140 - Add bio field and delete account functionality to Profile Settings

### DIFF
--- a/frontend/src/components/settings/ProfileSettings.tsx
+++ b/frontend/src/components/settings/ProfileSettings.tsx
@@ -13,10 +13,11 @@ import { useTranslation } from "@/hooks/useTranslation";
 
 export default function ProfileSettings() {
   const router = useRouter();
-  const { user, rooms, uiLanguage, handleSavePersonalSettings, setUiLanguage } = useChat();
+  const { user, rooms, uiLanguage, handleSavePersonalSettings, handleDeleteAccount, setUiLanguage } = useChat();
   const [personalUsername, setPersonalUsername] = useState("");
   const [personalEmail, setPersonalEmail] = useState("");
   const [personalAvatar, setPersonalAvatar] = useState("");
+  const [personalBio, setPersonalBio] = useState("");
   const [desktopNotifications, setDesktopNotifications] = useState(true);
   const [messageSounds, setMessageSounds] = useState(true);
   const [personalTheme, setPersonalTheme] = useState("light");
@@ -33,6 +34,7 @@ export default function ProfileSettings() {
         setPersonalUsername(parsed.username || user.username);
         setPersonalEmail(parsed.email || user.email);
         setPersonalAvatar(parsed.avatar || user.avatar);
+        setPersonalBio(parsed.bio || user.bio || "");
       } catch (error) {
         console.error(error);
       }
@@ -40,6 +42,7 @@ export default function ProfileSettings() {
       setPersonalUsername(user.username);
       setPersonalEmail(user.email);
       setPersonalAvatar(user.avatar);
+      setPersonalBio(user.bio || "");
     }
 
     setPersonalTheme(user.theme || localStorage.getItem("theme") || "light");
@@ -99,6 +102,7 @@ export default function ProfileSettings() {
         notifyDesktop: desktopNotifications,
         notifySound: messageSounds,
         password: personalNewPassword || undefined,
+        bio: personalBio,
       });
       setPersonalNewPassword("");
       setPersonalConfirmPassword("");
@@ -130,6 +134,7 @@ export default function ProfileSettings() {
             <Input label={t("profile.username")} value={personalUsername} onChange={(event) => setPersonalUsername(event.target.value)} required />
             <Input label={t("profile.email")} type="email" value={personalEmail} onChange={(event) => setPersonalEmail(event.target.value)} required />
           </div>
+          <Input label="Bio" value={personalBio} onChange={(event) => setPersonalBio(event.target.value)} />
         </div>
 
         <SectionTitle title={t("profile.notifications")} />
@@ -175,6 +180,29 @@ export default function ProfileSettings() {
           </Button>
         </div>
       </form>
+
+      <div className="mt-12 max-w-4xl border border-red-500/20 rounded-lg p-6 bg-red-500/5">
+        <h3 className="text-lg font-semibold text-red-500 mb-2">Delete Account</h3>
+        <p className="text-sm text-foreground/70 mb-4">
+          Once you delete your account, there is no going back. Please be certain.
+        </p>
+        <Button
+          type="button"
+          variant="secondary"
+          className="bg-red-500/10 text-red-500 hover:bg-red-500 hover:text-white border-red-500/20 transition-colors"
+          onClick={async () => {
+            if (window.confirm("Are you sure you want to delete your account? This action cannot be undone.")) {
+              try {
+                await handleDeleteAccount();
+              } catch (err) {
+                setFeedback({ type: "error", text: "Failed to delete account." });
+              }
+            }
+          }}
+        >
+          Delete Account
+        </Button>
+      </div>
     </>
   );
 }

--- a/frontend/src/context/ChatContext.tsx
+++ b/frontend/src/context/ChatContext.tsx
@@ -28,6 +28,7 @@ import {
   deleteEmergencyContact,
   deleteFriend,
   deleteFolder as deleteFolderApi,
+  deleteMe as deleteMeApi,
   getBlockedUsers,
   getMe,
   joinRoomByCode,
@@ -202,6 +203,7 @@ interface PersonalSettingsInput {
   notifyDesktop: boolean;
   notifySound: boolean;
   password?: string;
+  bio?: string;
   warningEnabled?: boolean;
   warningDays?: number;
 }
@@ -251,6 +253,7 @@ interface ChatContextType {
   handleModifyNickname: (roomId: string, nickname: string) => void;
   handleLeaveOrBlock: (roomId: string) => Promise<{ isDeleted: boolean; newActiveId?: string }>;
   handleSavePersonalSettings: (settings: PersonalSettingsInput) => Promise<void>;
+  handleDeleteAccount: () => Promise<void>;
   loadGroupMembers: (roomId: string) => Promise<Member[]>;
   saveGroupSettings: (roomId: string, settings: GroupSettingsInput) => Promise<void>;
   approveGroupMember: (roomId: string, userId: string) => Promise<void>;
@@ -589,12 +592,8 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
       socialDataRefreshResolversRef.current = [resolveFn!];
     } else {
       let resolveFn: () => void;
-      const p = new Promise<void>((resolve) => { resolveFn = resolve; });
+      new Promise<void>((resolve) => { resolveFn = resolve; });
       socialDataRefreshResolversRef.current.push(resolveFn!);
-      // We still return the single promise that represents the batch,
-      // but wait, if we push a new resolver, we should make sure we return a promise 
-      // that resolves when THIS specific call resolves. 
-      // It's easier to just return the shared promise:
     }
     const currentPromise = socialDataRefreshPromiseRef.current;
 
@@ -802,9 +801,6 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
     };
   }, [token, currentUserId]);
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const roomById = useMemo(() => new Map(rooms.map((room) => [room.id, room])), [rooms]);
-
   const toggleFolder = (folderId: string) => {
     setFolders((current) =>
       current.map((folder) =>
@@ -970,7 +966,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
       username: settings.username,
       email: settings.email,
       avatar: settings.avatar,
-      bio: user.bio ?? "",
+      bio: settings.bio ?? user.bio ?? "",
       language: settings.language,
       theme: settings.theme === "dark" ? "dark" : "light",
       notifyDesktop: settings.notifyDesktop,
@@ -985,6 +981,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
           name: settings.username,
           email: settings.email,
           avatarUrl: settings.avatar,
+          bio: settings.bio,
           ...(settings.password ? { password: settings.password } : {}),
         }),
         updateMySettings(token, {
@@ -1012,6 +1009,12 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
       warningEnabled: nextUser.warningEnabled ?? false,
       warningDays: nextUser.warningDays ?? 0,
     }));
+  };
+
+  const handleDeleteAccount = async () => {
+    if (!token) throw new Error("Not authenticated");
+    await deleteMeApi(token);
+    handleLogout();
   };
 
   const loadGroupMembers = async (roomId: string): Promise<Member[]> => {
@@ -1359,6 +1362,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
         handleModifyNickname,
         handleLeaveOrBlock,
         handleSavePersonalSettings,
+        handleDeleteAccount,
         loadGroupMembers,
         saveGroupSettings,
         approveGroupMember,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -145,6 +145,9 @@ export const updateMe = (token: string, data: UpdateMeRequest): Promise<MyProfil
     { token },
   );
 
+export const deleteMe = (token: string): Promise<void> =>
+  requestJson<void>('/users/me', { method: 'DELETE' }, { token });
+
 export const getMySettings = (token: string): Promise<UserSettings> =>
   requestJson<UserSettings>('/users/me/settings', {}, { token });
 


### PR DESCRIPTION
Resolves #140

- Added a `bio` input field in the Profile Settings page.
- Added a `Delete Account` button with a confirmation prompt in a dangerous action section.
- Added `deleteMe` API call in `frontend/src/lib/api.ts` to map to `DELETE /users/me`.
- Implemented `handleDeleteAccount` context action in `ChatContext` to call the API and logout.