### PR TITLE
Fix/profile info card 198 and some imporvement

### DIFF
--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/src/components/chat/Chatroom.tsx
+++ b/frontend/src/components/chat/Chatroom.tsx
@@ -65,6 +65,8 @@ export default function Chatroom({ roomId, onOpenGroupSettings }: ChatroomProps)
     showRightPanel,
     setShowRightPanel,
     typingUsers,
+    activeProfilePopover,
+    setActiveProfilePopover,
   } = useChat();
 
   const [inputText, setInputText] = useState("");
@@ -102,6 +104,14 @@ export default function Chatroom({ roomId, onOpenGroupSettings }: ChatroomProps)
     setPrevMentionResetKey(mentionResetKey);
     setSelectedMentionIndex(0);
   }
+
+  // Sync showHeaderPopover with activeProfilePopover
+  useEffect(() => {
+    const isHeaderActive = activeProfilePopover?.instanceId === `header-${activeRoom?.id}`;
+    if (!isHeaderActive && showHeaderPopover) {
+      setShowHeaderPopover(false);
+    }
+  }, [activeProfilePopover, activeRoom?.id, showHeaderPopover]);
 
   // Scroll to bottom when room or messages change
   const lastScrolledRoomIdRef = useRef<string | null>(null);
@@ -264,7 +274,16 @@ export default function Chatroom({ roomId, onOpenGroupSettings }: ChatroomProps)
           }`}
           onClick={() => {
             if (activeRoom.type === "msg") {
-              setShowHeaderPopover(!showHeaderPopover);
+              const instanceId = `header-${activeRoom.id}`;
+              if (activeProfilePopover?.instanceId === instanceId) {
+                setActiveProfilePopover(null);
+              } else {
+                const otherMember = activeRoom.members?.find((m) => m.userId !== user.userId);
+                if (otherMember) {
+                  setShowHeaderPopover(true);
+                  setActiveProfilePopover({ instanceId, userId: otherMember.userId });
+                }
+              }
             }
           }}
         >
@@ -296,7 +315,7 @@ export default function Chatroom({ roomId, onOpenGroupSettings }: ChatroomProps)
                 username={activeRoom.name}
                 onClose={(e) => {
                   e.stopPropagation();
-                  setShowHeaderPopover(false);
+                  setActiveProfilePopover(null);
                 }}
                 position="bottom"
               />
@@ -381,6 +400,7 @@ export default function Chatroom({ roomId, onOpenGroupSettings }: ChatroomProps)
                   readByAvatars={getReadAvatarsForMessage(activeRoom, msg)}
                   roomType={activeRoom.type}
                   senderId={msg.senderId || undefined}
+                  messageId={msg.id}
                   onReply={() => setReplyTarget(msg)}
                   onRecall={() => handleRecallMessage(msg.id)}
                   canRecall={Boolean(msg.isOutgoing) || canManageMembers}

--- a/frontend/src/components/chat/Chatroom.tsx
+++ b/frontend/src/components/chat/Chatroom.tsx
@@ -73,7 +73,6 @@ export default function Chatroom({ roomId, onOpenGroupSettings }: ChatroomProps)
   const [mentionDraft, setMentionDraft] = useState<MentionDraft | null>(null);
   const [selectedMentionIndex, setSelectedMentionIndex] = useState(0);
   const [replyTarget, setReplyTarget] = useState<Message | null>(null);
-  const [showHeaderPopover, setShowHeaderPopover] = useState(false);
   const [isModifyNickOpen, setIsModifyNickOpen] = useState(false);
   const [nickInputValue, setNickInputValue] = useState("");
   const [pendingAttachment, setPendingAttachment] = useState<File | null>(null);
@@ -104,14 +103,6 @@ export default function Chatroom({ roomId, onOpenGroupSettings }: ChatroomProps)
     setPrevMentionResetKey(mentionResetKey);
     setSelectedMentionIndex(0);
   }
-
-  // Sync showHeaderPopover with activeProfilePopover
-  useEffect(() => {
-    const isHeaderActive = activeProfilePopover?.instanceId === `header-${activeRoom?.id}`;
-    if (!isHeaderActive && showHeaderPopover) {
-      setShowHeaderPopover(false);
-    }
-  }, [activeProfilePopover, activeRoom?.id, showHeaderPopover]);
 
   // Scroll to bottom when room or messages change
   const lastScrolledRoomIdRef = useRef<string | null>(null);
@@ -268,25 +259,7 @@ export default function Chatroom({ roomId, onOpenGroupSettings }: ChatroomProps)
   return (
     <div className="flex-1 flex flex-col bg-background h-full overflow-hidden">
       <div className="h-14 border-b border-border-primary px-6 flex items-center justify-between select-none shrink-0 bg-surface-card z-10">
-        <div
-          className={`flex items-center gap-3 relative avatar-click-target ${
-            activeRoom.type === "msg" ? "cursor-pointer hover:opacity-85 transition-opacity" : ""
-          }`}
-          onClick={() => {
-            if (activeRoom.type === "msg") {
-              const instanceId = `header-${activeRoom.id}`;
-              if (activeProfilePopover?.instanceId === instanceId) {
-                setActiveProfilePopover(null);
-              } else {
-                const otherMember = activeRoom.members?.find((m) => m.userId !== user.userId);
-                if (otherMember) {
-                  setShowHeaderPopover(true);
-                  setActiveProfilePopover({ instanceId, userId: otherMember.userId });
-                }
-              }
-            }
-          }}
-        >
+        <div className="flex items-center gap-3 relative">
           <Avatar
             name={activeRoom.name}
             src={getAvatarForUser(activeRoom.name, user.avatar, user.username)}
@@ -306,21 +279,6 @@ export default function Chatroom({ roomId, onOpenGroupSettings }: ChatroomProps)
               </span>
             )}
           </div>
-
-          {showHeaderPopover && activeRoom.type === "msg" && (() => {
-            const otherMember = activeRoom.members?.find((m) => m.userId !== user.userId);
-            return (
-              <ProfilePopover
-                userId={otherMember?.userId || ""}
-                username={activeRoom.name}
-                onClose={(e) => {
-                  e.stopPropagation();
-                  setActiveProfilePopover(null);
-                }}
-                position="bottom"
-              />
-            );
-          })()}
         </div>
 
         <div className="flex items-center gap-3">

--- a/frontend/src/components/chat/Chatroom.tsx
+++ b/frontend/src/components/chat/Chatroom.tsx
@@ -378,6 +378,11 @@ export default function Chatroom({ roomId, onOpenGroupSettings }: ChatroomProps)
                   onReply={() => setReplyTarget(msg)}
                   onRecall={() => handleRecallMessage(msg.id)}
                   canRecall={Boolean(msg.isOutgoing) || canManageMembers}
+                  avatarName={
+                    msg.isOutgoing
+                      ? user.username
+                      : senderMember?.name || msg.senderName
+                  }
                 />
 
                 {!msg.isRecalled && (

--- a/frontend/src/components/chat/Chatroom.tsx
+++ b/frontend/src/components/chat/Chatroom.tsx
@@ -2,7 +2,8 @@
 
 import React, { useState, useEffect, useLayoutEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
-import { useChat, getAvatarForUser, Message } from "@/context/ChatContext";
+import { useChat, getAvatarForUser, Message, ChatRoom } from "@/context/ChatContext";
+import { resolveAssetUrl } from "@/lib/assets";
 import { Button } from "@/components/ui/Button";
 import { Dropdown } from "@/components/ui/Dropdown";
 import { Avatar } from "@/components/ui/Avatar";
@@ -287,16 +288,20 @@ export default function Chatroom({ roomId, onOpenGroupSettings }: ChatroomProps)
             )}
           </div>
 
-          {showHeaderPopover && activeRoom.type === "msg" && (
-            <ProfilePopover
-              username={activeRoom.name}
-              onClose={(e) => {
-                e.stopPropagation();
-                setShowHeaderPopover(false);
-              }}
-              position="bottom"
-            />
-          )}
+          {showHeaderPopover && activeRoom.type === "msg" && (() => {
+            const otherMember = activeRoom.members?.find((m) => m.userId !== user.userId);
+            return (
+              <ProfilePopover
+                userId={otherMember?.userId || ""}
+                username={activeRoom.name}
+                onClose={(e) => {
+                  e.stopPropagation();
+                  setShowHeaderPopover(false);
+                }}
+                position="bottom"
+              />
+            );
+          })()}
         </div>
 
         <div className="flex items-center gap-3">
@@ -365,10 +370,17 @@ export default function Chatroom({ roomId, onOpenGroupSettings }: ChatroomProps)
                   isRecalled={msg.isRecalled}
                   replyTo={msg.replyTo || undefined}
                   attachments={msg.attachments}
-                  senderAvatar={msg.isOutgoing ? user.avatar : getAvatarForUser(msg.senderName, user.avatar, user.username)}
+                  senderAvatar={
+                    msg.isOutgoing
+                      ? user.avatar
+                      : senderMember?.avatarUrl
+                      ? resolveAssetUrl(senderMember.avatarUrl)
+                      : undefined
+                  }
                   isRead={msg.isRead}
                   readByAvatars={getReadAvatarsForMessage(activeRoom, msg)}
                   roomType={activeRoom.type}
+                  senderId={msg.senderId || undefined}
                   onReply={() => setReplyTarget(msg)}
                   onRecall={() => handleRecallMessage(msg.id)}
                   canRecall={Boolean(msg.isOutgoing) || canManageMembers}

--- a/frontend/src/components/chat/Chatroom.tsx
+++ b/frontend/src/components/chat/Chatroom.tsx
@@ -54,6 +54,7 @@ export default function Chatroom({ roomId, onOpenGroupSettings }: ChatroomProps)
     rooms,
     messages,
     user,
+    friends,
     activeRoomNicknames,
     handleSendMessage,
     handleTyping,
@@ -262,7 +263,22 @@ export default function Chatroom({ roomId, onOpenGroupSettings }: ChatroomProps)
         <div className="flex items-center gap-3 relative">
           <Avatar
             name={activeRoom.name}
-            src={getAvatarForUser(activeRoom.name, user.avatar, user.username)}
+            src={(() => {
+              if (activeRoom.avatarUrl) {
+                return resolveAssetUrl(activeRoom.avatarUrl);
+              }
+              if (activeRoom.type === "msg") {
+                const otherMember = activeRoom.members?.find((m) => m.userId !== user.userId);
+                if (otherMember?.avatarUrl) {
+                  return resolveAssetUrl(otherMember.avatarUrl);
+                }
+                const friend = friends.find((f) => f.id === activeRoom.otherMemberId || f.name === activeRoom.name);
+                if (friend?.avatarUrl) {
+                  return resolveAssetUrl(friend.avatarUrl);
+                }
+              }
+              return getAvatarForUser(activeRoom.name, user.avatar, user.username);
+            })()}
             size="sm"
             isOnline={activeRoom.isOnline}
           />

--- a/frontend/src/components/chat/FriendInfoPanel.tsx
+++ b/frontend/src/components/chat/FriendInfoPanel.tsx
@@ -1,13 +1,17 @@
 "use client";
 
-import React from "react";
-import { getAvatarForUser, useChat } from "@/context/ChatContext";
+import React, { useEffect, useState } from "react";
+import { useChat } from "@/context/ChatContext";
 import { Avatar } from "@/components/ui/Avatar";
 import { Button } from "@/components/ui/Button";
 import { useRouter } from "next/navigation";
 import { useTranslation } from "@/hooks/useTranslation";
+import { getUserProfile } from "@/lib/api";
+import type { UserProfile } from "@shared/types";
+import { resolveAssetUrl } from "@/lib/assets";
 
 interface FriendInfoPanelProps {
+  userId?: string;
   friendName: string;
   onClose?: () => void;
   showChatButton?: boolean;
@@ -15,6 +19,7 @@ interface FriendInfoPanelProps {
 }
 
 export default function FriendInfoPanel({
+  userId,
   friendName,
   onClose,
   showChatButton = false,
@@ -24,12 +29,49 @@ export default function FriendInfoPanel({
   const router = useRouter();
   const { t } = useTranslation();
 
-  const friend = friends.find((f) => f.name === friendName);
+  const [profile, setProfile] = useState<UserProfile | null>(null);
+  const [loading, setLoading] = useState(false);
 
-  const email = friend ? friend.email : `${friendName.toLowerCase().replace(/\s+/g, "")}@example.com`;
-  const avatar = getAvatarForUser(friendName, user.avatar, user.username);
+  // Fetch user profile if userId is provided
+  useEffect(() => {
+    if (!userId) {
+      setProfile(null);
+      return;
+    }
+
+    if (userId === user.userId) {
+      setProfile({
+        userId: user.userId || "",
+        name: user.username,
+        bio: user.bio || "",
+        avatarUrl: user.avatar || "",
+      });
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    getUserProfile(userId)
+      .then((res) => {
+        setProfile(res);
+      })
+      .catch((err) => {
+        console.error("Failed to load user profile:", err);
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  }, [userId, user.userId]);
+
+  // Fallback resolving
+  const targetId = userId ?? friends.find((f) => f.name === friendName)?.id;
+  const friend = targetId ? friends.find((f) => f.id === targetId) : undefined;
+  const isSelf = targetId === user.userId;
+
+  const displayName = profile?.name ?? friendName;
+  const avatar = profile?.avatarUrl ? resolveAssetUrl(profile.avatarUrl) : undefined;
   const status = friend ? friend.status : "offline";
-  const bio = t("profileCard.defaultBio");
+  const bio = profile?.bio || t("profileCard.defaultBio");
 
   const isEmergency = friend ? emergencySettings.contacts.some((c) => c.contactId === friend.id) : false;
 
@@ -59,12 +101,17 @@ export default function FriendInfoPanel({
   };
 
   const handleSendMessage = async () => {
-    if (!friend) return;
-    const existingRoom = rooms.find((r) => r.type === "msg" && r.name === friendName);
+    const activeUserId = targetId ?? "";
+    if (!activeUserId) return;
+
+    const existingRoom = rooms.find(
+      (r) => r.type === "msg" && (r.members?.some((m) => m.userId === activeUserId) || r.name === displayName)
+    );
+
     if (existingRoom && !existingRoom.isArchived) {
       router.push(`/chat/${existingRoom.id}`);
     } else {
-      const newId = await handleOpenPrivateRoom(friend.id);
+      const newId = await handleOpenPrivateRoom(activeUserId);
       router.push(`/chat/${newId}`);
     }
   };
@@ -89,59 +136,68 @@ export default function FriendInfoPanel({
         </div>
       )}
 
-      <div className="flex-1 overflow-y-auto p-4 flex flex-col gap-5">
-        <div className="flex flex-col items-center text-center gap-3 py-2 border-b border-border-secondary/40 pb-5">
-          <Avatar name={friendName} src={avatar} size="lg" isOnline={status === "online"} />
-          <div className="min-w-0 w-full">
-            <h4 className="text-sm font-bold text-foreground truncate">{friendName}</h4>
-          </div>
+      {loading ? (
+        <div className="flex-1 flex items-center justify-center text-xs text-text-muted">
+          Loading...
         </div>
-
-        <div className="space-y-4 text-xs">
-          <div>
-            <span className="text-[10px] font-bold text-text-muted uppercase tracking-widest block mb-1">
-              {t("profileCard.status")}
-            </span>
-            <div className="flex items-center gap-1.5 mt-0.5">
-              <span className={`h-2.5 w-2.5 border border-border-primary ${status === "online" ? "bg-green-500" : "bg-zinc-500"}`} style={{ borderRadius: "0px" }} />
-              <span className="text-xs text-foreground">{t(`common.${status}`)}</span>
+      ) : (
+        <div className="flex-1 overflow-y-auto p-4 flex flex-col gap-5">
+          <div className="flex flex-col items-center text-center gap-3 py-2 border-b border-border-secondary/40 pb-5">
+            <Avatar name={displayName} src={avatar} size="lg" isOnline={status === "online"} />
+            <div className="min-w-0 w-full">
+              <h4 className="text-sm font-bold text-foreground truncate">{displayName}</h4>
+              {targetId && (
+                <p className="text-[10px] text-text-muted font-mono truncate mt-1">UID: {targetId}</p>
+              )}
             </div>
           </div>
 
-          <div>
-            <span className="text-[10px] font-bold text-text-muted uppercase tracking-widest block mb-1">
-              {t("profileCard.bio")}
-            </span>
-            <p className="text-text-muted leading-relaxed">
-              {bio}
-            </p>
-          </div>
+          <div className="space-y-4 text-xs">
+            <div>
+              <span className="text-[10px] font-bold text-text-muted uppercase tracking-widest block mb-1">
+                {t("profileCard.status")}
+              </span>
+              <div className="flex items-center gap-1.5 mt-0.5">
+                <span className={`h-2.5 w-2.5 border border-border-primary ${status === "online" ? "bg-green-500" : "bg-zinc-500"}`} style={{ borderRadius: "0px" }} />
+                <span className="text-xs text-foreground">{t(`common.${status}`)}</span>
+              </div>
+            </div>
 
-          {friend && (
-            <div className="flex items-center justify-between border-t border-border-secondary/40 pt-4 mt-2">
-              <span className="text-xs font-semibold text-foreground">{t("profileCard.setEmergency")}</span>
-              <button
-                onClick={handleToggleEmergency}
-                className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none ${
-                  isEmergency ? "bg-primary" : "bg-zinc-600"
-                }`}
-              >
-                <span
-                  className={`pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
-                    isEmergency ? "translate-x-4" : "translate-x-0"
+            <div>
+              <span className="text-[10px] font-bold text-text-muted uppercase tracking-widest block mb-1">
+                {t("profileCard.bio")}
+              </span>
+              <p className="text-text-muted leading-relaxed">
+                {bio}
+              </p>
+            </div>
+
+            {friend && (
+              <div className="flex items-center justify-between border-t border-border-secondary/40 pt-4 mt-2">
+                <span className="text-xs font-semibold text-foreground">{t("profileCard.setEmergency")}</span>
+                <button
+                  onClick={handleToggleEmergency}
+                  className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none ${
+                    isEmergency ? "bg-primary" : "bg-zinc-600"
                   }`}
-                />
-              </button>
-            </div>
+                >
+                  <span
+                    className={`pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
+                      isEmergency ? "translate-x-4" : "translate-x-0"
+                    }`}
+                  />
+                </button>
+              </div>
+            )}
+          </div>
+
+          {showChatButton && !isSelf && (
+            <Button onClick={handleSendMessage} variant="primary" className="w-full mt-2 text-xs py-2 font-bold select-none">
+              {t("profileCard.sendMessage")}
+            </Button>
           )}
         </div>
-
-        {showChatButton && (
-          <Button onClick={handleSendMessage} variant="primary" className="w-full mt-2 text-xs py-2 font-bold select-none">
-            {t("profileCard.sendMessage")}
-          </Button>
-        )}
-      </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/chat/FriendInfoPanel.tsx
+++ b/frontend/src/components/chat/FriendInfoPanel.tsx
@@ -31,6 +31,21 @@ export default function FriendInfoPanel({
 
   const [profile, setProfile] = useState<UserProfile | null>(null);
   const [loading, setLoading] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const handleCopyUid = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    const uidToCopy = userId || friends.find((f) => f.name === friendName)?.id;
+    if (!uidToCopy) return;
+    navigator.clipboard.writeText(uidToCopy)
+      .then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      })
+      .catch((err) => {
+        console.error("Failed to copy UID:", err);
+      });
+  };
 
   // Fetch user profile if userId is provided
   useEffect(() => {
@@ -147,7 +162,20 @@ export default function FriendInfoPanel({
             <div className="min-w-0 w-full">
               <h4 className="text-sm font-bold text-foreground truncate">{displayName}</h4>
               {targetId && (
-                <p className="text-[10px] text-text-muted font-mono truncate mt-1">{targetId}</p>
+                <div className="relative inline-block mt-1 max-w-full">
+                  <p
+                    onClick={handleCopyUid}
+                    title="Click to copy UID"
+                    className="text-[10px] text-text-muted font-mono truncate cursor-pointer hover:text-foreground hover:underline transition-colors"
+                  >
+                    {targetId}
+                  </p>
+                  {copied && (
+                    <span className="absolute left-1/2 bottom-full -translate-x-1/2 mb-1 z-10 px-2 py-0.5 text-[9px] font-bold text-white bg-zinc-800 border border-zinc-700 rounded shadow-md whitespace-nowrap">
+                      Copied!
+                    </span>
+                  )}
+                </div>
               )}
             </div>
           </div>

--- a/frontend/src/components/chat/FriendInfoPanel.tsx
+++ b/frontend/src/components/chat/FriendInfoPanel.tsx
@@ -147,7 +147,7 @@ export default function FriendInfoPanel({
             <div className="min-w-0 w-full">
               <h4 className="text-sm font-bold text-foreground truncate">{displayName}</h4>
               {targetId && (
-                <p className="text-[10px] text-text-muted font-mono truncate mt-1">UID: {targetId}</p>
+                <p className="text-[10px] text-text-muted font-mono truncate mt-1">{targetId}</p>
               )}
             </div>
           </div>

--- a/frontend/src/components/chat/ProfilePopover.tsx
+++ b/frontend/src/components/chat/ProfilePopover.tsx
@@ -43,6 +43,19 @@ export default function ProfilePopover({
 
   const [profile, setProfile] = useState<UserProfile | null>(null);
   const [loading, setLoading] = useState(true);
+  const [copied, setCopied] = useState(false);
+
+  const handleCopyUid = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    navigator.clipboard.writeText(userId)
+      .then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      })
+      .catch((err) => {
+        console.error("Failed to copy UID:", err);
+      });
+  };
 
   // Close popover if clicked outside
   useEffect(() => {
@@ -175,7 +188,20 @@ export default function ProfilePopover({
               <h4 className="text-xs font-bold text-foreground truncate">
                 {nickname && nickname !== displayName ? `${displayName} (${nickname})` : displayName}
               </h4>
-              <p className="text-[9px] text-text-muted font-mono truncate mt-0.5">{userId}</p>
+              <div className="relative inline-block mt-0.5 max-w-full">
+                <p
+                  onClick={handleCopyUid}
+                  title="Click to copy UID"
+                  className="text-[9px] text-text-muted font-mono truncate cursor-pointer hover:text-foreground hover:underline transition-colors"
+                >
+                  {userId}
+                </p>
+                {copied && (
+                  <span className="absolute left-1/2 bottom-full -translate-x-1/2 mb-1 z-[110] px-1.5 py-0.5 text-[8px] font-bold text-white bg-zinc-800 border border-zinc-700 rounded shadow-md whitespace-nowrap">
+                    Copied!
+                  </span>
+                )}
+              </div>
             </div>
           </div>
 

--- a/frontend/src/components/chat/ProfilePopover.tsx
+++ b/frontend/src/components/chat/ProfilePopover.tsx
@@ -1,25 +1,48 @@
 "use client";
 
-import React, { useRef, useEffect } from "react";
-import { useChat, getAvatarForUser } from "@/context/ChatContext";
+import React, { useRef, useEffect, useState } from "react";
+import { useChat } from "@/context/ChatContext";
 import { Avatar } from "@/components/ui/Avatar";
 import { Button } from "@/components/ui/Button";
 import { useRouter } from "next/navigation";
 import { useTranslation } from "@/hooks/useTranslation";
+import { getUserProfile } from "@/lib/api";
+import type { UserProfile } from "@shared/types";
+import { resolveAssetUrl } from "@/lib/assets";
 
 interface ProfilePopoverProps {
+  userId: string;
   username: string;
+  nickname?: string;
   onClose: (e: React.MouseEvent) => void;
   position?: "left" | "right" | "bottom" | "custom";
   style?: React.CSSProperties;
   className?: string;
 }
 
-export default function ProfilePopover({ username, onClose, position = "right", style, className }: ProfilePopoverProps) {
-  const { user, friends, rooms, handleOpenPrivateRoom, emergencySettings, saveEmergencySettings } = useChat();
+export default function ProfilePopover({
+  userId,
+  username,
+  nickname,
+  onClose,
+  position = "right",
+  style,
+  className,
+}: ProfilePopoverProps) {
+  const {
+    user,
+    friends,
+    rooms,
+    handleOpenPrivateRoom,
+    emergencySettings,
+    saveEmergencySettings,
+  } = useChat();
   const router = useRouter();
   const popoverRef = useRef<HTMLDivElement>(null);
   const { t } = useTranslation();
+
+  const [profile, setProfile] = useState<UserProfile | null>(null);
+  const [loading, setLoading] = useState(true);
 
   // Close popover if clicked outside
   useEffect(() => {
@@ -38,21 +61,41 @@ export default function ProfilePopover({ username, onClose, position = "right", 
     };
   }, [onClose]);
 
-  const isSelf = username === user.username;
-  const friend = friends.find((f) => f.name === username);
+  // Fetch user profile on mount / userId change
+  useEffect(() => {
+    if (userId === user.userId) {
+      setProfile({
+        userId: user.userId || "",
+        name: user.username,
+        bio: user.bio || "",
+        avatarUrl: user.avatar || "",
+      });
+      setLoading(false);
+      return;
+    }
 
-  const email = isSelf
-    ? user.email
-    : friend
-    ? friend.email
-    : `${username.toLowerCase().replace(/\s+/g, "")}@example.com`;
+    setLoading(true);
+    getUserProfile(userId)
+      .then((res) => {
+        setProfile(res);
+      })
+      .catch((err) => {
+        console.error("Failed to load user profile:", err);
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  }, [userId, user.userId]);
 
-  const avatar = isSelf
-    ? user.avatar
-    : getAvatarForUser(username, user.avatar, user.username);
+  const isSelf = userId === user.userId;
+  const friend = friends.find((f) => f.id === userId);
 
+  const displayName = profile?.name ?? username;
+  const displayAvatar = profile?.avatarUrl ? resolveAssetUrl(profile.avatarUrl) : undefined;
   const status = isSelf ? "online" : friend ? friend.status : "offline";
-  const bio = isSelf ? user.bio || t("profileCard.defaultBio") : t("profileCard.defaultBio");
+  const bio = isSelf
+    ? user.bio || t("profileCard.defaultBio")
+    : profile?.bio || t("profileCard.defaultBio");
 
   const isEmergency = friend ? emergencySettings.contacts.some((c) => c.contactId === friend.id) : false;
 
@@ -84,13 +127,17 @@ export default function ProfilePopover({ username, onClose, position = "right", 
 
   const handleSendMessage = async (e: React.MouseEvent) => {
     e.stopPropagation();
-    if (isSelf || !friend) return;
+    if (isSelf) return;
 
-    const existingRoom = rooms.find((r) => r.type === "msg" && r.name === username);
+    const existingRoom = rooms.find(
+      (r) => r.type === "msg" && (r.members?.some((m) => m.userId === userId) || r.name === username)
+    );
+
     if (existingRoom && !existingRoom.isArchived) {
       router.push(`/chat/${existingRoom.id}`);
     } else {
-      const newId = await handleOpenPrivateRoom(friend.id);
+      const targetId = friend?.id ?? userId;
+      const newId = await handleOpenPrivateRoom(targetId);
       router.push(`/chat/${newId}`);
     }
     onClose(e);
@@ -125,56 +172,66 @@ export default function ProfilePopover({ username, onClose, position = "right", 
         </button>
       </div>
 
-      <div className="flex flex-col items-center text-center gap-2 py-2">
-        <Avatar name={username} src={avatar} size="md" isOnline={status === "online"} />
-        <div className="min-w-0 w-full">
-          <h4 className="text-xs font-bold text-foreground truncate">{username}</h4>
-          <p className="text-[9px] text-text-muted font-mono truncate mt-0.5">{email}</p>
+      {loading ? (
+        <div className="flex items-center justify-center py-6 text-xs text-text-muted">
+          Loading...
         </div>
-      </div>
-
-      <div className="space-y-3 pt-2 border-t border-border-secondary/40 text-xs">
-        <div>
-          <span className="text-[9px] font-bold text-text-muted uppercase tracking-widest block mb-0.5">
-            {t("profileCard.status")}
-          </span>
-          <div className="flex items-center gap-1.5 mt-0.5">
-            <span className={`h-2.5 w-2.5 border border-border-primary ${status === "online" ? "bg-green-500" : "bg-zinc-500"}`} />
-            <span className="text-[11px] text-foreground leading-none">{t(`common.${status}`)}</span>
+      ) : (
+        <>
+          <div className="flex flex-col items-center text-center gap-2 py-2">
+            <Avatar name={displayName} src={displayAvatar} size="md" isOnline={status === "online"} />
+            <div className="min-w-0 w-full">
+              <h4 className="text-xs font-bold text-foreground truncate">
+                {nickname && nickname !== displayName ? `${displayName} (${nickname})` : displayName}
+              </h4>
+              <p className="text-[9px] text-text-muted font-mono truncate mt-0.5">UID: {userId}</p>
+            </div>
           </div>
-        </div>
 
-        <div>
-          <span className="text-[9px] font-bold text-text-muted uppercase tracking-widest block mb-0.5">
-            {t("profileCard.bio")}
-          </span>
-          <p className="text-[11px] text-text-muted leading-relaxed truncate-3-lines">{bio}</p>
-        </div>
+          <div className="space-y-3 pt-2 border-t border-border-secondary/40 text-xs">
+            <div>
+              <span className="text-[9px] font-bold text-text-muted uppercase tracking-widest block mb-0.5">
+                {t("profileCard.status")}
+              </span>
+              <div className="flex items-center gap-1.5 mt-0.5">
+                <span className={`h-2.5 w-2.5 border border-border-primary ${status === "online" ? "bg-green-500" : "bg-zinc-500"}`} />
+                <span className="text-[11px] text-foreground leading-none">{t(`common.${status}`)}</span>
+              </div>
+            </div>
 
-        {friend && (
-          <div className="flex items-center justify-between border-t border-border-secondary/40 pt-2.5 mt-1">
-            <span className="text-[11px] font-semibold text-foreground">{t("profileCard.setEmergency")}</span>
-            <button
-              onClick={handleToggleEmergency}
-              type="button"
-              className={`relative inline-flex h-4 w-8 shrink-0 cursor-pointer rounded-full border border-transparent transition-colors duration-200 ease-in-out focus:outline-none ${
-                isEmergency ? "bg-primary" : "bg-zinc-600"
-              }`}
-            >
-              <span
-                className={`pointer-events-none inline-block h-3.5 w-3.5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
-                  isEmergency ? "translate-x-3.5" : "translate-x-0"
-                }`}
-              />
-            </button>
+            <div>
+              <span className="text-[9px] font-bold text-text-muted uppercase tracking-widest block mb-0.5">
+                {t("profileCard.bio")}
+              </span>
+              <p className="text-[11px] text-text-muted leading-relaxed truncate-3-lines">{bio}</p>
+            </div>
+
+            {friend && (
+              <div className="flex items-center justify-between border-t border-border-secondary/40 pt-2.5 mt-1">
+                <span className="text-[11px] font-semibold text-foreground">{t("profileCard.setEmergency")}</span>
+                <button
+                  onClick={handleToggleEmergency}
+                  type="button"
+                  className={`relative inline-flex h-4 w-8 shrink-0 cursor-pointer rounded-full border border-transparent transition-colors duration-200 ease-in-out focus:outline-none ${
+                    isEmergency ? "bg-primary" : "bg-zinc-600"
+                  }`}
+                >
+                  <span
+                    className={`pointer-events-none inline-block h-3.5 w-3.5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
+                      isEmergency ? "translate-x-3.5" : "translate-x-0"
+                    }`}
+                  />
+                </button>
+              </div>
+            )}
           </div>
-        )}
-      </div>
 
-      {!isSelf && (
-        <Button onClick={handleSendMessage} variant="primary" className="w-full mt-3 text-[11px] py-1.5 font-bold">
-          {t("profileCard.sendMessage")}
-        </Button>
+          {!isSelf && (
+            <Button onClick={handleSendMessage} variant="primary" className="w-full mt-3 text-[11px] py-1.5 font-bold">
+              {t("profileCard.sendMessage")}
+            </Button>
+          )}
+        </>
       )}
     </div>
   );

--- a/frontend/src/components/chat/ProfilePopover.tsx
+++ b/frontend/src/components/chat/ProfilePopover.tsx
@@ -184,7 +184,7 @@ export default function ProfilePopover({
               <h4 className="text-xs font-bold text-foreground truncate">
                 {nickname && nickname !== displayName ? `${displayName} (${nickname})` : displayName}
               </h4>
-              <p className="text-[9px] text-text-muted font-mono truncate mt-0.5">UID: {userId}</p>
+              <p className="text-[9px] text-text-muted font-mono truncate mt-0.5">{userId}</p>
             </div>
           </div>
 

--- a/frontend/src/components/chat/ProfilePopover.tsx
+++ b/frontend/src/components/chat/ProfilePopover.tsx
@@ -161,15 +161,6 @@ export default function ProfilePopover({
         <span className="text-[9px] font-bold text-text-muted uppercase tracking-widest">
           {isSelf ? t("profileCard.myInfo") : friend ? t("profileCard.friendInfo") : t("profileCard.memberInfo")}
         </span>
-        <button
-          onClick={onClose}
-          type="button"
-          className="text-text-muted hover:text-foreground cursor-pointer p-0.5 hover:bg-surface-muted rounded-sm transition-colors"
-        >
-          <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2">
-            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-          </svg>
-        </button>
       </div>
 
       {loading ? (

--- a/frontend/src/components/chat/RoomMembersPanel.tsx
+++ b/frontend/src/components/chat/RoomMembersPanel.tsx
@@ -1,14 +1,15 @@
 "use client";
 
 import React, { useState } from "react";
-import { ChatRoom, Member, getAvatarForUser, useChat } from "@/context/ChatContext";
+import { ChatRoom, Member, useChat } from "@/context/ChatContext";
 import { Avatar } from "@/components/ui/Avatar";
 import ProfilePopover from "./ProfilePopover";
 import { useTranslation } from "@/hooks/useTranslation";
+import { resolveAssetUrl } from "@/lib/assets";
 
 export default function RoomMembersPanel({ room, members }: { room: ChatRoom; members: Member[] }) {
   const { user } = useChat();
-  const [selectedMemberName, setSelectedMemberName] = useState<string | null>(null);
+  const [selectedMember, setSelectedMember] = useState<Member | null>(null);
   const [popoverTop, setPopoverTop] = useState<number>(0);
   const { t } = useTranslation();
 
@@ -28,7 +29,7 @@ export default function RoomMembersPanel({ room, members }: { room: ChatRoom; me
           }
           return (
             <div
-              key={`${member.name}-${index}`}
+              key={`${member.userId}-${index}`}
               onClick={(e) => {
                 const rect = e.currentTarget.getBoundingClientRect();
                 const parentEl = e.currentTarget.closest(".members-panel-root");
@@ -49,12 +50,12 @@ export default function RoomMembersPanel({ room, members }: { room: ChatRoom; me
                   }
                   setPopoverTop(topVal);
                 }
-                setSelectedMemberName(selectedMemberName === member.name ? null : member.name);
+                setSelectedMember(selectedMember?.userId === member.userId ? null : member);
               }}
               className="p-3.5 flex items-center justify-between hover:bg-surface-muted/50 transition-colors cursor-pointer relative avatar-click-target"
             >
               <div className="flex items-center gap-3 min-w-0">
-                <Avatar name={member.name} src={getAvatarForUser(member.name, user.avatar, user.username)} size="sm" />
+                <Avatar name={member.name} src={member.avatarUrl ? resolveAssetUrl(member.avatarUrl) : undefined} size="sm" />
                 <div className="min-w-0">
                   <p className="text-xs font-semibold text-foreground truncate">{displayNick}</p>
                   <p className="text-[9px] text-text-muted capitalize mt-0.5 font-mono">{member.role}</p>
@@ -66,12 +67,14 @@ export default function RoomMembersPanel({ room, members }: { room: ChatRoom; me
         })}
       </div>
 
-      {selectedMemberName && (
+      {selectedMember && (
         <ProfilePopover
-          username={selectedMemberName}
+          userId={selectedMember.userId}
+          username={selectedMember.name}
+          nickname={selectedMember.nickname}
           onClose={(e) => {
             e.stopPropagation();
-            setSelectedMemberName(null);
+            setSelectedMember(null);
           }}
           position="custom"
           className="absolute right-full mr-3 -translate-y-1/2"

--- a/frontend/src/components/chat/RoomMembersPanel.tsx
+++ b/frontend/src/components/chat/RoomMembersPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { ChatRoom, Member, useChat } from "@/context/ChatContext";
 import { Avatar } from "@/components/ui/Avatar";
 import ProfilePopover from "./ProfilePopover";
@@ -8,10 +8,16 @@ import { useTranslation } from "@/hooks/useTranslation";
 import { resolveAssetUrl } from "@/lib/assets";
 
 export default function RoomMembersPanel({ room, members }: { room: ChatRoom; members: Member[] }) {
-  const { user } = useChat();
+  const { user, activeProfilePopover, setActiveProfilePopover } = useChat();
   const [selectedMember, setSelectedMember] = useState<Member | null>(null);
   const [popoverTop, setPopoverTop] = useState<number>(0);
   const { t } = useTranslation();
+
+  useEffect(() => {
+    if (!activeProfilePopover || activeProfilePopover.instanceId !== `member-${selectedMember?.userId}`) {
+      setSelectedMember(null);
+    }
+  }, [activeProfilePopover, selectedMember?.userId]);
 
   return (
     <div className="members-panel-root w-[240px] shrink-0 border-l border-border-primary bg-surface-card flex flex-col h-full select-none relative">
@@ -50,7 +56,13 @@ export default function RoomMembersPanel({ room, members }: { room: ChatRoom; me
                   }
                   setPopoverTop(topVal);
                 }
-                setSelectedMember(selectedMember?.userId === member.userId ? null : member);
+                const instanceId = `member-${member.userId}`;
+                if (activeProfilePopover?.instanceId === instanceId) {
+                  setActiveProfilePopover(null);
+                } else {
+                  setSelectedMember(member);
+                  setActiveProfilePopover({ instanceId, userId: member.userId });
+                }
               }}
               className="p-3.5 flex items-center justify-between hover:bg-surface-muted/50 transition-colors cursor-pointer relative avatar-click-target"
             >
@@ -74,7 +86,7 @@ export default function RoomMembersPanel({ room, members }: { room: ChatRoom; me
           nickname={selectedMember.nickname}
           onClose={(e) => {
             e.stopPropagation();
-            setSelectedMember(null);
+            setActiveProfilePopover(null);
           }}
           position="custom"
           className="absolute right-full mr-3 -translate-y-1/2"

--- a/frontend/src/components/layout/ChatList.tsx
+++ b/frontend/src/components/layout/ChatList.tsx
@@ -6,6 +6,7 @@ import { ChatRoom, getAvatarForUser, useChat } from "@/context/ChatContext";
 import { Avatar } from "@/components/ui/Avatar";
 import { Badge } from "@/components/ui/Badge";
 import { useTranslation } from "@/hooks/useTranslation";
+import { resolveAssetUrl } from "@/lib/assets";
 
 interface ChatListProps {
   searchQuery: string;
@@ -19,6 +20,7 @@ export default function ChatList({ searchQuery }: ChatListProps) {
     rooms,
     folders,
     user,
+    friends,
     toggleFolder,
     handleDeleteFolder,
     handleCategorizeRoom,
@@ -178,7 +180,22 @@ export default function ChatList({ searchQuery }: ChatListProps) {
                   onClick={() => router.push(`/chat/${room.id}`)}
                   onDragStart={(event) => handleRoomDragStart(event, room.id)}
                   onDragEnd={resetDragState}
-                  avatarSrc={getAvatarForUser(room.name, user.avatar, user.username)}
+                  avatarSrc={(() => {
+                    if (room.avatarUrl) {
+                      return resolveAssetUrl(room.avatarUrl);
+                    }
+                    if (room.type === "msg") {
+                      const otherMember = room.members?.find((m) => m.userId !== user.userId);
+                      if (otherMember?.avatarUrl) {
+                        return resolveAssetUrl(otherMember.avatarUrl);
+                      }
+                      const friend = friends.find((f) => f.id === room.otherMemberId || f.name === room.name);
+                      if (friend?.avatarUrl) {
+                        return resolveAssetUrl(friend.avatarUrl);
+                      }
+                    }
+                    return getAvatarForUser(room.name, user.avatar, user.username);
+                  })()}
                   noMessagesText={t("sidebar.noMessages")}
                 />
               ))}
@@ -241,7 +258,22 @@ export default function ChatList({ searchQuery }: ChatListProps) {
                         onClick={() => router.push(`/chat/${room.id}`)}
                         onDragStart={(event) => handleRoomDragStart(event, room.id)}
                         onDragEnd={resetDragState}
-                        avatarSrc={getAvatarForUser(room.name, user.avatar, user.username)}
+                        avatarSrc={(() => {
+                          if (room.avatarUrl) {
+                            return resolveAssetUrl(room.avatarUrl);
+                          }
+                          if (room.type === "msg") {
+                            const otherMember = room.members?.find((m) => m.userId !== user.userId);
+                            if (otherMember?.avatarUrl) {
+                              return resolveAssetUrl(otherMember.avatarUrl);
+                            }
+                            const friend = friends.find((f) => f.id === room.otherMemberId || f.name === room.name);
+                            if (friend?.avatarUrl) {
+                              return resolveAssetUrl(friend.avatarUrl);
+                            }
+                          }
+                          return getAvatarForUser(room.name, user.avatar, user.username);
+                        })()}
                         noMessagesText={t("sidebar.noMessages")}
                       />
                     ))}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -12,6 +12,7 @@ import { useTranslation } from "@/hooks/useTranslation";
 import ChatList from "./ChatList";
 import FriendInfoPanel from "@/components/chat/FriendInfoPanel";
 import { Icon } from "@iconify/react";
+import { resolveAssetUrl } from "@/lib/assets";
 
 export default function Sidebar() {
   const router = useRouter();
@@ -192,6 +193,7 @@ export default function Sidebar() {
         ) : pathname === "/friends" ? (
           selectedFriendForSidebar ? (
             <FriendInfoPanel
+              userId={selectedFriendForSidebar.id}
               friendName={selectedFriendForSidebar.name}
               showChatButton={true}
               hideHeader={true}
@@ -207,7 +209,7 @@ export default function Sidebar() {
 
       <div className="border-t border-border-primary bg-surface-muted select-none shrink-0 flex flex-col">
         <div className="p-4 flex items-center gap-3">
-          <Avatar name={user.username} src={user.avatar} size="sm" isOnline />
+          <Avatar name={user.username} src={user.avatar ? resolveAssetUrl(user.avatar) : undefined} size="sm" isOnline />
           <div className="flex-1 min-w-0">
             <p className="text-xs font-bold text-foreground truncate leading-tight">{user.username}</p>
             <p className="text-[10px] text-text-muted truncate font-mono mt-0.5">{user.email}</p>

--- a/frontend/src/components/pages/ChatroomPageContent.tsx
+++ b/frontend/src/components/pages/ChatroomPageContent.tsx
@@ -10,7 +10,7 @@ import FriendInfoPanel from "@/components/chat/FriendInfoPanel";
 
 export default function ChatroomPageContent() {
   const params = useParams();
-  const { rooms, showRightPanel } = useChat();
+  const { rooms, showRightPanel, user } = useChat();
   const [showSettings, setShowSettings] = useState(false);
 
   const chatId = params?.chatId as string;
@@ -31,6 +31,11 @@ export default function ChatroomPageContent() {
     );
   }
 
+  // Find the other member in a private (msg) chatroom
+  const otherMember = activeRoom.type === "msg"
+    ? activeRoom.members?.find((m) => m.userId !== user.userId)
+    : undefined;
+
   return (
     <div className="flex-1 flex h-full overflow-hidden">
       {showSettings ? (
@@ -47,7 +52,7 @@ export default function ChatroomPageContent() {
           <RoomMembersPanel room={activeRoom} members={activeRoom.members} />
         ) : activeRoom.type === "msg" ? (
           <div className="w-[240px] shrink-0 border-l border-border-primary bg-surface-card h-full">
-            <FriendInfoPanel friendName={activeRoom.name} />
+            <FriendInfoPanel userId={otherMember?.userId} friendName={activeRoom.name} />
           </div>
         ) : null
       )}

--- a/frontend/src/components/settings/FriendsPanel.tsx
+++ b/frontend/src/components/settings/FriendsPanel.tsx
@@ -27,6 +27,7 @@ export default function FriendsPanel() {
     blockFriend,
     unblockUser,
     setSelectedFriendForSidebar,
+    refreshSocialData,
   } = useChat();
   const { t } = useTranslation();
 
@@ -102,6 +103,7 @@ export default function FriendsPanel() {
     try {
       await sendFriendRequestApi(token, targetUserId);
       setSentIds((prev) => new Set(prev).add(targetUserId));
+      await refreshSocialData();
     } catch (err) {
       console.error(err);
       const msg = err instanceof Error ? err.message : "Failed";

--- a/frontend/src/components/settings/FriendsPanel.tsx
+++ b/frontend/src/components/settings/FriendsPanel.tsx
@@ -11,6 +11,7 @@ import { useTranslation } from "@/hooks/useTranslation";
 import { searchUsers, sendFriendRequest as sendFriendRequestApi } from "@/lib/api";
 import { getActiveAccessToken } from "@/lib/api";
 import type { SearchUserResult } from "@shared/types";
+import { resolveAssetUrl } from "@/lib/assets";
 
 type Tab = "friends" | "incoming" | "outgoing" | "blocked" | "add";
 type SearchMode = "name" | "userId" | "email";
@@ -58,11 +59,12 @@ export default function FriendsPanel() {
   const outgoingRequests = friendRequests.filter((r) => r.direction === "outgoing");
 
   /** Convert any user with id/name/email into a Friend shape for the sidebar. */
-  const toFriendShape = (user: { id: string; name: string; email?: string }): Friend => ({
+  const toFriendShape = (user: { id: string; name: string; email?: string; avatarUrl?: string }): Friend => ({
     id: user.id,
     name: user.name,
     email: user.email ?? '',
     status: "offline",
+    avatarUrl: user.avatarUrl,
   });
 
   const handleSearch = async (event: React.FormEvent) => {
@@ -174,7 +176,7 @@ export default function FriendsPanel() {
                     onClick={() => setSelectedFriendForSidebar(friend)}
                     className="flex items-center gap-3 min-w-0 cursor-pointer hover:opacity-85 active:scale-98 transition-all"
                   >
-                    <Avatar name={friend.name} size="sm" isOnline={friend.status === "online"} />
+                    <Avatar name={friend.name} src={friend.avatarUrl ? resolveAssetUrl(friend.avatarUrl) : undefined} size="sm" isOnline={friend.status === "online"} />
                     <div className="min-w-0">
                       <div className="flex items-center gap-2">
                         <p className="text-sm font-semibold text-foreground truncate">{friend.name}</p>
@@ -223,7 +225,7 @@ export default function FriendsPanel() {
                     onClick={() => setSelectedFriendForSidebar(toFriendShape(req))}
                     className="flex items-center gap-3 min-w-0 cursor-pointer hover:opacity-85 transition-all"
                   >
-                    <Avatar name={req.name} size="sm" />
+                    <Avatar name={req.name} src={req.avatarUrl ? resolveAssetUrl(req.avatarUrl) : undefined} size="sm" />
                     <div className="min-w-0">
                       <p className="text-sm font-semibold text-foreground truncate">{req.name}</p>
                       <p className="text-[10px] text-text-muted font-mono truncate">{req.email}</p>
@@ -267,7 +269,7 @@ export default function FriendsPanel() {
                     onClick={() => setSelectedFriendForSidebar(toFriendShape(req))}
                     className="flex items-center gap-3 min-w-0 cursor-pointer hover:opacity-85 transition-all"
                   >
-                    <Avatar name={req.name} size="sm" />
+                    <Avatar name={req.name} src={req.avatarUrl ? resolveAssetUrl(req.avatarUrl) : undefined} size="sm" />
                     <div className="min-w-0">
                       <p className="text-sm font-semibold text-foreground truncate">{req.name}</p>
                       <p className="text-[10px] text-text-muted font-mono truncate">{req.email}</p>
@@ -301,7 +303,7 @@ export default function FriendsPanel() {
                     onClick={() => setSelectedFriendForSidebar(toFriendShape(user))}
                     className="flex items-center gap-3 min-w-0 cursor-pointer hover:opacity-85 transition-all"
                   >
-                    <Avatar name={user.name} size="sm" />
+                    <Avatar name={user.name} src={user.avatarUrl ? resolveAssetUrl(user.avatarUrl) : undefined} size="sm" />
                     <div className="min-w-0">
                       <p className="text-sm font-semibold text-foreground truncate">{user.name}</p>
                       <p className="text-[10px] text-text-muted font-mono truncate">{user.email}</p>
@@ -413,11 +415,12 @@ export default function FriendsPanel() {
                               name: user.name,
                               email: user.email ?? '',
                               status: "offline",
+                              avatarUrl: user.avatarUrl,
                             })
                           }
                           className="flex items-center gap-3 min-w-0 cursor-pointer hover:opacity-85 transition-all"
                         >
-                          <Avatar name={user.name} size="sm" />
+                          <Avatar name={user.name} src={user.avatarUrl ? resolveAssetUrl(user.avatarUrl) : undefined} size="sm" />
                           <div className="min-w-0">
                             <p className="text-sm font-semibold text-foreground truncate">{user.name}</p>
                             <p className="text-[10px] text-text-muted font-mono truncate">{user.userId}</p>

--- a/frontend/src/components/ui/ChatBubble.tsx
+++ b/frontend/src/components/ui/ChatBubble.tsx
@@ -4,6 +4,7 @@ import { cn } from "@/lib/utils";
 import { Avatar } from "./Avatar";
 import ProfilePopover from "../chat/ProfilePopover";
 import { downloadAttachment } from "@/lib/api";
+import { useChat } from "@/context/ChatContext";
 
 export interface Attachment {
   filename: string;
@@ -32,6 +33,7 @@ export interface ChatBubbleProps {
   canRecall?: boolean;
   canEdit?: boolean;
   senderId?: string;
+  messageId?: string;
 }
 
 const renderMentionContent = (
@@ -73,12 +75,15 @@ export function ChatBubble({
   canRecall = false,
   canEdit = false,
   senderId,
+  messageId,
 }: ChatBubbleProps) {
   const [menuPosition, setMenuPosition] = useState<{ x: number; y: number } | null>(null);
-  const [showPopover, setShowPopover] = useState(false);
   const [popoverStyle, setPopoverStyle] = useState<React.CSSProperties>({});
   const [downloadingUrl, setDownloadingUrl] = useState<string | null>(null);
   const [downloadError, setDownloadError] = useState("");
+
+  const { activeProfilePopover, setActiveProfilePopover } = useChat();
+  const showPopover = messageId ? activeProfilePopover?.instanceId === messageId : false;
 
   useEffect(() => {
     if (!menuPosition) return;
@@ -94,6 +99,11 @@ export function ChatBubble({
   }, [menuPosition]);
 
   const handleTogglePopover = (event: React.MouseEvent) => {
+    if (!senderId) {
+      console.warn("No senderId provided to ChatBubble, cannot open profile popover");
+      return;
+    }
+
     const rect = event.currentTarget.getBoundingClientRect();
     const scrollEl = event.currentTarget.closest(".overflow-y-auto");
 
@@ -119,7 +129,13 @@ export function ChatBubble({
       });
     }
 
-    setShowPopover((current) => !current);
+    if (messageId) {
+      if (activeProfilePopover?.instanceId === messageId) {
+        setActiveProfilePopover(null);
+      } else {
+        setActiveProfilePopover({ instanceId: messageId, userId: senderId });
+      }
+    }
   };
 
   const handleCopy = async () => {
@@ -166,7 +182,7 @@ export function ChatBubble({
               username={senderName}
               onClose={(event) => {
                 event.stopPropagation();
-                setShowPopover(false);
+                setActiveProfilePopover(null);
               }}
               position="custom"
               className="absolute left-full ml-3"

--- a/frontend/src/components/ui/ChatBubble.tsx
+++ b/frontend/src/components/ui/ChatBubble.tsx
@@ -26,7 +26,7 @@ export interface ChatBubbleProps {
   attachments?: Attachment[];
   senderAvatar?: string;
   isRead?: boolean;
-  readByAvatars?: { name: string; avatarUrl: string }[];
+  readByAvatars?: { name: string; displayName?: string; avatarUrl: string }[];
   roomType?: "msg" | "group";
   onReply?: () => void;
   onRecall?: () => void;
@@ -34,6 +34,7 @@ export interface ChatBubbleProps {
   canEdit?: boolean;
   senderId?: string;
   messageId?: string;
+  avatarName?: string;
 }
 
 const renderMentionContent = (
@@ -76,6 +77,7 @@ export function ChatBubble({
   canEdit = false,
   senderId,
   messageId,
+  avatarName,
 }: ChatBubbleProps) {
   const [menuPosition, setMenuPosition] = useState<{ x: number; y: number } | null>(null);
   const [popoverStyle, setPopoverStyle] = useState<React.CSSProperties>({});
@@ -175,7 +177,7 @@ export function ChatBubble({
           className="shrink-0 mt-1 relative cursor-pointer avatar-click-target"
           onClick={handleTogglePopover}
         >
-          <Avatar name={senderName} src={senderAvatar} size="sm" />
+          <Avatar name={avatarName || senderName} src={senderAvatar} size="sm" />
           {showPopover && (
             <ProfilePopover
               userId={senderId || ""}
@@ -373,7 +375,7 @@ export function ChatBubble({
               <div
                 key={idx}
                 className="h-4.5 w-4.5 border border-border-primary bg-surface-muted rounded-sm overflow-hidden select-none flex items-center justify-center"
-                title={reader.name}
+                title={reader.displayName || reader.name}
               >
                 {reader.avatarUrl ? (
                   <img src={resolveAssetUrl(reader.avatarUrl)} alt={reader.name} className="h-full w-full object-cover" />

--- a/frontend/src/components/ui/ChatBubble.tsx
+++ b/frontend/src/components/ui/ChatBubble.tsx
@@ -31,6 +31,7 @@ export interface ChatBubbleProps {
   onRecall?: () => void;
   canRecall?: boolean;
   canEdit?: boolean;
+  senderId?: string;
 }
 
 const renderMentionContent = (
@@ -71,6 +72,7 @@ export function ChatBubble({
   onRecall,
   canRecall = false,
   canEdit = false,
+  senderId,
 }: ChatBubbleProps) {
   const [menuPosition, setMenuPosition] = useState<{ x: number; y: number } | null>(null);
   const [showPopover, setShowPopover] = useState(false);
@@ -160,6 +162,7 @@ export function ChatBubble({
           <Avatar name={senderName} src={senderAvatar} size="sm" />
           {showPopover && (
             <ProfilePopover
+              userId={senderId || ""}
               username={senderName}
               onClose={(event) => {
                 event.stopPropagation();

--- a/frontend/src/context/ChatContext.tsx
+++ b/frontend/src/context/ChatContext.tsx
@@ -518,7 +518,7 @@ const fetchRoomMembers = async (authToken: string, roomId: string): Promise<Memb
   const apiMembers = await listRoomMembers(authToken, roomId);
   const profiles = await Promise.all(
     apiMembers.map((member) =>
-      getUserProfile(authToken, member.userId).catch(() => undefined),
+      getUserProfile(member.userId, authToken).catch(() => undefined),
     ),
   );
 

--- a/frontend/src/context/ChatContext.tsx
+++ b/frontend/src/context/ChatContext.tsx
@@ -296,6 +296,8 @@ interface ChatContextType {
   saveEmergencySettings: (settings: EmergencySettings) => Promise<void>;
   triggerEmergencyAlertNow: (message?: string) => Promise<TriggerEmergencyAlertResult>;
   setUiLanguage: (language: UiLanguage) => void;
+  activeProfilePopover: { instanceId: string; userId: string } | null;
+  setActiveProfilePopover: React.Dispatch<React.SetStateAction<{ instanceId: string; userId: string } | null>>;
 }
 
 const ChatContext = createContext<ChatContextType | undefined>(undefined);
@@ -597,6 +599,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
   const [selectedFriendForSidebar, setSelectedFriendForSidebar] = useState<Friend | null>(null);
   const [showRightPanel, setShowRightPanel] = useState<boolean>(true);
   const [typingUsers, setTypingUsers] = useState<Record<string, string[]>>({});
+  const [activeProfilePopover, setActiveProfilePopover] = useState<{ instanceId: string; userId: string } | null>(null);
   const typingTimersRef = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
 
   const activeRoomId = useMemo(() => {
@@ -1682,6 +1685,8 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
         triggerEmergencyAlertNow,
         setUiLanguage,
         typingUsers,
+        activeProfilePopover,
+        setActiveProfilePopover,
       }}
     >
       {children}

--- a/frontend/src/context/ChatContext.tsx
+++ b/frontend/src/context/ChatContext.tsx
@@ -288,7 +288,7 @@ interface ChatContextType {
   kickGroupMember: (roomId: string, userId: string) => Promise<Member[] | undefined>;
   transferGroupOwner: (roomId: string, userId: string) => Promise<Member[] | undefined>;
   handleDeleteGroupRoom: (roomId: string) => Promise<string | null>;
-  getReadAvatarsForMessage: (room: ChatRoom, msg: Message) => { name: string; avatarUrl: string }[];
+  getReadAvatarsForMessage: (room: ChatRoom, msg: Message) => { name: string; displayName?: string; avatarUrl: string }[];
 
   searchUsersForInvite: (query: string) => Promise<PublicUser[]>;
   handleJoinByInviteCode: (inviteCode: string) => Promise<string>;
@@ -1070,6 +1070,29 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
 
     localStorage.setItem("user", JSON.stringify(nextUser));
     setUser(nextUser);
+
+    if (nextUser.userId) {
+      setRooms((current) =>
+        current.map((room) => {
+          if (!room.members) return room;
+          const updatedMembers = room.members.map((m) => {
+            if (m.userId === nextUser.userId) {
+              return {
+                ...m,
+                name: nextUser.username,
+                avatarUrl: nextUser.avatar,
+              };
+            }
+            return m;
+          });
+          return {
+            ...room,
+            members: updatedMembers,
+          };
+        })
+      );
+    }
+
     return nextUser;
   };
 
@@ -1368,7 +1391,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
     return remaining[0]?.id ?? null;
   };
 
-  const getReadAvatarsForMessage = (room: ChatRoom, msg: Message): { name: string; avatarUrl: string }[] => {
+  const getReadAvatarsForMessage = (room: ChatRoom, msg: Message): { name: string; displayName?: string; avatarUrl: string }[] => {
     if (room.type !== "group") return [];
 
     const roomReads = groupReadStates[room.id];
@@ -1378,7 +1401,11 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
       .filter(([readerId, lastReadId]) => readerId !== currentUserId && lastReadId === msg.id)
       .map(([readerId]) => {
         const member = room.members?.find((m) => m.userId === readerId);
-        return { name: member?.nickname ?? member?.name ?? readerId, avatarUrl: member?.avatarUrl ?? "" };
+        return {
+          name: member?.name ?? readerId,
+          displayName: member?.nickname ?? member?.name ?? readerId,
+          avatarUrl: member?.avatarUrl ?? "",
+        };
       });
   };
 

--- a/frontend/src/context/ChatContext.tsx
+++ b/frontend/src/context/ChatContext.tsx
@@ -303,6 +303,7 @@ interface ChatContextType {
   setUiLanguage: (language: UiLanguage) => void;
   activeProfilePopover: { instanceId: string; userId: string } | null;
   setActiveProfilePopover: React.Dispatch<React.SetStateAction<{ instanceId: string; userId: string } | null>>;
+  refreshSocialData: () => Promise<void>;
 }
 
 const ChatContext = createContext<ChatContextType | undefined>(undefined);
@@ -1449,7 +1450,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
     if (request?.direction === "incoming") {
       await respondFriendRequest(token, requestId, "rejected");
     }
-    setFriendRequests((prev) => prev.filter((item) => item.id !== requestId));
+    await refreshSocialData(token);
   };
 
   const removeFriend = async (friendId: string) => {
@@ -1464,18 +1465,14 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
     if (!friend) return;
 
     await blockUserApi(token, friendId);
-    setBlockedUsers((prev) => {
-      if (prev.some((item) => item.id === friendId)) return prev;
-      return [...prev, { id: friend.id, name: friend.name, email: friend.email }];
-    });
     await refreshSocialData(token);
   };
 
   const unblockUser = async (blockedId: string) => {
     if (token) {
       await unblockUserApi(token, blockedId);
+      await refreshSocialData(token);
     }
-    setBlockedUsers((prev) => prev.filter((item) => item.id !== blockedId));
   };
 
   const saveEmergencySettings = async (settings: EmergencySettings) => {
@@ -1632,6 +1629,12 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
     });
   }, [rooms, friends, currentUserId]);
 
+  const handleRefreshSocialData = async () => {
+    if (token) {
+      await refreshSocialData(token);
+    }
+  };
+
   return (
     <ChatContext.Provider
       value={{
@@ -1696,6 +1699,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
         typingUsers,
         activeProfilePopover,
         setActiveProfilePopover,
+        refreshSocialData: handleRefreshSocialData,
       }}
     >
       {children}

--- a/frontend/src/context/ChatContext.tsx
+++ b/frontend/src/context/ChatContext.tsx
@@ -2,6 +2,7 @@
 
 import React, { createContext, useContext, useEffect, useMemo, useRef, useState } from "react";
 import { usePathname, useRouter } from "next/navigation";
+import { resolveAssetUrl } from "@/lib/assets";
 import type {
   Attachment as ApiAttachment,
   EmergencyContactResponse,
@@ -106,6 +107,7 @@ export interface ChatRoom {
   unreadCount?: number;
   lastMessagePreview?: string;
   lastMessageAt?: string;
+  avatarUrl?: string;
 }
 
 export interface Message {
@@ -156,6 +158,7 @@ export interface Friend {
   email: string;
   status: "online" | "offline";
   isEmergencyContact?: boolean;
+  avatarUrl?: string;
 }
 
 export interface FriendRequest {
@@ -163,12 +166,14 @@ export interface FriendRequest {
   name: string;
   email: string;
   direction: "incoming" | "outgoing";
+  avatarUrl?: string;
 }
 
 export interface BlockedUser {
   id: string;
   name: string;
   email: string;
+  avatarUrl?: string;
 }
 
 export interface EmergencyContact {
@@ -199,7 +204,7 @@ export const getAvatarForUser = (
   currentUsername?: string,
 ) => {
   if (currentUsername && username === currentUsername) {
-    return currentUserAvatar || "";
+    return currentUserAvatar ? resolveAssetUrl(currentUserAvatar) : "";
   }
   return "";
 };
@@ -432,6 +437,7 @@ const mapRooms = (
     return {
       id: room.roomId,
       type: room.type === "group" ? "group" : "msg",
+      avatarUrl: room.avatarUrl,
       name:
         room.name ||
         (currentRoom?.name && !isPrivateRoomFallbackName(currentRoom.name, room.roomId)
@@ -479,6 +485,7 @@ const mapFriend = (item: FriendResponse, emergencyContactIds: Set<string>): Frie
   email: "",
   status: item.status || "offline",
   isEmergencyContact: emergencyContactIds.has(item.friend.userId),
+  avatarUrl: item.friend.avatarUrl,
 });
 
 const mapFriendRequest = (item: FriendRequestResponse, currentUserId: string): FriendRequest => {
@@ -488,6 +495,7 @@ const mapFriendRequest = (item: FriendRequestResponse, currentUserId: string): F
       name: item.addressee?.name ?? item.addresseeId,
       email: "",
       direction: "outgoing",
+      avatarUrl: item.addressee?.avatarUrl,
     };
   }
   return {
@@ -495,6 +503,7 @@ const mapFriendRequest = (item: FriendRequestResponse, currentUserId: string): F
     name: item.requester?.name ?? item.requesterId,
     email: "",
     direction: "incoming",
+    avatarUrl: item.requester?.avatarUrl,
   };
 };
 
@@ -678,7 +687,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
 
         setFriends(apiFriends.map((friend) => mapFriend(friend, emergencyContactIds)));
         setFriendRequests(apiRequests.map((req) => mapFriendRequest(req, effectiveUserId)));
-        setBlockedUsers(apiBlockedUsers.map(u => ({ id: u.userId, name: u.name, email: u.email })));
+        setBlockedUsers(apiBlockedUsers.map(u => ({ id: u.userId, name: u.name, email: u.email, avatarUrl: u.avatarUrl })));
         setEmergencySettings({
           warningEnabled: settings?.warningEnabled ?? user.warningEnabled ?? false,
           warningDays: settings?.warningDays ?? user.warningDays ?? 0,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -233,7 +233,7 @@ export const logout = (token: string): Promise<void> =>
 export const getMe = (token: string): Promise<MyProfile> =>
   requestJson<MyProfile>('/users/me', {}, { token });
 
-export const getUserProfile = (token: string, userId: string): Promise<UserProfile> =>
+export const getUserProfile = (userId: string, token?: string): Promise<UserProfile> =>
   requestJson<UserProfile>(`/users/${userId}`, {}, { token });
 
 export const updateMe = (token: string, data: UpdateMeRequest): Promise<MyProfile> =>


### PR DESCRIPTION
修正 Issue #198 、變更個人頭貼後的即時更新同步、好友列表相關問題。
   
1. **資訊卡 Bug 修復與優化**
       - 移除彈出個人資訊卡右上角關閉按鈕，改為點擊卡片外部即關閉。
       - 確保畫面上同一時間只會出現一張個人資訊卡。
       - 取消私聊上方聊天室名稱按下去彈出個人資訊卡的功能。
       - 點擊 UID 時即時複製至剪貼簿，並顯示獨立提示框。
      
2. **群組頭貼 Fallback 字母改用本名**
       - 修正前：沒有頭貼的群組成員在對話泡泡中顯示的頭貼 Fallback 字母為「暱稱（Nickname）」的首字母。
       - 修正後：即使設定了暱稱，對話泡泡的頭貼 Fallback 字母仍會以該成員的「本名（真實使用者名稱）」首字母來渲染，而對話泡泡旁的名字依然維持顯示暱稱。
       - 訊息下方的已讀狀態頭貼，其 Fallback 字母亦改用本名，並在懸停時顯示暱稱。
    
3. **頭貼變更後的群組成員清單即時更新**
       - 修正前：修改個人頭貼後，群組右側的成員清單（`RoomMembersPanel`）中自己的頭貼不會即時更新，需要重新整理網頁。
       - 修正後：在 `handleUpdateProfile` 儲存成功時，會即時更新本地 `rooms` 狀態中所有聊天室的成員資料（把匹配當前使用者 ID
  的成員頭貼與名稱更新為最新值），使右側成員清單以及其他使用該列表的元件能免刷新即時同步。
    
4. **好友列表**
       - 好友相關清單（等待中、已封鎖等）與搜尋結果的頭貼能正常解析與即時同步。
       - 修正新增/接受/拒絕好友、封鎖/解鎖等動作後，各列表能夠即時刷新