### PR TITLE
feat(chat): display image attachments inline in chatroom (#249)

### DIFF
--- a/frontend/src/components/ui/ChatBubble.tsx
+++ b/frontend/src/components/ui/ChatBubble.tsx
@@ -98,15 +98,20 @@ function ImageAttachmentPreview({
   const [blobUrl, setBlobUrl] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(!!file.url);
   const [hasError, setHasError] = useState(false);
+  const [prevUrl, setPrevUrl] = useState(file.url);
+
+  if (file.url !== prevUrl) {
+    setPrevUrl(file.url);
+    setBlobUrl(null);
+    setIsLoading(!!file.url);
+    setHasError(false);
+  }
 
   useEffect(() => {
     if (!file.url) {
-      setIsLoading(false);
       return;
     }
     let objectUrl: string | null = null;
-    setIsLoading(true);
-    setHasError(false);
     fetchAttachmentBlobUrl(file.url)
       .then((url) => {
         objectUrl = url;

--- a/frontend/src/components/ui/ChatBubble.tsx
+++ b/frontend/src/components/ui/ChatBubble.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "@/hooks/useTranslation";
 import { cn } from "@/lib/utils";
 import { Avatar } from "./Avatar";
 import ProfilePopover from "../chat/ProfilePopover";
-import { downloadAttachment } from "@/lib/api";
+import { downloadAttachment, fetchAttachmentBlobUrl } from "@/lib/api";
 import { useChat } from "@/context/ChatContext";
 
 export interface Attachment {
@@ -81,6 +81,104 @@ const renderMentionContent = (
     ),
   );
 };
+
+function ImageAttachmentPreview({
+  file,
+  isOutgoing,
+  isHighEmphasis,
+  onDownload,
+  isDownloading,
+}: {
+  file: Attachment;
+  isOutgoing: boolean;
+  isHighEmphasis: boolean;
+  onDownload: () => void;
+  isDownloading: boolean;
+}) {
+  const [blobUrl, setBlobUrl] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(!!file.url);
+  const [hasError, setHasError] = useState(false);
+
+  useEffect(() => {
+    if (!file.url) {
+      setIsLoading(false);
+      return;
+    }
+    let objectUrl: string | null = null;
+    setIsLoading(true);
+    setHasError(false);
+    fetchAttachmentBlobUrl(file.url)
+      .then((url) => {
+        objectUrl = url;
+        setBlobUrl(url);
+      })
+      .catch(() => setHasError(true))
+      .finally(() => setIsLoading(false));
+    return () => {
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [file.url]);
+
+  const fallbackClassName = cn(
+    "flex w-full items-center gap-2.5 p-2 border rounded-sm text-xs cursor-pointer select-none transition-colors text-left disabled:cursor-wait disabled:opacity-70",
+    isOutgoing && isHighEmphasis
+      ? "bg-white/10 border-white/20 hover:bg-white/20 text-white"
+      : "bg-surface-card border-border-secondary hover:border-border-primary text-foreground",
+  );
+  const labelClass = cn(
+    "text-[9px] uppercase tracking-wider font-mono mt-0.5 truncate",
+    isOutgoing && isHighEmphasis ? "text-white/60" : "text-text-muted",
+  );
+  const clipIcon = (
+    <svg className="h-4 w-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13" />
+    </svg>
+  );
+
+  if (isLoading) {
+    return (
+      <div
+        className={cn(
+          "rounded-sm w-48 h-32 animate-pulse",
+          isOutgoing && isHighEmphasis ? "bg-white/20" : "bg-surface-muted",
+        )}
+      />
+    );
+  }
+
+  if (hasError || !blobUrl) {
+    return (
+      <button
+        type="button"
+        onClick={onDownload}
+        disabled={isDownloading}
+        className={fallbackClassName}
+        title={isDownloading ? "Downloading attachment" : "Download attachment"}
+      >
+        {clipIcon}
+        <div className="flex-1 min-w-0">
+          <p className="font-medium truncate leading-tight">{file.filename}</p>
+          <p className={labelClass}>{file.filetype}</p>
+        </div>
+      </button>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-1">
+      <img
+        src={blobUrl}
+        alt={file.filename}
+        className="max-w-full max-h-64 rounded-sm object-contain cursor-pointer"
+        onClick={onDownload}
+        title="Click to download"
+      />
+      <p className={cn("text-[9px] font-mono truncate", isOutgoing && isHighEmphasis ? "text-white/60" : "text-text-muted")}>
+        {file.filename}
+      </p>
+    </div>
+  );
+}
 
 export function ChatBubble({
   content,
@@ -280,6 +378,21 @@ export function ChatBubble({
             {attachments.length > 0 && (
               <div className="flex flex-col gap-1.5 mt-1 border-t border-border-secondary/40 pt-2">
                 {attachments.map((file, idx) => {
+                  const isImage = file.filetype?.startsWith("image/");
+
+                  if (isImage) {
+                    return (
+                      <ImageAttachmentPreview
+                        key={idx}
+                        file={file}
+                        isOutgoing={isOutgoing}
+                        isHighEmphasis={isHighEmphasis}
+                        onDownload={() => void handleDownloadAttachment(file)}
+                        isDownloading={downloadingUrl === file.url}
+                      />
+                    );
+                  }
+
                   const fileContent = (
                     <>
                       <svg

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -582,6 +582,11 @@ export const downloadAttachment = async (fileUrl: string, filename: string): Pro
   window.setTimeout(() => URL.revokeObjectURL(downloadUrl), 0);
 };
 
+export const fetchAttachmentBlobUrl = async (fileUrl: string): Promise<string> => {
+  const response = await request(fileUrl);
+  const blob = await response.blob();
+  return URL.createObjectURL(blob);
+};
 
 export const listEmergencyContacts = (token: string): Promise<EmergencyContactResponse[]> =>
   requestJson<EmergencyContactResponse[]>('/users/me/emergency-contacts', {}, { token });


### PR DESCRIPTION
## Summary
- Image attachments (MIME type `image/*`) now render inline inside the chat bubble instead of showing only a download button
- `fetchAttachmentBlobUrl` added to `api.ts` — performs an authenticated fetch and returns a `blob:` URL, since the attachment endpoint requires a Bearer token that the browser can't send for plain `<img src>`
- `ImageAttachmentPreview` component handles three states:
  - **Loading**: animated skeleton placeholder (`w-48 h-32`)
  - **Success**: `<img>` with `max-h-64` constraint; clicking the image triggers download
  - **Error**: falls back gracefully to the existing download button UI
- Non-image attachments are unchanged (file clip-icon button)
- Blob URLs are revoked in the `useEffect` cleanup to prevent memory leaks

## Test plan
- [ ] Send an image (PNG/JPG/GIF/WebP) as an attachment — verify it appears inline
- [ ] Send a non-image file (PDF, ZIP) — verify it still shows the download button
- [ ] Click the inline image — verify it downloads the file
- [ ] Test with the backend offline after loading to confirm error fallback shows the download button
- [ ] Send multiple attachments mixing image and non-image — verify each renders correctly
- [ ] Verify blob URLs are cleaned up (no memory leak on room switch)

Closes #249