### PR TITLE
fix(friend): auto-create private room when friend request accepted

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -97,6 +97,7 @@ const friendService = makeFriendService(friendRepo, (userId, eventName, payload)
   io.to(`user_${userId}`).emit(eventName as any, payload);
 }, {
   markPrivateReadOnly: roomService.markPrivateReadOnly,
+  createPrivate: (userA: string, userB: string) => roomService.createPrivate(userA, userB),
   reopenPrivateRoom: roomService.reopenPrivateRoom,
 });
 const friendController = makeFriendController(friendService);

--- a/backend/src/services/friendService.ts
+++ b/backend/src/services/friendService.ts
@@ -6,6 +6,7 @@ export function makeFriendService(
   notifyUser?: (userId: string, eventName: string, payload: any) => void,
   privateRooms?: {
     markPrivateReadOnly(userA: string, userB: string): Promise<void>;
+    createPrivate?(userA: string, userB: string): Promise<unknown>;
     reopenPrivateRoom?(userA: string, userB: string): Promise<void>;
   }
 ) {
@@ -32,7 +33,11 @@ export function makeFriendService(
         if (notifyUser) {
           notifyUser(targetUserId, 'friend_request', accepted);
         }
-        await privateRooms?.reopenPrivateRoom?.(requesterId, targetUserId);
+        if (privateRooms?.createPrivate) {
+          await privateRooms.createPrivate(requesterId, targetUserId);
+        } else {
+          await privateRooms?.reopenPrivateRoom?.(requesterId, targetUserId);
+        }
         return accepted;
       }
 
@@ -58,7 +63,11 @@ export function makeFriendService(
         if (!accepted) {
           throw new AppError(404, 'Friend request not found', 'NOT_FOUND');
         }
-        await privateRooms?.reopenPrivateRoom?.(requesterId, userId);
+        if (privateRooms?.createPrivate) {
+          await privateRooms.createPrivate(requesterId, userId);
+        } else {
+          await privateRooms?.reopenPrivateRoom?.(requesterId, userId);
+        }
         return accepted;
       } else {
         const rejected = await repo.rejectFriendRequest(requesterId, userId);

--- a/backend/tests/e2e/routes/friend.e2e.test.ts
+++ b/backend/tests/e2e/routes/friend.e2e.test.ts
@@ -104,14 +104,15 @@ describe('Friendships & Blocks E2E', () => {
       expect(listRes.body.length).toBe(1);
       expect(listRes.body[0].friend.userId).toBe(userA.userId);
 
+      // accepting the request now auto-creates the private room
       const roomsBeforeOpen = await request(app).get('/api/v1/rooms').set('Authorization', `Bearer ${tokenA}`);
-      expect(roomsBeforeOpen.body.some((room: { type: string }) => room.type === 'private')).toBe(false);
+      expect(roomsBeforeOpen.body.some((room: { type: string }) => room.type === 'private')).toBe(true);
 
       const openRoom = await request(app)
         .post('/api/v1/rooms')
         .set('Authorization', `Bearer ${tokenA}`)
         .send({ type: 'private', targetUserId: userB.userId });
-      expect(openRoom.status).toBe(201);
+      expect(openRoom.status).toBe(200); // room already exists, returns existing
 
       const roomsB = await request(app).get('/api/v1/rooms').set('Authorization', `Bearer ${tokenB}`);
       const privateRoomB = roomsB.body.find((room: { type: string }) => room.type === 'private');
@@ -132,7 +133,7 @@ describe('Friendships & Blocks E2E', () => {
         .post('/api/v1/rooms')
         .set('Authorization', `Bearer ${tokenA}`)
         .send({ type: 'private', targetUserId: userB.userId });
-      expect(privateRoom.status).toBe(201);
+      expect(privateRoom.status).toBe(200); // auto-created on accept, returns existing
 
       const deleteRes = await request(app)
         .delete(`/api/v1/friends/${userB.userId}`)
@@ -221,7 +222,7 @@ describe('Friendships & Blocks E2E', () => {
         .post('/api/v1/rooms')
         .set('Authorization', `Bearer ${tokenA}`)
         .send({ type: 'private', targetUserId: userB.userId });
-      expect(privateRoom.status).toBe(201);
+      expect(privateRoom.status).toBe(200); // auto-created on accept, returns existing
 
       const blockRes = await request(app)
         .post('/api/v1/blocks')

--- a/backend/tests/e2e/routes/room.e2e.test.ts
+++ b/backend/tests/e2e/routes/room.e2e.test.ts
@@ -122,7 +122,7 @@ describe('Room E2E', () => {
       .set('Authorization', `Bearer ${token}`)
       .send({ type: 'private', target_user_id: otherUserId });
 
-    expect(first.status).toBe(201);
+    expect(first.status).toBe(200); // auto-created when friends accepted, returns existing
     expect(first.body.type).toBe('private');
     expect(first.body.roomHash).toBeUndefined();
     expect(second.status).toBe(200);


### PR DESCRIPTION
## Summary

- Added `createPrivate` to the `privateRooms` interface in `friendService.ts`
- Replaced both `reopenPrivateRoom` call sites with logic that calls `createPrivate` (find-or-create + un-readonly) when available, falling back to `reopenPrivateRoom` otherwise
- Wired `roomService.createPrivate` into the `privateRooms` object passed to `makeFriendService` in `index.ts`

Closes #180

## Test plan

- [ ] Accept a friend request between two users who have never had a private room — verify a private chat room is created
- [ ] Accept a friend request between two users who previously had a private room (e.g. were friends, unfriended, re-friended) — verify the existing room is re-opened (not a duplicate)
- [ ] Verify the reciprocal-accept path (user A sends request, user B sends request back, triggering auto-accept) also creates the private room
- [ ] Verify `pnpm run build` inside the backend container produces no TypeScript errors