### PR TITLE
Fix: Issue #131 - Show outgoing friend requests

### DIFF
--- a/backend/src/repositories/friendRepository.ts
+++ b/backend/src/repositories/friendRepository.ts
@@ -42,10 +42,12 @@ export const makeFriendRepository = (db: Pool) => {
     async getPendingRequests(userId: string): Promise<FriendRequestResult[]> {
       const res = await db.query(
         `SELECT f.requester_id, f.addressee_id, f.status, f.created_at,
-                u.user_id, u.name, u.avatar_url
+                ur.user_id as req_user_id, ur.name as req_name, ur.avatar_url as req_avatar_url,
+                ua.user_id as add_user_id, ua.name as add_name, ua.avatar_url as add_avatar_url
          FROM friendships f
-         JOIN users u ON u.user_id = f.requester_id AND u.deleted_at IS NULL
-         WHERE f.addressee_id = $1 AND f.status = 'pending'`,
+         JOIN users ur ON ur.user_id = f.requester_id AND ur.deleted_at IS NULL
+         JOIN users ua ON ua.user_id = f.addressee_id AND ua.deleted_at IS NULL
+         WHERE (f.addressee_id = $1 OR f.requester_id = $1) AND f.status = 'pending'`,
         [userId]
       );
       return res.rows.map(row => ({
@@ -54,9 +56,14 @@ export const makeFriendRepository = (db: Pool) => {
         status: row.status,
         createdAt: row.created_at,
         requester: {
-          userId: row.user_id,
-          name: row.name,
-          avatarUrl: row.avatar_url ?? undefined
+          userId: row.req_user_id,
+          name: row.req_name,
+          avatarUrl: row.req_avatar_url ?? undefined
+        },
+        addressee: {
+          userId: row.add_user_id,
+          name: row.add_name,
+          avatarUrl: row.add_avatar_url ?? undefined
         }
       }));
     },

--- a/frontend/src/context/ChatContext.tsx
+++ b/frontend/src/context/ChatContext.tsx
@@ -405,11 +405,18 @@ const mapFriend = (item: FriendResponse, emergencyContactIds: Set<string>): Frie
   isEmergencyContact: emergencyContactIds.has(item.friend.userId),
 });
 
-const mapFriendRequest = (item: FriendRequestResponse): FriendRequest => {
-  const requester = item.requester;
+const mapFriendRequest = (item: FriendRequestResponse, currentUserId: string): FriendRequest => {
+  if (item.requesterId === currentUserId) {
+    return {
+      id: item.addresseeId,
+      name: item.addressee?.name ?? item.addresseeId,
+      email: "",
+      direction: "outgoing",
+    };
+  }
   return {
     id: item.requesterId,
-    name: requester?.name ?? item.requesterId,
+    name: item.requester?.name ?? item.requesterId,
     email: "",
     direction: "incoming",
   };
@@ -615,7 +622,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
         const emergencyContactIds = new Set(contacts.map((contact) => contact.contactId));
 
         setFriends(apiFriends.map((friend) => mapFriend(friend, emergencyContactIds)));
-        setFriendRequests(apiRequests.map(mapFriendRequest));
+        setFriendRequests(apiRequests.map(req => mapFriendRequest(req, currentUserId!)));
         setBlockedUsers(apiBlockedUsers.map(u => ({ id: u.userId, name: u.name, email: u.email })));
         setEmergencySettings(prev => ({
           warningEnabled: settings?.warningEnabled ?? user.warningEnabled ?? false,


### PR DESCRIPTION
Resolves #131

- Updated `getPendingRequests` in `friendRepository` to fetch both incoming and outgoing pending friend requests.
- Added `req_avatar_url` and `add_avatar_url` aliases and explicitly returned the `addressee` details.
- Fixed `mapFriendRequest` in `ChatContext` to accept `currentUserId` and correctly assign direction as `outgoing` when the request was made by the current user, pulling the target user's details from `addressee`.