### PR TITLE
feat: @everyone mention + unit test coverage ≥90% for all source files

### DIFF
--- a/backend/pnpm-lock.yaml
+++ b/backend/pnpm-lock.yaml
@@ -6,7 +6,9 @@ settings:
 
 overrides:
   esbuild: ^0.28.1
-  ws: ^8.20.1
+  ws: ^8.21.0
+  form-data: ^4.0.6
+  vite: ^7.3.5
 
 importers:
 
@@ -568,7 +570,7 @@ packages:
     resolution: {integrity: sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+      vite: ^7.3.5
     peerDependenciesMeta:
       msw:
         optional: true
@@ -917,8 +919,8 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   formidable@3.5.4:
@@ -993,6 +995,10 @@ packages:
 
   hasown@2.0.3:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
   helmet@8.2.0:
@@ -1652,8 +1658,8 @@ packages:
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
-  vite@7.3.3:
-    resolution: {integrity: sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==}
+  vite@7.3.5:
+    resolution: {integrity: sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -1741,8 +1747,8 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@8.20.1:
-    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -2098,7 +2104,7 @@ snapshots:
       '@types/cookiejar': 2.1.5
       '@types/methods': 1.1.4
       '@types/node': 25.7.0
-      form-data: 4.0.5
+      form-data: 4.0.6
 
   '@types/supertest@7.2.0':
     dependencies:
@@ -2136,13 +2142,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.6(vite@7.3.3(@types/node@25.7.0)(tsx@4.22.4))':
+  '@vitest/mocker@3.2.6(vite@7.3.5(@types/node@25.7.0)(tsx@4.22.4))':
     dependencies:
       '@vitest/spy': 3.2.6
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.3(@types/node@25.7.0)(tsx@4.22.4)
+      vite: 7.3.5(@types/node@25.7.0)(tsx@4.22.4)
 
   '@vitest/pretty-format@3.2.6':
     dependencies:
@@ -2398,7 +2404,7 @@ snapshots:
       '@socket.io/component-emitter': 3.1.2
       debug: 4.4.3
       engine.io-parser: 5.2.3
-      ws: 8.20.1
+      ws: 8.21.0
       xmlhttprequest-ssl: 2.1.2
     transitivePeerDependencies:
       - bufferutil
@@ -2418,7 +2424,7 @@ snapshots:
       cors: 2.8.6
       debug: 4.4.3
       engine.io-parser: 5.2.3
-      ws: 8.20.1
+      ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -2546,12 +2552,12 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  form-data@4.0.5:
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.3
+      hasown: 2.0.4
       mime-types: 2.1.35
 
   formidable@3.5.4:
@@ -2633,6 +2639,10 @@ snapshots:
       has-symbols: 1.1.0
 
   hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
+
+  hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
 
@@ -3098,7 +3108,7 @@ snapshots:
   socket.io-adapter@2.5.6:
     dependencies:
       debug: 4.4.3
-      ws: 8.20.1
+      ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -3193,7 +3203,7 @@ snapshots:
       cookiejar: 2.1.4
       debug: 4.4.3
       fast-safe-stringify: 2.1.1
-      form-data: 4.0.5
+      form-data: 4.0.6
       formidable: 3.5.4
       methods: 1.1.2
       mime: 2.6.0
@@ -3324,7 +3334,7 @@ snapshots:
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.3(@types/node@25.7.0)(tsx@4.22.4)
+      vite: 7.3.5(@types/node@25.7.0)(tsx@4.22.4)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -3339,7 +3349,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.3(@types/node@25.7.0)(tsx@4.22.4):
+  vite@7.3.5(@types/node@25.7.0)(tsx@4.22.4):
     dependencies:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.4)
@@ -3356,7 +3366,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.6
-      '@vitest/mocker': 3.2.6(vite@7.3.3(@types/node@25.7.0)(tsx@4.22.4))
+      '@vitest/mocker': 3.2.6(vite@7.3.5(@types/node@25.7.0)(tsx@4.22.4))
       '@vitest/pretty-format': 3.2.6
       '@vitest/runner': 3.2.6
       '@vitest/snapshot': 3.2.6
@@ -3374,7 +3384,7 @@ snapshots:
       tinyglobby: 0.2.16
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.3(@types/node@25.7.0)(tsx@4.22.4)
+      vite: 7.3.5(@types/node@25.7.0)(tsx@4.22.4)
       vite-node: 3.2.4(@types/node@25.7.0)(tsx@4.22.4)
       why-is-node-running: 2.3.0
     optionalDependencies:
@@ -3416,7 +3426,7 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@8.20.1: {}
+  ws@8.21.0: {}
 
   xmlhttprequest-ssl@2.1.2: {}
 

--- a/backend/pnpm-workspace.yaml
+++ b/backend/pnpm-workspace.yaml
@@ -1,6 +1,8 @@
 overrides:
   esbuild: "^0.28.1"
-  ws: "^8.20.1"
+  ws: "^8.21.0"
+  form-data: "^4.0.6"
+  vite: "^7.3.5"
 
 allowBuilds:
   esbuild: true

--- a/backend/tests/unit/realtime/socketServer.test.ts
+++ b/backend/tests/unit/realtime/socketServer.test.ts
@@ -3,6 +3,12 @@ import { ForbiddenError, NotFoundError } from '../../../src/errors/AppError';
 import { attachSockets } from '../../../src/realtime/socketServer';
 import type { ChatServer } from '../../../src/realtime/authSocket';
 import type { MessageWithSender } from '../../../../shared/types';
+import { trackUserConnection, trackUserDisconnection } from '../../../src/realtime/presence';
+
+vi.mock('../../../src/realtime/presence', () => ({
+  trackUserConnection: vi.fn().mockResolvedValue(undefined),
+  trackUserDisconnection: vi.fn().mockResolvedValue(undefined),
+}));
 
 const message: MessageWithSender = {
   messageId: 'msg-1',
@@ -162,6 +168,68 @@ describe('attachSockets', () => {
       statusCode: 400,
       message: 'Invalid messageId for this room',
       code: 'VALIDATION_ERROR',
+    });
+  });
+
+  it('emits NotFoundError when recall_message target does not exist', async () => {
+    repo.findById.mockResolvedValue(null);
+
+    await handlers.recall_message({ messageId: 'missing-msg' });
+
+    expect(service.recallMessage).not.toHaveBeenCalled();
+    expect(socket.emit).toHaveBeenCalledWith('error', {
+      statusCode: 404,
+      message: 'message with id missing-msg not found',
+      code: 'NOT_FOUND',
+    });
+  });
+
+  describe('with friendRepository', () => {
+    let frHandlers: Record<string, any>;
+    let frSocket: any;
+    const friendRepo = { getFriends: vi.fn() };
+
+    beforeEach(() => {
+      vi.mocked(trackUserConnection).mockClear();
+      vi.mocked(trackUserDisconnection).mockClear();
+
+      frHandlers = {};
+      frSocket = {
+        id: 'socket-fr-1',
+        data: { user: { userId: 'user-1', name: 'Alice' } },
+        join: vi.fn(),
+        leave: vi.fn(),
+        emit: vi.fn(),
+        to: vi.fn(() => ({ emit: vi.fn() })),
+        on: vi.fn((event, handler) => { frHandlers[event] = handler; }),
+      };
+
+      let frConnectionHandler: any;
+      const frIo = {
+        on: vi.fn((event, handler) => { if (event === 'connection') frConnectionHandler = handler; }),
+        to: vi.fn(() => ({ emit: vi.fn() })),
+      } as unknown as ChatServer;
+
+      attachSockets(frIo, {
+        messageService: service,
+        messageRepository: repo,
+        roomMemberRepository: roomMemberRepo,
+        friendRepository: friendRepo,
+      });
+      frConnectionHandler(frSocket);
+    });
+
+    it('calls trackUserConnection on connect when friendRepository is provided', () => {
+      expect(trackUserConnection).toHaveBeenCalledWith(
+        expect.anything(), 'user-1', 'socket-fr-1', friendRepo,
+      );
+    });
+
+    it('calls trackUserDisconnection on disconnect when friendRepository is provided', () => {
+      frHandlers.disconnect();
+      expect(trackUserDisconnection).toHaveBeenCalledWith(
+        expect.anything(), 'user-1', 'socket-fr-1', friendRepo,
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary

- **@everyone mention**: Add `@everyone` mention feature in chatroom — broadcasts to all room members; frontend highlights the mention and adds i18n strings for EN/ZH-TW
- **Unit test coverage**: Raise statement AND branch coverage to ≥90% across all non-infrastructure source files (26 files passing)
- **messageService refactor**: Minor adjustments to support testability

## Coverage highlights (branch → dev delta)

| File | Before | After |
|------|--------|-------|
| `auth/jwt.ts` | ~85% | 100%/100% |
| `middlewares/authMiddleware.ts` | 87%/83% | 100%/100% |
| `controllers/authController.ts` | 97%/85% | 100%/90.5% |
| `controllers/roomController.ts` | 79%/97% | 100%/98% |
| `services/roomService.ts` | 95%/83% | 99.4%/94.2% |
| `services/userService.ts` | st:94%/br:84% | 100%/96.6% |
| `realtime/socketServer.ts` | 85.9%/85.7% | 97.4%/100% |
| All 26 files | mixed | **≥90% st & br** ✓ |

## Test plan

- [ ] `rtk vitest run --coverage tests/unit` — all 375 tests pass, all files ≥90%
- [ ] Verify `@everyone` mention renders correctly in chatroom UI
- [ ] Confirm i18n strings appear in both EN and ZH-TW locales
- [ ] Smoke-test socket send/recall flows in staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)