### PR TITLE
fix(chat): render typing indicator when members are typing

### DIFF
--- a/frontend/src/components/chat/Chatroom.tsx
+++ b/frontend/src/components/chat/Chatroom.tsx
@@ -56,6 +56,7 @@ export default function Chatroom({ roomId, onOpenGroupSettings }: ChatroomProps)
     getReadAvatarsForMessage,
     showRightPanel,
     setShowRightPanel,
+    typingUsers,
   } = useChat();
 
   const [inputText, setInputText] = useState("");
@@ -378,6 +379,19 @@ export default function Chatroom({ roomId, onOpenGroupSettings }: ChatroomProps)
           </button>
         </div>
       )}
+
+      {(() => {
+        const names = typingUsers[activeRoom.id] ?? [];
+        if (names.length === 0) return null;
+        const label = names.length === 1
+          ? `${names[0]} is typing...`
+          : `${names.slice(0, 2).join(', ')} are typing...`;
+        return (
+          <div className="px-6 py-1 text-xs text-text-muted italic select-none">
+            {label}
+          </div>
+        );
+      })()}
 
       {/* Input Box Area */}
       <div className="border-t border-border-primary bg-surface-card px-6 py-4 shrink-0">

--- a/frontend/src/context/ChatContext.tsx
+++ b/frontend/src/context/ChatContext.tsx
@@ -224,6 +224,7 @@ interface ChatContextType {
   rooms: ChatRoom[];
   folders: Folder[];
   messages: Message[];
+  typingUsers: Record<string, string[]>;
   groupReadStates: Record<string, Record<string, string>>;
   user: User;
   activeRoomNicknames: Record<string, string>;
@@ -580,6 +581,8 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
   });
   const [selectedFriendForSidebar, setSelectedFriendForSidebar] = useState<Friend | null>(null);
   const [showRightPanel, setShowRightPanel] = useState<boolean>(true);
+  const [typingUsers, setTypingUsers] = useState<Record<string, string[]>>({});
+  const typingTimersRef = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
 
   const activeRoomId = useMemo(() => {
     const match = pathname.match(/^\/chat\/([^/]+)$/);
@@ -824,7 +827,31 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
       );
     });
     const cleanupTyping = onUserTyping(socket, ({ roomId, userId, isTyping }) => {
-      console.debug("typing", { roomId, userId, isTyping });
+      const typingRoom = roomsRef.current.find(r => r.id === roomId);
+      const typingMember = typingRoom?.members?.find(m => m.userId === userId);
+      const displayName = typingMember?.nickname ?? typingMember?.name ?? userId;
+      const timerKey = `${roomId}:${userId}`;
+      if (typingTimersRef.current[timerKey]) {
+        clearTimeout(typingTimersRef.current[timerKey]);
+      }
+      if (isTyping) {
+        setTypingUsers(prev => {
+          const current = prev[roomId] ?? [];
+          if (current.includes(displayName)) return prev;
+          return { ...prev, [roomId]: [...current, displayName] };
+        });
+        typingTimersRef.current[timerKey] = setTimeout(() => {
+          setTypingUsers(prev => ({
+            ...prev,
+            [roomId]: (prev[roomId] ?? []).filter(n => n !== displayName),
+          }));
+        }, 3000);
+      } else {
+        setTypingUsers(prev => ({
+          ...prev,
+          [roomId]: (prev[roomId] ?? []).filter(n => n !== displayName),
+        }));
+      }
     });
     const cleanupError = onSocketError(socket, (error) => {
       console.error("Socket error", error);
@@ -1517,6 +1544,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
         saveEmergencySettings,
         triggerEmergencyAlertNow,
         setUiLanguage,
+        typingUsers,
       }}
     >
       {children}


### PR DESCRIPTION
## Summary
- Add `typingUsers: Record<string, string[]>` state to `ChatContext`
- Replace `console.debug`-only `onUserTyping` handler with one that updates state, with a 3-second auto-clear debounce
- Display `"X is typing..."` above the message input box in `Chatroom.tsx`

## Test plan
- [ ] Open two browser windows logged in as different users in the same group
- [ ] Type in one window — the other should show "X is typing..."
- [ ] Stop typing — indicator disappears after 3 seconds

Closes #181