### PR TITLE
feat: implement group avatar upload API and UI integration (#206)

### DIFF
--- a/backend/src/controllers/roomController.ts
+++ b/backend/src/controllers/roomController.ts
@@ -17,6 +17,7 @@ interface RoomService {
   approveMember(roomId: string, callerId: string, targetUserId: string): Promise<void>;
   updateMember(roomId: string, callerId: string, targetUserId: string, data: { role?: string; nickname?: string; isMuted?: boolean }): Promise<void>;
   kickMember(roomId: string, callerId: string, targetUserId: string): Promise<void>;
+  uploadAvatar(roomId: string, callerId: string, file: Express.Multer.File): Promise<Room>;
 }
 
 export const makeRoomController = (service: RoomService) => ({
@@ -155,6 +156,18 @@ export const makeRoomController = (service: RoomService) => ({
     try {
       await service.kickMember(req.params.id, req.user!.userId, req.params.userId);
       res.status(204).send();
+    } catch (err) {
+      next(err);
+    }
+  },
+
+  async uploadAvatar(req: Request<{ id: string }>, res: Response, next: NextFunction): Promise<void> {
+    try {
+      if (!req.file) {
+        return next(new ValidationError('Avatar file is required'));
+      }
+      const room = await service.uploadAvatar(req.params.id, req.user!.userId, req.file);
+      res.status(200).json(room);
     } catch (err) {
       next(err);
     }

--- a/backend/src/routes/roomRoutes.ts
+++ b/backend/src/routes/roomRoutes.ts
@@ -1,6 +1,23 @@
 import { Router } from 'express';
+import multer from 'multer';
+import { ValidationError } from '../errors/AppError';
+import { ALLOWED_AVATAR_MIME_TYPES, AVATAR_UPLOAD_MAX_BYTES } from '../lib/avatarUpload';
 import { authMiddleware } from '../middlewares/authMiddleware';
 import type { makeRoomController } from '../controllers/roomController';
+
+const avatarUpload = multer({
+  storage: multer.memoryStorage(),
+  limits: {
+    fileSize: AVATAR_UPLOAD_MAX_BYTES,
+    files: 1,
+  },
+  fileFilter: (_req, file, cb) => {
+    if (!ALLOWED_AVATAR_MIME_TYPES.includes(file.mimetype as (typeof ALLOWED_AVATAR_MIME_TYPES)[number])) {
+      return cb(new ValidationError('Unsupported avatar file type'));
+    }
+    cb(null, true);
+  },
+});
 
 export const makeRoomRoutes = (ctrl: ReturnType<typeof makeRoomController>): Router => {
   const router = Router();
@@ -18,6 +35,7 @@ export const makeRoomRoutes = (ctrl: ReturnType<typeof makeRoomController>): Rou
   router.post('/:id/members/:userId/approve', ctrl.approveMember.bind(ctrl));
   router.get('/:id', ctrl.getById.bind(ctrl));
   router.patch('/:id', ctrl.update.bind(ctrl));
+  router.post('/:id/avatar', avatarUpload.single('file'), ctrl.uploadAvatar.bind(ctrl));
   router.delete('/:id', ctrl.deleteGroup.bind(ctrl));
 
   return router;

--- a/backend/src/services/roomService.ts
+++ b/backend/src/services/roomService.ts
@@ -1,6 +1,7 @@
 import type { Room, RoomSummary } from '@shared/types';
 import { randomBytes } from 'crypto';
 import { isUserOnline } from '../realtime/presence';
+import { removeManagedAvatar, saveAvatarUpload } from '../lib/avatarUpload';
 import type { IRoomRepository } from '../repositories/IRoomRepository';
 import type { IRoomMemberRepository } from '../repositories/IRoomMemberRepository';
 import type { IUserRepository } from '../repositories/IUserRepository';
@@ -303,6 +304,33 @@ export const makeRoomService = (
       await roomMemberRepo.remove(roomId, targetUserId);
       if (emitRoomEvent) {
         emitRoomEvent(roomId, 'room_update', { type: 'MEMBER_KICKED', data: { userId: targetUserId } });
+      }
+    },
+
+    async uploadAvatar(roomId: string, callerId: string, file: Express.Multer.File): Promise<Room> {
+      const room = await repo.findById(roomId);
+      if (!room) throw new NotFoundError('room', roomId);
+      if (room.type !== 'group') throw new ValidationError('Cannot upload avatar for a private room');
+
+      const member = await roomMemberRepo.findMember(roomId, callerId);
+      if (!member || (member.role !== 'owner' && member.role !== 'admin')) {
+        throw new ForbiddenError('Only owner or admin can update room avatar');
+      }
+
+      const avatarUrl = await saveAvatarUpload(roomId, file);
+
+      try {
+        const updated = await repo.update(roomId, { avatarUrl });
+        if (room.avatarUrl && room.avatarUrl !== avatarUrl) {
+          await removeManagedAvatar(room.avatarUrl);
+        }
+        if (emitRoomEvent) {
+          emitRoomEvent(roomId, 'room_update', { type: 'ROOM_AVATAR_UPDATED', data: { roomId, avatarUrl } });
+        }
+        return updated;
+      } catch (error) {
+        await removeManagedAvatar(avatarUrl);
+        throw error;
       }
     },
   };

--- a/backend/tests/e2e/routes/room.e2e.test.ts
+++ b/backend/tests/e2e/routes/room.e2e.test.ts
@@ -191,4 +191,56 @@ describe('Room E2E', () => {
       .set('Authorization', `Bearer ${token}`);
     expect(fetchDeleted.status).toBe(404);
   });
+
+  it('should upload group avatar successfully by owner', async () => {
+    const createRes = await request(app)
+      .post('/api/v1/rooms')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        type: 'group',
+        name: 'Avatar E2E Room',
+      });
+    expect(createRes.status).toBe(201);
+    const roomId = createRes.body.roomId;
+
+    const buffer = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    const uploadRes = await request(app)
+      .post(`/api/v1/rooms/${roomId}/avatar`)
+      .set('Authorization', `Bearer ${token}`)
+      .attach('file', buffer, 'avatar.png');
+
+    expect(uploadRes.status).toBe(200);
+    expect(uploadRes.body.avatarUrl).toContain('/uploads/avatars/');
+
+    // Clean up uploaded file
+    const fs = await import('fs/promises');
+    const path = await import('path');
+    const filename = path.basename(uploadRes.body.avatarUrl);
+    const filepath = path.resolve(process.cwd(), 'uploads/avatars', filename);
+    await fs.unlink(filepath).catch(() => {});
+  });
+
+  it('should reject avatar upload by non-admin member', async () => {
+    const createRes = await request(app)
+      .post('/api/v1/rooms')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        type: 'group',
+        name: 'Avatar Reject Room',
+      });
+    const roomId = createRes.body.roomId;
+
+    await request(app)
+      .post(`/api/v1/rooms/${roomId}/members`)
+      .set('Authorization', `Bearer ${otherToken}`)
+      .send({ inviteCode: createRes.body.inviteCode });
+
+    const buffer = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    const uploadRes = await request(app)
+      .post(`/api/v1/rooms/${roomId}/avatar`)
+      .set('Authorization', `Bearer ${otherToken}`)
+      .attach('file', buffer, 'avatar.png');
+
+    expect(uploadRes.status).toBe(403);
+  });
 });

--- a/backend/tests/unit/services/roomService.test.ts
+++ b/backend/tests/unit/services/roomService.test.ts
@@ -4,6 +4,12 @@ import { ConflictError, ForbiddenError, NotFoundError, ValidationError } from '.
 import type { IRoomRepository } from '../../../src/repositories/IRoomRepository';
 import type { IRoomMemberRepository } from '../../../src/repositories/IRoomMemberRepository';
 import type { Room, RoomMember } from '../../../../shared/types';
+import { saveAvatarUpload, removeManagedAvatar } from '../../../src/lib/avatarUpload';
+
+vi.mock('../../../src/lib/avatarUpload', () => ({
+  saveAvatarUpload: vi.fn(),
+  removeManagedAvatar: vi.fn(),
+}));
 
 describe('roomService', () => {
   let mockRepo: Mocked<IRoomRepository>;
@@ -318,6 +324,92 @@ describe('roomService', () => {
         content: '[System] Bob已加入',
       });
       expect(mockEmit).toHaveBeenCalledWith('room-1', 'new_message', { messageId: 'msg-sys', content: '[System] Bob已加入' });
+    });
+  });
+
+  describe('uploadAvatar', () => {
+    let mockFile: any;
+
+    beforeEach(() => {
+      mockFile = {
+        buffer: Buffer.from('mock-image-data'),
+        mimetype: 'image/png',
+        originalname: 'avatar.png',
+      } as any;
+
+      vi.mocked(saveAvatarUpload).mockReset();
+      vi.mocked(removeManagedAvatar).mockReset();
+      
+      vi.mocked(saveAvatarUpload).mockResolvedValue('/uploads/avatars/new-avatar.png');
+    });
+
+    it('updates room avatar successfully by owner', async () => {
+      mockRepo.findById.mockResolvedValue(room);
+      mockMemberRepo.findMember.mockResolvedValue(ownerMember);
+      
+      const updatedRoom = { ...room, avatarUrl: '/uploads/avatars/new-avatar.png' };
+      mockRepo.update.mockResolvedValue(updatedRoom);
+
+      const result = await roomService.uploadAvatar('room-1', 'user-1', mockFile);
+
+      expect(mockRepo.findById).toHaveBeenCalledWith('room-1');
+      expect(mockMemberRepo.findMember).toHaveBeenCalledWith('room-1', 'user-1');
+      expect(saveAvatarUpload).toHaveBeenCalledWith('room-1', mockFile);
+      expect(mockRepo.update).toHaveBeenCalledWith('room-1', { avatarUrl: '/uploads/avatars/new-avatar.png' });
+      expect(result.avatarUrl).toBe('/uploads/avatars/new-avatar.png');
+    });
+
+    it('updates room avatar successfully by admin', async () => {
+      mockRepo.findById.mockResolvedValue(room);
+      mockMemberRepo.findMember.mockResolvedValue({ role: 'admin' } as RoomMember);
+      
+      const updatedRoom = { ...room, avatarUrl: '/uploads/avatars/new-avatar.png' };
+      mockRepo.update.mockResolvedValue(updatedRoom);
+
+      const result = await roomService.uploadAvatar('room-1', 'user-1', mockFile);
+      expect(result.avatarUrl).toBe('/uploads/avatars/new-avatar.png');
+    });
+
+    it('throws ForbiddenError if caller is normal member', async () => {
+      mockRepo.findById.mockResolvedValue(room);
+      mockMemberRepo.findMember.mockResolvedValue({ role: 'member' } as RoomMember);
+
+      await expect(roomService.uploadAvatar('room-1', 'user-1', mockFile)).rejects.toThrow(ForbiddenError);
+    });
+
+    it('throws NotFoundError if room does not exist', async () => {
+      mockRepo.findById.mockResolvedValue(null);
+
+      await expect(roomService.uploadAvatar('room-1', 'user-1', mockFile)).rejects.toThrow(NotFoundError);
+    });
+
+    it('throws ValidationError if room is a private room', async () => {
+      const privateRoom = { ...room, type: 'private' as const };
+      mockRepo.findById.mockResolvedValue(privateRoom);
+
+      await expect(roomService.uploadAvatar('room-1', 'user-1', mockFile)).rejects.toThrow(ValidationError);
+    });
+
+    it('deletes newly uploaded avatar and throws error if db update fails', async () => {
+      mockRepo.findById.mockResolvedValue(room);
+      mockMemberRepo.findMember.mockResolvedValue(ownerMember);
+      mockRepo.update.mockRejectedValue(new Error('DB failure'));
+
+      await expect(roomService.uploadAvatar('room-1', 'user-1', mockFile)).rejects.toThrow('DB failure');
+      expect(removeManagedAvatar).toHaveBeenCalledWith('/uploads/avatars/new-avatar.png');
+    });
+
+    it('deletes old avatar after successful update', async () => {
+      const roomWithOldAvatar = { ...room, avatarUrl: '/uploads/avatars/old-avatar.png' };
+      mockRepo.findById.mockResolvedValue(roomWithOldAvatar);
+      mockMemberRepo.findMember.mockResolvedValue(ownerMember);
+      
+      const updatedRoom = { ...room, avatarUrl: '/uploads/avatars/new-avatar.png' };
+      mockRepo.update.mockResolvedValue(updatedRoom);
+
+      await roomService.uploadAvatar('room-1', 'user-1', mockFile);
+      
+      expect(removeManagedAvatar).toHaveBeenCalledWith('/uploads/avatars/old-avatar.png');
     });
   });
 });

--- a/frontend/src/components/settings/GroupSettings.tsx
+++ b/frontend/src/components/settings/GroupSettings.tsx
@@ -11,6 +11,10 @@ import { Input } from "@/components/ui/Input";
 import { Modal } from "@/components/ui/Modal";
 import { useTranslation } from "@/hooks/useTranslation";
 import { Dropdown, DropdownItem } from "@/components/ui/Dropdown";
+import { resolveAssetUrl } from "@/lib/assets";
+
+const ACCEPTED_AVATAR_TYPES = ["image/png", "image/jpeg", "image/gif", "image/webp"];
+const AVATAR_UPLOAD_MAX_BYTES = 2 * 1024 * 1024;
 
 interface GroupSettingsProps {
   roomId: string;
@@ -50,6 +54,17 @@ export default function GroupSettings({ roomId, onClose }: GroupSettingsProps) {
   const [nickInputValue, setNickInputValue] = useState("");
   const [memberActionUserId, setMemberActionUserId] = useState<string | null>(null);
   const searchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [avatarFile, setAvatarFile] = useState<File | null>(null);
+  const [avatarPreviewUrl, setAvatarPreviewUrl] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    return () => {
+      if (avatarPreviewUrl) {
+        URL.revokeObjectURL(avatarPreviewUrl);
+      }
+    };
+  }, [avatarPreviewUrl]);
 
   const currentMember = useMemo(
     () => members.find((member) => member.userId === user.userId || member.name === user.username),
@@ -157,13 +172,51 @@ export default function GroupSettings({ roomId, onClose }: GroupSettingsProps) {
     setIsSaving(true);
     setFeedback("");
     try {
-      await saveGroupSettings(roomId, { name, requireApproval, viewHistory });
+      await saveGroupSettings(roomId, { name, requireApproval, viewHistory, avatarFile });
       setFeedback(t("groupSettings.settingsSaved"));
+      setAvatarFile(null);
+      if (avatarPreviewUrl) {
+        URL.revokeObjectURL(avatarPreviewUrl);
+        setAvatarPreviewUrl(null);
+      }
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
     } catch (error) {
       setFeedback(error instanceof Error ? error.message : t("groupSettings.roleFailed"));
     } finally {
       setIsSaving(false);
     }
+  };
+
+  const handleAvatarClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleAvatarFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    if (!ACCEPTED_AVATAR_TYPES.includes(file.type)) {
+      setFeedback(t("avatarUpload.invalidType"));
+      event.target.value = "";
+      return;
+    }
+
+    if (file.size > AVATAR_UPLOAD_MAX_BYTES) {
+      setFeedback(t("avatarUpload.tooLarge"));
+      event.target.value = "";
+      return;
+    }
+
+    if (avatarPreviewUrl) {
+      URL.revokeObjectURL(avatarPreviewUrl);
+    }
+
+    const previewUrl = URL.createObjectURL(file);
+    setAvatarFile(file);
+    setAvatarPreviewUrl(previewUrl);
+    setFeedback("");
   };
 
   const handleApprove = async (member: Member) =>
@@ -359,6 +412,27 @@ export default function GroupSettings({ roomId, onClose }: GroupSettingsProps) {
           {canManageMembers && (
             <section className="flex flex-col gap-4">
               <SectionTitle title={t("groupSettings.basicSettings")} />
+              <div className="flex items-center gap-6 py-2">
+                <Avatar
+                  name={name}
+                  src={avatarPreviewUrl ?? (activeRoom.avatarUrl ? resolveAssetUrl(activeRoom.avatarUrl) : undefined)}
+                  size="lg"
+                />
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept="image/png,image/jpeg,image/gif,image/webp"
+                  className="hidden"
+                  onChange={handleAvatarFileChange}
+                />
+                <Button type="button" variant="secondary" onClick={handleAvatarClick}>
+                  {t("profile.changeAvatar")}
+                </Button>
+              </div>
+              <div className="text-xs text-text-muted -mt-3">
+                {t("avatarUpload.requirements")}
+                {avatarFile ? ` ${t("avatarUpload.selected", { name: avatarFile.name })}` : ""}
+              </div>
               <Input
                 label={t("groupSettings.groupName")}
                 value={name}

--- a/frontend/src/context/ChatContext.tsx
+++ b/frontend/src/context/ChatContext.tsx
@@ -60,6 +60,7 @@ import {
   upsertEmergencyContact,
   uploadAttachment,
   uploadAvatar as uploadAvatarApi,
+  uploadRoomAvatar as uploadRoomAvatarApi,
   getActiveAccessToken,
   setActiveAccessToken,
   refreshTokens,
@@ -232,6 +233,7 @@ interface GroupSettingsInput {
   requireApproval: boolean;
   viewHistory: boolean;
   isArchived?: boolean;
+  avatarFile?: File | null;
 }
 
 interface ChatContextType {
@@ -1344,12 +1346,16 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
   const saveGroupSettings = async (roomId: string, settings: GroupSettingsInput) => {
     if (!token) return;
 
-    const updated = await updateRoom(token, roomId, {
+    let updated = await updateRoom(token, roomId, {
       name: settings.name,
       requireApproval: settings.requireApproval,
       viewHistory: settings.viewHistory,
       ...(settings.isArchived !== undefined && { isArchived: settings.isArchived }),
     });
+
+    if (settings.avatarFile) {
+      updated = await uploadRoomAvatarApi(token, roomId, settings.avatarFile);
+    }
 
     setRooms((current) =>
       current.map((room) =>
@@ -1361,6 +1367,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
               requireApproval: updated.requireApproval,
               viewHistory: updated.viewHistory,
               isArchived: updated.isArchived,
+              avatarUrl: updated.avatarUrl,
             }
           : room,
       ),

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -388,6 +388,20 @@ export const updateRoom = (
     { token },
   );
 
+export const uploadRoomAvatar = (token: string, roomId: string, file: File): Promise<Room> => {
+  const formData = new FormData();
+  formData.append('file', file);
+
+  return requestJson<Room>(
+    `/rooms/${roomId}/avatar`,
+    {
+      method: 'POST',
+      body: formData,
+    },
+    { token },
+  );
+};
+
 export const deleteRoom = (token: string, roomId: string): Promise<void> =>
   requestJson<void>(`/rooms/${roomId}`, { method: 'DELETE' }, { token });
 


### PR DESCRIPTION
Close #206. Implement backend API and frontend settings UI to allow owners and admins to upload and modify group avatars.