### PR TITLE
fix: change emergency alert to send real chat message

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -68,9 +68,23 @@ const folderRepo = new FolderRepository(pool);
 const attachmentRepo = new AttachmentRepository(pool);
 const friendRepo = makeFriendRepository(pool);
 
-const userService = makeUserService(userRepo, emergencyContactRepo, { signToken }, (contactId, payload) =>
-  io.to(`user_${contactId}`).emit('emergency_alert', payload),
-);
+const userService = makeUserService(userRepo, emergencyContactRepo, { signToken }, async (contactId, payload) => {
+  // Send a real chat message
+  const room = await roomRepo.findPrivateRoomByMembers(payload.userId, contactId);
+  if (room) {
+    try {
+      const message = await messageService.sendMessage(payload.userId, room.roomId, payload.message);
+      io.to(`room_${room.roomId}`).emit('new_message', message);
+    } catch (err) {
+      console.error('Failed to auto-send emergency message:', err);
+      // Fallback to basic socket alert if messaging fails
+      io.to(`user_${contactId}`).emit('emergency_alert', payload);
+    }
+  } else {
+    // Fallback to basic socket alert if they have no private room
+    io.to(`user_${contactId}`).emit('emergency_alert', payload);
+  }
+});
 const roomService = makeRoomService(roomRepo, roomMemberRepo, (roomId, eventName, payload) =>
   io.to(`room_${roomId}`).emit(eventName as any, payload),
   friendRepo,

--- a/backend/src/services/userService.ts
+++ b/backend/src/services/userService.ts
@@ -66,9 +66,9 @@ export const makeUserService = (
   repo: IUserRepository,
   emergencyContactRepo: IEmergencyContactRepository,
   jwt: JwtHelper,
-  notifyEmergencyContact?: (contactId: string, payload: { userId: string; message: string }) => void,
+  notifyEmergencyContact?: (contactId: string, payload: { userId: string; message: string }) => void | Promise<void>,
 ) => {
-  const notifyContacts = async (userId: string, fallbackMessage: string): Promise<EmergencyAlertResult> => {
+  const notifyContacts = async (userId: string, fallbackMessage: string, isTest: boolean = false): Promise<EmergencyAlertResult> => {
     const user = await repo.findById(userId);
     if (!user) throw new NotFoundError('user', userId);
 
@@ -79,10 +79,13 @@ export const makeUserService = (
 
     const recipients: string[] = [];
     for (const contact of contacts) {
-      notifyEmergencyContact?.(contact.contactId, {
-        userId,
-        message: contact.message || fallbackMessage,
-      });
+      const msg = (isTest ? '(測試) ' : '') + (contact.message || fallbackMessage);
+      if (notifyEmergencyContact) {
+        await notifyEmergencyContact(contact.contactId, {
+          userId,
+          message: msg,
+        });
+      }
       recipients.push(contact.contactId);
     }
 
@@ -229,7 +232,7 @@ export const makeUserService = (
     },
 
     async triggerEmergencyAlert(userId: string, message = 'Emergency alert triggered'): Promise<EmergencyAlertResult> {
-      return notifyContacts(userId, message);
+      return notifyContacts(userId, message, true);
     },
 
     async checkInactivity(userId: string, now = new Date()): Promise<EmergencyAlertResult> {

--- a/backend/tests/e2e/socket/emergencyAlert.e2e.test.ts
+++ b/backend/tests/e2e/socket/emergencyAlert.e2e.test.ts
@@ -4,7 +4,7 @@ import { io as createClient, type Socket as ClientSocket } from 'socket.io-clien
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { app, server } from '../../../src/index';
 import { resetDb } from '../../helpers/resetDb';
-import type { ClientToServerEvents, ServerToClientEvents } from '../../../../shared/types';
+import type { ClientToServerEvents, ServerToClientEvents, Room, Message } from '../../../../shared/types';
 
 type TestClient = ClientSocket<ServerToClientEvents, ClientToServerEvents>;
 
@@ -51,7 +51,7 @@ describe('Emergency alert Socket.IO E2E', () => {
       socket.once('connect_error', reject);
     });
 
-  it('emits emergency_alert to configured emergency contacts', async () => {
+  it('sends real chat message to configured emergency contacts (private room)', async () => {
     const userRes = await request(app).post('/api/v1/auth/register').send({
       name: 'Alert User',
       email: 'alert-user@example.com',
@@ -63,6 +63,24 @@ describe('Emergency alert Socket.IO E2E', () => {
       password: 'Password123!',
     });
 
+    // Become friends
+    await request(app).post('/api/v1/friend-requests').set('Authorization', `Bearer ${userRes.body.token}`).send({
+      target_user_id: contactRes.body.user.userId,
+    });
+    await request(app).patch(`/api/v1/friend-requests/${userRes.body.user.userId}`).set('Authorization', `Bearer ${contactRes.body.token}`).send({
+      status: 'accepted',
+    });
+
+    // explicitly create private room
+    const roomRes = await request(app)
+      .post('/api/v1/rooms')
+      .set('Authorization', `Bearer ${userRes.body.token}`)
+      .send({ type: 'private', targetUserId: contactRes.body.user.userId });
+    
+    expect(roomRes.status).to.be.oneOf([200, 201]);
+    const privateRoomId = roomRes.body.roomId;
+
+    // Set up emergency contact
     await request(app)
       .post('/api/v1/users/me/emergency-contacts')
       .set('Authorization', `Bearer ${userRes.body.token}`)
@@ -72,9 +90,14 @@ describe('Emergency alert Socket.IO E2E', () => {
       });
 
     const contactSocket = await connectClient(contactRes.body.token);
-    const alertPayload = waitFor<Parameters<ServerToClientEvents['emergency_alert']>[0]>(
+    
+    // Have the contact socket join the room to receive new_message event
+    contactSocket.emit('join_room', { roomId: privateRoomId });
+    await new Promise((res) => setTimeout(res, 100));
+    
+    const messagePayload = waitFor<Message>(
       contactSocket,
-      'emergency_alert',
+      'new_message',
     );
 
     const triggerRes = await request(app)
@@ -83,9 +106,10 @@ describe('Emergency alert Socket.IO E2E', () => {
       .send();
 
     expect(triggerRes.status).toBe(202);
-    await expect(alertPayload).resolves.toEqual({
-      userId: userRes.body.user.userId,
-      message: 'Please check on me',
-    });
+    
+    const received = await messagePayload;
+    expect(received.content).toBe('(測試) Please check on me');
+    expect(received.senderId).toBe(userRes.body.user.userId);
+    expect(received.roomId).toBe(privateRoomId);
   });
 });

--- a/backend/tests/unit/services/userService.test.ts
+++ b/backend/tests/unit/services/userService.test.ts
@@ -334,7 +334,7 @@ describe('userService', () => {
       expect(result).toEqual({ alerted: true, recipients: ['u2'] });
       expect(notifyEmergencyContact).toHaveBeenCalledWith('u2', {
         userId: 'u1',
-        message: 'please check on me',
+        message: '(測試) please check on me',
       });
     });
 


### PR DESCRIPTION
Change the emergency alert implementation to send an actual chat message into the private room with the emergency contact, instead of emitting a bare socket alert event.