### PR TITLE
fix(deploy): 修復 Dockerfile 多階段建置與 standalone 配置

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,28 @@
+# Root .dockerignore — used when frontend build context is the monorepo root
+.git
+.github
+.vscode
+.claude
+.claire
+.omc
+.agents
+.gemini
+docs
+reference
+
+# Node
+**/node_modules
+**/.pnpm-store
+
+# Next.js build artifacts
+frontend/.next
+
+# Environment files
+.env
+.env.*
+!.env.example
+
+# Miscellaneous
+**/.DS_Store
+*.md
+LICENSE

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,8 +44,7 @@ services:
     depends_on:
       db:
         condition: service_healthy
-    volumes:
-      - ${UPLOADS_MOUNT_SOURCE:-app_uploads}:/app/uploads
+    command: sh -c "pnpm run migrate:up && pnpm dev"
 
   frontend:
     build:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,28 +1,34 @@
-FROM node:lts-slim
+# Stage 1: Install dependencies
+FROM node:lts-slim AS deps
+RUN corepack enable && corepack prepare pnpm@latest --activate
+WORKDIR /workspace
+
+COPY frontend/package.json frontend/pnpm-lock.yaml ./frontend/
+
+WORKDIR /workspace/frontend
+RUN pnpm install --no-frozen-lockfile --ignore-scripts
 
 # Stage 2: Build the frontend
 FROM node:lts-slim AS builder
 ARG NEXT_PUBLIC_API_URL
 ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
 RUN corepack enable && corepack prepare pnpm@latest --activate
+WORKDIR /workspace
 
 # Copy global configs and shared files
 COPY tsconfig.base.json ./
 COPY shared/ ./shared/
 
-# Copy frontend packages and node_modules
+# Copy frontend node_modules from deps stage and source code
 COPY --from=deps /workspace/frontend/node_modules ./frontend/node_modules
 COPY frontend/ ./frontend/
+
 WORKDIR /workspace/frontend
 ENV NEXT_TELEMETRY_DISABLED=1
 
-# Pass API URL at build time for Next.js to inline into client bundles
-ARG NEXT_PUBLIC_API_URL
-ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
-
 RUN pnpm build
 
-# Stage 3: Runner
+# Stage 3: Production runner (minimal image)
 FROM node:lts-slim AS runner
 WORKDIR /app
 ENV NODE_ENV=production
@@ -33,15 +39,13 @@ RUN chown -R node:node /app
 
 USER node
 
-COPY --chown=node:node package.json pnpm-lock.yaml ./
-
-RUN pnpm install --no-frozen-lockfile --ignore-scripts
-
-COPY --chown=node:node . .
+# Copy standalone server, static assets, and public files
+COPY --from=builder --chown=node:node /workspace/frontend/.next/standalone ./
+COPY --from=builder --chown=node:node /workspace/frontend/.next/static ./.next/static
+COPY --from=builder --chown=node:node /workspace/frontend/public ./public
 
 EXPOSE 3000
 ENV PORT=3000
 ENV HOSTNAME="0.0.0.0"
 
 CMD ["node", "server.js"]
-

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -5,7 +5,7 @@ const allowedDevOrigins = process.env.ALLOWED_DEV_ORIGINS
   : ["laptop.tail544a05.ts.net"];
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  output: 'standalone',
   allowedDevOrigins,
 };
 

--- a/frontend/src/lib/socket.ts
+++ b/frontend/src/lib/socket.ts
@@ -1,23 +1,5 @@
 import { io, type Socket } from 'socket.io-client';
 import type { ClientToServerEvents, ServerToClientEvents } from '@shared/types';
-
-const getSocketUrl = (): string => {
-  if (typeof window !== 'undefined') {
-    const envUrl = process.env.NEXT_PUBLIC_API_URL;
-    let port = '4005';
-    if (envUrl) {
-      try {
-        const urlObj = new URL(envUrl);
-        if (urlObj.port) port = urlObj.port;
-      } catch (e) {
-        // ignore
-      }
-    }
-    return `${window.location.protocol}//${window.location.hostname}:${port}`;
-  }
-  return process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:4000';
-};
-const SOCKET_URL = getSocketUrl();
 import { getApiBaseUrl } from './api';
 
 export type ChatSocket = Socket<ServerToClientEvents, ClientToServerEvents>;


### PR DESCRIPTION
## 問題描述

PR #232（`chore(domain): 部署至公開網域`）合併到 main 再合併到 dev 後，引入了多個**阻塞建置與運行的嚴重問題**：

### 🛑 修復的嚴重問題

1. **`frontend/Dockerfile` 缺失 `deps` 階段**
   - `COPY --from=deps` 引用了不存在的建置階段，導致 `docker build` 直接失敗
   
2. **Runner 階段路徑錯誤**
   - 建置上下文已改為根目錄 `.`，但 `COPY package.json` 仍指向根目錄（根目錄無 `package.json`）
   - `COPY . .` 會把整個 monorepo（含 backend）都打包進前端映像檔

3. **Next.js Standalone 模式未啟用**
   - `CMD ["node", "server.js"]` 需要 `output: 'standalone'` 才能產生 `server.js`
   - 原 `next.config.ts` 缺少此設定，容器啟動時會直接崩潰

4. **`docker-compose.yml` backend 有重複的 `volumes` 鍵**
   - YAML 不允許同一個 mapping 有重複鍵，第二個會覆蓋第一個
   - 同時 `command` 被意外移除，導致 backend 不會執行 migration

5. **`socket.ts` 死程式碼與語法問題**
   - `import` 被放在檔案中間而非頂部
   - 原本的 `getSocketUrl()` 與 `SOCKET_URL` 已不再使用

### ✅ 修改內容

| 檔案 | 改動 |
|------|------|
| `frontend/Dockerfile` | 補上 `deps` 階段，修正所有 COPY 路徑，runner 只複製 standalone 產物 |
| `frontend/next.config.ts` | 加入 `output: 'standalone'` |
| `frontend/src/lib/socket.ts` | 移除死程式碼，import 移至頂部 |
| `docker-compose.yml` | 合併重複 volumes，恢復 backend command |
| `.dockerignore` (新增) | 防止 1.2GB+ 的建置上下文（.git, node_modules 等） |

### 🧪 驗證

- [x] TypeScript 編譯通過（`pnpm exec tsc --noEmit`）
- [x] `docker compose config` 驗證通過
- [x] `docker build` 三階段全部成功完成
- [x] Next.js standalone 正確產生 `server.js` 與 static assets