### PR TITLE
fix(frontend): align personal settings page with backend contract

### DIFF
--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/src/components/settings/ProfileSettings.tsx
+++ b/frontend/src/components/settings/ProfileSettings.tsx
@@ -13,7 +13,7 @@ import { useTranslation } from "@/hooks/useTranslation";
 
 export default function ProfileSettings() {
   const router = useRouter();
-  const { user, rooms, uiLanguage, handleSavePersonalSettings, handleDeleteAccount, setUiLanguage } = useChat();
+  const { user, rooms, uiLanguage, handleUpdateProfile, handleUpdatePreferences, handleDeleteAccount, setUiLanguage } = useChat();
   const [personalUsername, setPersonalUsername] = useState("");
   const [personalEmail, setPersonalEmail] = useState("");
   const [personalAvatar, setPersonalAvatar] = useState("");
@@ -24,7 +24,8 @@ export default function ProfileSettings() {
   const [personalLanguage, setPersonalLanguage] = useState<UiLanguage>("zh-TW");
   const [personalNewPassword, setPersonalNewPassword] = useState("");
   const [personalConfirmPassword, setPersonalConfirmPassword] = useState("");
-  const [feedback, setFeedback] = useState<SettingsFeedback | null>(null);
+  const [profileFeedback, setProfileFeedback] = useState<SettingsFeedback | null>(null);
+  const [preferencesFeedback, setPreferencesFeedback] = useState<SettingsFeedback | null>(null);
 
   useEffect(() => {
     const savedUser = localStorage.getItem("user");
@@ -80,47 +81,63 @@ export default function ProfileSettings() {
 
   const handleProfileSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
-    setFeedback(null);
+    setProfileFeedback(null);
 
     if (personalNewPassword && personalNewPassword.length < 8) {
-      setFeedback({ type: "error", text: t("profile.passwordTooShort") });
+      setProfileFeedback({ type: "error", text: t("profile.passwordTooShort") });
       return;
     }
 
     if (personalNewPassword !== personalConfirmPassword) {
-      setFeedback({ type: "error", text: t("profile.passwordMismatch") });
+      setProfileFeedback({ type: "error", text: t("profile.passwordMismatch") });
       return;
     }
 
     try {
-      await handleSavePersonalSettings({
+      await handleUpdateProfile({
         username: personalUsername,
         email: personalEmail,
         avatar: personalAvatar,
-        theme: personalTheme,
-        language: personalLanguage,
-        notifyDesktop: desktopNotifications,
-        notifySound: messageSounds,
         password: personalNewPassword || undefined,
         bio: personalBio,
       });
       setPersonalNewPassword("");
       setPersonalConfirmPassword("");
-      setFeedback({ type: "success", text: t("profile.profileSaved") });
+      setProfileFeedback({ type: "success", text: t("profile.profileSaved") });
     } catch (error) {
       console.error(error);
-      setFeedback({
+      setProfileFeedback({
         type: "error",
         text: error instanceof Error ? error.message : "Failed to save profile.",
       });
     }
   };
 
+  const handlePreferencesSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setPreferencesFeedback(null);
+
+    try {
+      await handleUpdatePreferences({
+        theme: personalTheme,
+        language: personalLanguage,
+        notifyDesktop: desktopNotifications,
+        notifySound: messageSounds,
+      });
+      setPreferencesFeedback({ type: "success", text: "Preferences saved successfully" });
+    } catch (error) {
+      console.error(error);
+      setPreferencesFeedback({
+        type: "error",
+        text: error instanceof Error ? error.message : "Failed to save preferences.",
+      });
+    }
+  };
+
   return (
     <>
-      <FeedbackMessage feedback={feedback} />
-
       <form onSubmit={handleProfileSubmit} className="flex flex-col gap-6 max-w-4xl">
+        <FeedbackMessage feedback={profileFeedback} />
         <SectionTitle title={t("profile.profile")} />
         <div className="flex items-center gap-6 py-2">
           <Avatar name={personalUsername} src={personalAvatar} size="lg" />
@@ -137,6 +154,24 @@ export default function ProfileSettings() {
           <Input label="Bio" value={personalBio} onChange={(event) => setPersonalBio(event.target.value)} />
         </div>
 
+        <SectionTitle title={t("profile.security")} />
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <Input label={t("profile.newPassword")} type="password" value={personalNewPassword} onChange={(event) => setPersonalNewPassword(event.target.value)} />
+          <Input label={t("profile.confirmPassword")} type="password" value={personalConfirmPassword} onChange={(event) => setPersonalConfirmPassword(event.target.value)} />
+        </div>
+
+        <div className="border-t border-border-primary pt-6 flex items-center justify-end gap-3">
+          <Button type="button" variant="secondary" onClick={handleBack}>
+            {t("profile.cancel")}
+          </Button>
+          <Button type="submit" variant="primary">
+            {t("profile.saveProfile")}
+          </Button>
+        </div>
+      </form>
+
+      <form onSubmit={handlePreferencesSubmit} className="flex flex-col gap-6 max-w-4xl mt-12">
+        <FeedbackMessage feedback={preferencesFeedback} />
         <SectionTitle title={t("profile.notifications")} />
         <div className="flex flex-col gap-3">
           <Checkbox label={t("profile.desktopNotifications")} checked={desktopNotifications} onChange={(event) => setDesktopNotifications(event.target.checked)} />
@@ -165,18 +200,12 @@ export default function ProfileSettings() {
           <option value="en">English</option>
         </select>
 
-        <SectionTitle title={t("profile.security")} />
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <Input label={t("profile.newPassword")} type="password" value={personalNewPassword} onChange={(event) => setPersonalNewPassword(event.target.value)} />
-          <Input label={t("profile.confirmPassword")} type="password" value={personalConfirmPassword} onChange={(event) => setPersonalConfirmPassword(event.target.value)} />
-        </div>
-
         <div className="border-t border-border-primary pt-6 flex items-center justify-end gap-3">
           <Button type="button" variant="secondary" onClick={handleBack}>
             {t("profile.cancel")}
           </Button>
           <Button type="submit" variant="primary">
-            {t("profile.saveProfile")}
+            Save Preferences
           </Button>
         </div>
       </form>
@@ -195,7 +224,7 @@ export default function ProfileSettings() {
               try {
                 await handleDeleteAccount();
               } catch (err) {
-                setFeedback({ type: "error", text: "Failed to delete account." });
+                setProfileFeedback({ type: "error", text: "Failed to delete account." });
               }
             }
           }}

--- a/frontend/src/context/ChatContext.tsx
+++ b/frontend/src/context/ChatContext.tsx
@@ -194,16 +194,19 @@ export const getAvatarForUser = (
   return "";
 };
 
-interface PersonalSettingsInput {
+export interface ProfileInput {
   username: string;
   email: string;
   avatar: string;
+  password?: string;
+  bio?: string;
+}
+
+export interface PreferencesInput {
   theme: string;
   language: UiLanguage;
   notifyDesktop: boolean;
   notifySound: boolean;
-  password?: string;
-  bio?: string;
   warningEnabled?: boolean;
   warningDays?: number;
 }
@@ -245,6 +248,8 @@ interface ChatContextType {
   handleTyping: (roomId: string, isTyping: boolean) => void;
   handleUploadAttachment: (roomId: string, file: File) => Promise<void>;
   handleRecallMessage: (msgId: string) => void;
+  handleUpdateProfile: (profile: ProfileInput) => Promise<void>;
+  handleUpdatePreferences: (preferences: PreferencesInput) => Promise<void>;
   handleCreateRoom: (name: string, type: "msg" | "group", folderId: string) => Promise<string>;
   handleOpenPrivateRoom: (targetUserId: string) => Promise<string>;
   handleCreateFolder: (name: string) => Promise<void>;
@@ -252,7 +257,6 @@ interface ChatContextType {
   handleCategorizeRoom: (roomId: string, folderId: string | null) => Promise<void>;
   handleModifyNickname: (roomId: string, nickname: string) => void;
   handleLeaveOrBlock: (roomId: string) => Promise<{ isDeleted: boolean; newActiveId?: string }>;
-  handleSavePersonalSettings: (settings: PersonalSettingsInput) => Promise<void>;
   handleDeleteAccount: () => Promise<void>;
   loadGroupMembers: (roomId: string) => Promise<Member[]>;
   saveGroupSettings: (roomId: string, settings: GroupSettingsInput) => Promise<void>;
@@ -855,6 +859,86 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
     recallMessage(socketRef.current, msgId);
   };
 
+  const handleUpdateProfile = async (profile: ProfileInput) => {
+    let nextUser: StoredUser = {
+      ...user,
+      username: profile.username,
+      email: profile.email,
+      avatar: profile.avatar,
+      bio: profile.bio ?? user.bio ?? "",
+    };
+
+    if (token) {
+      const updatedProfile = await updateMe(token, {
+        name: profile.username,
+        email: profile.email,
+        avatarUrl: profile.avatar,
+        bio: profile.bio,
+        ...(profile.password ? { password: profile.password } : {}),
+      });
+      nextUser = { ...nextUser, ...toStoredUser(updatedProfile, {
+        language: user.language ?? uiLanguage,
+        theme: user.theme ?? "light",
+        notifyDesktop: user.notifyDesktop ?? true,
+        notifySound: user.notifySound ?? true,
+        warningEnabled: user.warningEnabled ?? false,
+        warningDays: user.warningDays ?? 14,
+      }) };
+    }
+
+    localStorage.setItem("user", JSON.stringify(nextUser));
+    setUser(nextUser);
+  };
+
+  const handleUpdatePreferences = async (preferences: PreferencesInput) => {
+    const nextWarningEnabled = preferences.warningEnabled ?? user.warningEnabled ?? false;
+    const nextWarningDays = preferences.warningDays ?? user.warningDays ?? 0;
+    
+    let nextUser: StoredUser = {
+      ...user,
+      language: preferences.language,
+      theme: preferences.theme === "dark" ? "dark" : "light",
+      notifyDesktop: preferences.notifyDesktop,
+      notifySound: preferences.notifySound,
+      warningEnabled: nextWarningEnabled,
+      warningDays: nextWarningDays,
+    };
+
+    if (token) {
+      const updatedSettings = await updateMySettings(token, {
+        language: preferences.language,
+        theme: preferences.theme === "dark" ? "dark" : "light",
+        notifyDesktop: preferences.notifyDesktop,
+        notifySound: preferences.notifySound,
+        ...(preferences.warningEnabled !== undefined ? { warningEnabled: nextWarningEnabled } : {}),
+        ...(preferences.warningDays !== undefined ? { warningDays: nextWarningDays } : {}),
+      });
+      nextUser = { 
+        ...nextUser, 
+        language: updatedSettings.language as UiLanguage, 
+        theme: updatedSettings.theme as "light" | "dark", 
+        notifyDesktop: updatedSettings.notifyDesktop, 
+        notifySound: updatedSettings.notifySound, 
+        warningEnabled: updatedSettings.warningEnabled, 
+        warningDays: updatedSettings.warningDays 
+      };
+    }
+
+    localStorage.setItem("user", JSON.stringify(nextUser));
+    localStorage.setItem("theme", preferences.theme);
+    localStorage.setItem("language", preferences.language);
+    localStorage.setItem("notify-desktop", String(preferences.notifyDesktop));
+    localStorage.setItem("notify-sound", String(preferences.notifySound));
+    document.documentElement.classList.toggle("dark", preferences.theme === "dark");
+    setUser(nextUser);
+    setUiLanguageState(preferences.language);
+    setEmergencySettings((current) => ({
+      ...current,
+      warningEnabled: nextWarningEnabled,
+      warningDays: nextWarningDays,
+    }));
+  };
+
   const handleCreateRoom = async (name: string, type: "msg" | "group", folderId: string) => {
     if (!token) return "";
 
@@ -963,59 +1047,6 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
       ),
     );
     return { isDeleted: false };
-  };
-
-  const handleSavePersonalSettings = async (settings: PersonalSettingsInput) => {
-    const nextWarningEnabled = settings.warningEnabled ?? user.warningEnabled ?? false;
-    const nextWarningDays = settings.warningDays ?? user.warningDays ?? 0;
-    let nextUser: StoredUser = {
-      userId: currentUserId,
-      username: settings.username,
-      email: settings.email,
-      avatar: settings.avatar,
-      bio: settings.bio ?? user.bio ?? "",
-      language: settings.language,
-      theme: settings.theme === "dark" ? "dark" : "light",
-      notifyDesktop: settings.notifyDesktop,
-      notifySound: settings.notifySound,
-      warningEnabled: nextWarningEnabled,
-      warningDays: nextWarningDays,
-    };
-
-    if (token) {
-      const [updatedProfile, updatedSettings] = await Promise.all([
-        updateMe(token, {
-          name: settings.username,
-          email: settings.email,
-          avatarUrl: settings.avatar,
-          bio: settings.bio,
-          ...(settings.password ? { password: settings.password } : {}),
-        }),
-        updateMySettings(token, {
-          language: settings.language,
-          theme: settings.theme === "dark" ? "dark" : "light",
-          notifyDesktop: settings.notifyDesktop,
-          notifySound: settings.notifySound,
-          ...(settings.warningEnabled !== undefined ? { warningEnabled: nextWarningEnabled } : {}),
-          ...(settings.warningDays !== undefined ? { warningDays: nextWarningDays } : {}),
-        }),
-      ]);
-      nextUser = toStoredUser(updatedProfile, updatedSettings);
-    }
-
-    localStorage.setItem("user", JSON.stringify(nextUser));
-    localStorage.setItem("theme", settings.theme);
-    localStorage.setItem("language", settings.language);
-    localStorage.setItem("notify-desktop", String(settings.notifyDesktop));
-    localStorage.setItem("notify-sound", String(settings.notifySound));
-    document.documentElement.classList.toggle("dark", settings.theme === "dark");
-    setUser(nextUser);
-    setUiLanguageState(settings.language);
-    setEmergencySettings((current) => ({
-      ...current,
-      warningEnabled: nextUser.warningEnabled ?? false,
-      warningDays: nextUser.warningDays ?? 0,
-    }));
   };
 
   const handleDeleteAccount = async () => {
@@ -1361,6 +1392,8 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
         handleTyping,
         handleUploadAttachment,
         handleRecallMessage,
+        handleUpdateProfile,
+        handleUpdatePreferences,
         handleCreateRoom,
         handleOpenPrivateRoom,
         handleCreateFolder,
@@ -1368,7 +1401,6 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
         handleCategorizeRoom,
         handleModifyNickname,
         handleLeaveOrBlock,
-        handleSavePersonalSettings,
         handleDeleteAccount,
         loadGroupMembers,
         saveGroupSettings,


### PR DESCRIPTION
Resolves #97. Split profile updates and preferences settings into separate API calls and forms to align with the backend contract. Also supports password editing now.