### PR TITLE
fix(frontend): show read status avatar for private messages (#200)

### DIFF
--- a/.github/workflows/close-issues-on-dev-merge.yml
+++ b/.github/workflows/close-issues-on-dev-merge.yml
@@ -1,0 +1,39 @@
+name: Close Issues on Dev Merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [dev]
+
+permissions:
+  issues: write
+  pull-requests: read
+
+jobs:
+  close-linked-issues:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.pull_request.body || '';
+            const pattern = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi;
+            const issueNumbers = [];
+            let match;
+            while ((match = pattern.exec(body)) !== null) {
+              issueNumbers.push(parseInt(match[1], 10));
+            }
+            if (issueNumbers.length === 0) {
+              console.log('No linked issues found in PR body.');
+              return;
+            }
+            for (const issueNumber of issueNumbers) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                state: 'closed',
+              });
+              console.log(`Closed issue #${issueNumber}`);
+            }

--- a/backend/src/repositories/roomRepository.ts
+++ b/backend/src/repositories/roomRepository.ts
@@ -22,6 +22,7 @@ function mapRowToRoomSummary(row: any): RoomSummary {
     ...mapRowToRoom(row),
     unreadCount: Number(row.unread_count ?? 0),
     otherMemberId: row.other_member_id ?? undefined,
+    lastReadId: row.last_read_id ?? undefined,
   };
 
   if (row.latest_message_id) {
@@ -72,6 +73,7 @@ export class RoomRepository implements IRoomRepository {
     const res = await this.db.query(
       `SELECT
          cr.*,
+         rm.last_read_id AS last_read_id,
          latest.message_id AS latest_message_id,
          latest.sender_id AS latest_sender_id,
          latest.content AS latest_content,

--- a/frontend/src/components/ui/ChatBubble.tsx
+++ b/frontend/src/components/ui/ChatBubble.tsx
@@ -207,9 +207,6 @@ export function ChatBubble({
         <div className="flex items-end gap-1.5">
           {isOutgoing && (
             <div className="flex flex-col items-end text-[10px] text-text-muted font-mono leading-none select-none mb-0.5">
-              {roomType === "msg" && isRead && (
-                <span className="text-primary font-bold text-[9px] mb-1 font-sans">已讀</span>
-              )}
               <span>{timestamp}</span>
             </div>
           )}
@@ -369,7 +366,7 @@ export function ChatBubble({
           )}
         </div>
 
-        {roomType === "group" && readByAvatars && readByAvatars.length > 0 && (
+        {(roomType === "group" || roomType === "msg") && readByAvatars && readByAvatars.length > 0 && (
           <div className="flex gap-1 mt-1 justify-end w-full px-0.5">
             {readByAvatars.map((reader, idx) => (
               <div

--- a/frontend/src/context/ChatContext.tsx
+++ b/frontend/src/context/ChatContext.tsx
@@ -1412,7 +1412,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
   };
 
   const getReadAvatarsForMessage = (room: ChatRoom, msg: Message): { name: string; displayName?: string; avatarUrl: string }[] => {
-    if (room.type !== "group") return [];
+    if (room.type !== "group" && room.type !== "msg") return [];
 
     const roomReads = groupReadStates[room.id];
     if (!roomReads) return [];

--- a/frontend/src/context/ChatContext.tsx
+++ b/frontend/src/context/ChatContext.tsx
@@ -109,6 +109,7 @@ export interface ChatRoom {
   lastMessagePreview?: string;
   lastMessageAt?: string;
   avatarUrl?: string;
+  lastReadId?: string | null;
 }
 
 export interface Message {
@@ -461,6 +462,7 @@ const mapRooms = (
       otherMemberId: room.otherMemberId ?? currentRoom?.otherMemberId,
       members: currentRoom?.members ?? (room.type === "group" ? [] : undefined),
       unreadCount: room.unreadCount ?? currentRoom?.unreadCount ?? 0,
+      lastReadId: room.lastReadId ?? currentRoom?.lastReadId ?? null,
       lastMessagePreview: latestMessage
         ? summarizeMessagePreview(latestMessage)
         : currentRoom?.lastMessagePreview,
@@ -1594,6 +1596,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
         const latestMessage = roomMessages.at(-1);
         const roomLastReadId =
           groupReadStates[room.id]?.[currentUserId] ??
+          room.lastReadId ??
           room.members?.find((member) => member.userId === currentUserId)?.lastReadId ??
           null;
         const nextUnreadCount =

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -18,7 +18,23 @@ import type {
   UserSettings,
 } from '@shared/types';
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:4000';
+const getApiBaseUrl = (): string => {
+  if (typeof window !== 'undefined') {
+    const envUrl = process.env.NEXT_PUBLIC_API_URL;
+    let port = '4005';
+    if (envUrl) {
+      try {
+        const urlObj = new URL(envUrl);
+        if (urlObj.port) port = urlObj.port;
+      } catch (e) {
+        // ignore
+      }
+    }
+    return `${window.location.protocol}//${window.location.hostname}:${port}`;
+  }
+  return process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:4000';
+};
+const API_BASE_URL = getApiBaseUrl();
 const API_PREFIX = '/api/v1';
 
 type UpdateMeRequest = Partial<Pick<MyProfile, 'name' | 'email' | 'bio' | 'avatarUrl'>> & {

--- a/frontend/src/lib/assets.ts
+++ b/frontend/src/lib/assets.ts
@@ -1,4 +1,20 @@
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:4000";
+const getApiBaseUrl = (): string => {
+  if (typeof window !== 'undefined') {
+    const envUrl = process.env.NEXT_PUBLIC_API_URL;
+    let port = "4005";
+    if (envUrl) {
+      try {
+        const urlObj = new URL(envUrl);
+        if (urlObj.port) port = urlObj.port;
+      } catch (e) {
+        // ignore
+      }
+    }
+    return `${window.location.protocol}//${window.location.hostname}:${port}`;
+  }
+  return process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:4000";
+};
+const API_BASE_URL = getApiBaseUrl();
 
 export const resolveAssetUrl = (value?: string): string | undefined => {
   if (!value) {

--- a/frontend/src/lib/socket.ts
+++ b/frontend/src/lib/socket.ts
@@ -1,7 +1,23 @@
 import { io, type Socket } from 'socket.io-client';
 import type { ClientToServerEvents, ServerToClientEvents } from '@shared/types';
 
-const SOCKET_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:4000';
+const getSocketUrl = (): string => {
+  if (typeof window !== 'undefined') {
+    const envUrl = process.env.NEXT_PUBLIC_API_URL;
+    let port = '4005';
+    if (envUrl) {
+      try {
+        const urlObj = new URL(envUrl);
+        if (urlObj.port) port = urlObj.port;
+      } catch (e) {
+        // ignore
+      }
+    }
+    return `${window.location.protocol}//${window.location.hostname}:${port}`;
+  }
+  return process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:4000';
+};
+const SOCKET_URL = getSocketUrl();
 
 export type ChatSocket = Socket<ServerToClientEvents, ClientToServerEvents>;
 

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -93,6 +93,7 @@ export interface RoomSummary extends Room {
   unreadCount: number;
   isOnline?: boolean;
   otherMemberId?: string;
+  lastReadId?: string;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
This PR fixes the read status representation on private messages to use avatar icons (similar to group chats) rather than the blue text label, resolving user feedback in #200.

Closes #222
Closes #200 