### PR TITLE
fix: hide and revoke access to attachments on recalled messages (#273)

### DIFF
--- a/backend/src/repositories/attachmentRepository.ts
+++ b/backend/src/repositories/attachmentRepository.ts
@@ -13,7 +13,10 @@ export class AttachmentRepository {
 
   async findById(attachmentId: string): Promise<any> {
     const res = await this.pool.query(
-      'SELECT * FROM attachments WHERE attachment_id = $1',
+      `SELECT a.*, m.is_recalled AS message_is_recalled
+       FROM attachments a
+       LEFT JOIN messages m ON m.message_id = a.message_id
+       WHERE a.attachment_id = $1`,
       [attachmentId]
     );
     return res.rows[0] || null;

--- a/backend/src/repositories/messageRepository.ts
+++ b/backend/src/repositories/messageRepository.ts
@@ -25,7 +25,7 @@ function mapRowToMessage(row: any): Message {
     isRecalled: row.is_recalled,
     sentAt: row.sent_at,
   };
-  if (row.attachments && row.attachments.length > 0) {
+  if (!row.is_recalled && row.attachments && row.attachments.length > 0) {
     msg.attachments = row.attachments.filter(Boolean);
   }
   return msg;

--- a/backend/src/services/attachmentService.ts
+++ b/backend/src/services/attachmentService.ts
@@ -44,7 +44,7 @@ export function makeAttachmentService(attachmentRepo: AttachmentRepository) {
     },
     async getAttachment(attachmentId: string) {
       const attachment = await attachmentRepo.findById(attachmentId);
-      if (!attachment) {
+      if (!attachment || attachment.message_is_recalled === true) {
         return null;
       }
       return attachment;

--- a/backend/tests/e2e/routes/attachment.e2e.test.ts
+++ b/backend/tests/e2e/routes/attachment.e2e.test.ts
@@ -90,4 +90,28 @@ describe('Attachment E2E', () => {
 
     expect(getRes.status).toBe(404);
   });
+
+  it('should return 404 for an attachment whose message has been recalled', async () => {
+    const uploadRes = await request(app)
+      .post('/api/v1/attachments')
+      .set('Authorization', `Bearer ${token}`)
+      .attach('file', Buffer.from('dummy file content'), 'test.txt');
+
+    const attachmentId = uploadRes.body.attachmentId;
+
+    await testPool.query(
+      'UPDATE attachments SET message_id = $1 WHERE attachment_id = $2',
+      [messageId, attachmentId],
+    );
+    await testPool.query(
+      'UPDATE messages SET is_recalled = true WHERE message_id = $1',
+      [messageId],
+    );
+
+    const getRes = await request(app)
+      .get(`/api/v1/attachments/${attachmentId}`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(getRes.status).toBe(404);
+  });
 });

--- a/backend/tests/integration/repositories/messageRepository.int.test.ts
+++ b/backend/tests/integration/repositories/messageRepository.int.test.ts
@@ -180,4 +180,32 @@ describe('MessageRepository (pg)', () => {
     const missing = await repo.findById('00000000-0000-0000-0000-000000000000');
     expect(missing).toBeNull();
   });
+
+  it('markRecalled hides attachments from the recalled message and future fetches', async () => {
+    const senderId = await createUser('recall-attachment-sender@test.com');
+    const roomId = await createRoom();
+    const attachmentRes = await testPool.query(
+      `INSERT INTO attachments (uploaded_by, file_path, file_type, original_name)
+       VALUES ($1, $2, $3, $4)
+       RETURNING attachment_id`,
+      [senderId, 'uploads/recall-test.txt', 'text/plain', 'recall-test.txt'],
+    );
+    const attachmentId = attachmentRes.rows[0].attachment_id as string;
+
+    const created = await repo.create({
+      roomId,
+      senderId,
+      content: 'recall me with an attachment',
+      attachmentIds: [attachmentId],
+    });
+    expect(created.attachments).toHaveLength(1);
+
+    const recalled = await repo.markRecalled(created.messageId);
+    expect(recalled.isRecalled).toBe(true);
+    expect(recalled.attachments).toBeUndefined();
+
+    const messages = await repo.findByRoom(roomId, { limit: 10 });
+    expect(messages[0].isRecalled).toBe(true);
+    expect(messages[0].attachments).toBeUndefined();
+  });
 });

--- a/backend/tests/unit/services/attachmentService.test.ts
+++ b/backend/tests/unit/services/attachmentService.test.ts
@@ -34,4 +34,42 @@ describe('AttachmentService', () => {
       }),
     );
   });
+
+  it('getAttachment returns null when the parent message has been recalled', async () => {
+    attachmentRepo.findById.mockResolvedValue({
+      attachment_id: 'att-1',
+      message_id: 'msg-1',
+      message_is_recalled: true,
+    });
+
+    await expect(service.getAttachment('att-1')).resolves.toBeNull();
+  });
+
+  it('getAttachment returns the attachment when the parent message has not been recalled', async () => {
+    const attachment = {
+      attachment_id: 'att-1',
+      message_id: 'msg-1',
+      message_is_recalled: false,
+    };
+    attachmentRepo.findById.mockResolvedValue(attachment);
+
+    await expect(service.getAttachment('att-1')).resolves.toEqual(attachment);
+  });
+
+  it('getAttachment returns the attachment when it is not yet linked to any message', async () => {
+    const attachment = {
+      attachment_id: 'att-1',
+      message_id: null,
+      message_is_recalled: null,
+    };
+    attachmentRepo.findById.mockResolvedValue(attachment);
+
+    await expect(service.getAttachment('att-1')).resolves.toEqual(attachment);
+  });
+
+  it('getAttachment returns null when the attachment does not exist', async () => {
+    attachmentRepo.findById.mockResolvedValue(null);
+
+    await expect(service.getAttachment('missing')).resolves.toBeNull();
+  });
 });

--- a/frontend/src/components/ui/ChatBubble.tsx
+++ b/frontend/src/components/ui/ChatBubble.tsx
@@ -277,7 +277,7 @@ export function ChatBubble({
               {isRecalled ? t("chatroom.messageRecalled") : renderMentionContent(content, isOutgoing, isHighEmphasis, searchHighlight)}
             </div>
 
-            {attachments.length > 0 && (
+            {!isRecalled && attachments.length > 0 && (
               <div className="flex flex-col gap-1.5 mt-1 border-t border-border-secondary/40 pt-2">
                 {attachments.map((file, idx) => {
                   const fileContent = (

--- a/frontend/src/context/ChatContext.tsx
+++ b/frontend/src/context/ChatContext.tsx
@@ -1038,7 +1038,9 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
       setMessages((current) =>
         hydrateReplyTargets(
           current.map((message) =>
-            message.id === messageId ? { ...message, isRecalled: true, content: "" } : message,
+            message.id === messageId
+              ? { ...message, isRecalled: true, content: "", attachments: [] }
+              : message,
           ),
         ),
       );


### PR DESCRIPTION
Closes #273

## Root cause

Recalling a message with an attachment only cleared the text; the attachment kept showing and stayed permanently downloadable. This was a three-layer gap:

1. `backend/src/repositories/messageRepository.ts` (`mapRowToMessage`) always attached attachment metadata to a message row regardless of `is_recalled`, so every REST/history fetch (`findByRoom`, `markRecalled`'s own return value, etc.) kept serving attachment URLs for recalled messages forever.
2. `GET /api/v1/attachments/:id` (`attachmentController.download` -> `attachmentService.getAttachment` -> `attachmentRepository.findById`) never checked whether the parent message had been recalled, so the raw file bytes stayed downloadable indefinitely via the direct URL even after recall.
3. On the frontend, the realtime `message_recalled` handler in `ChatContext.tsx` cleared `content` but not `attachments`, and `ChatBubble.tsx` rendered the attachment list with no `isRecalled` check at all (unlike the text content, which already branches on `isRecalled` a few lines above).

## What changed and why

- `backend/src/repositories/messageRepository.ts`: `mapRowToMessage` no longer populates `attachments` when `is_recalled` is true. This single change covers every read path uniformly (all message fetches funnel through this function).
- `backend/src/repositories/attachmentRepository.ts`: `findById` now `LEFT JOIN`s `messages` and returns `message_is_recalled` alongside the row.
- `backend/src/services/attachmentService.ts`: `getAttachment` treats a recalled parent message as "not found" (returns `null`, which the controller already maps to a 404), closing the direct-download loophole. Attachments not yet linked to a message (`message_id IS NULL`, mid-upload-before-send) are explicitly left downloadable — the check is a strict `=== true`, not a falsy check, so `null`/`undefined` never gets treated as recalled.
- `frontend/src/context/ChatContext.tsx`: the `message_recalled` socket handler now also clears `attachments: []` locally, matching how `content` is already cleared, so a realtime recall (no page refresh) immediately hides the attachment block.
- `frontend/src/components/ui/ChatBubble.tsx`: the attachment list is now gated on `!isRecalled`, mirroring the existing `isRecalled` branch used for `content`. This is defense-in-depth on top of the backend fix.

Not in scope (flagged but intentionally not touched): the attachment download endpoint has no room-membership/authorization check at all (pre-existing, separate issue), and the room list's last-message preview can still show raw recalled text since it reads a separate `room_last_message_view` that isn't touched by this fix (pre-existing, separate, and does not affect attachments since that view already hardcodes `attachments: []` on the frontend side).

## Test plan

- Added `backend/tests/integration/repositories/messageRepository.int.test.ts`: create a message with an attachment, recall it, assert the attachment is absent from the recalled message and from subsequent `findByRoom` fetches.
- Added `backend/tests/unit/services/attachmentService.test.ts` cases: `getAttachment` returns `null` when the parent message is recalled, returns the attachment when not recalled, and still returns attachments that aren't linked to any message yet (upload-before-send).
- Added `backend/tests/e2e/routes/attachment.e2e.test.ts` case: download returns 404 once the owning message is recalled.
- Ran locally: `pnpm run test:unit` (384/384 passing, including the new attachment service tests), `pnpm exec tsc --noEmit` on both backend and frontend (clean), and frontend `pnpm run lint` (0 errors, only 3 pre-existing/unrelated warnings).
- Not run locally: `pnpm run test:integration` and `pnpm run test:e2e` require the Docker Postgres test stack (`DATABASE_URL_TEST` via `db-test`), which isn't available in this environment. A reviewer should run these in the Docker test environment to execute the new integration and e2e tests before merging.

## Advisor notes (opus architect review, before implementation)

- Confirmed the root-cause analysis was complete: all message-with-attachment read paths funnel through the single `fetchMessageWithSenderByIds` -> `mapRowToMessage` chokepoint, so the fix covers them uniformly; there's no optimistic-recall path to worry about since recall only emits a socket event with no local state mutation before the server ack.
- Endorsed keeping the download-endpoint fix rather than treating this purely as a UI bug like `content`: a leaked attachment is a live, permanently downloadable file URL, which is a materially different risk than leaked text.
- Endorsed filter-on-read over deleting/unlinking attachments on recall: no migration needed, keeps the DB as source of truth, and is forward-compatible if an "un-recall" feature is ever added.
- Flagged the critical implementation detail: attachments not yet linked to a message (`message_id IS NULL`) must remain downloadable, so the recalled-check must be a strict `=== true`, never a falsy check on `NULL`/`undefined`.
- Endorsed the repository-does-the-JOIN / service-decides-the-policy split as matching this codebase's existing Repository -> Service -> Controller layering.
- Flagged two pre-existing, out-of-scope items for awareness (not fixed here): the attachment download endpoint has no room-membership check at all, and the room list's last-message preview can still surface raw recalled text (unrelated to attachments).

Generated with Claude Code (https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019K3jorpjcn9q5DMz1ABMWr)_