### PR TITLE
fix: resolve unblock friend (#225) & ws vulnerability (#226)

### DIFF
--- a/backend/pnpm-lock.yaml
+++ b/backend/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   esbuild: ^0.28.1
+  ws: ^8.20.1
 
 importers:
 
@@ -1740,18 +1741,6 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@8.18.3:
-    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
   ws@8.20.1:
     resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
     engines: {node: '>=10.0.0'}
@@ -2429,7 +2418,7 @@ snapshots:
       cors: 2.8.6
       debug: 4.4.3
       engine.io-parser: 5.2.3
-      ws: 8.18.3
+      ws: 8.20.1
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -3109,7 +3098,7 @@ snapshots:
   socket.io-adapter@2.5.6:
     dependencies:
       debug: 4.4.3
-      ws: 8.18.3
+      ws: 8.20.1
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -3426,8 +3415,6 @@ snapshots:
       strip-ansi: 7.2.0
 
   wrappy@1.0.2: {}
-
-  ws@8.18.3: {}
 
   ws@8.20.1: {}
 

--- a/backend/pnpm-workspace.yaml
+++ b/backend/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 overrides:
   esbuild: "^0.28.1"
+  ws: "^8.20.1"
 
 allowBuilds:
   esbuild: true


### PR DESCRIPTION
This PR covers the following fixes:
- **Issue #225**: Verifies and confirms the friend unblocking fix.
- **Issue #226**: Resolves the `ws` dependency vulnerability (CVE-2026-45736) by adding a version override in `pnpm-workspace.yaml`.

Closes #225
Closes #226