### PR TITLE
fix: 支援長按觸控開啟訊息操作選單 (#297)

### DIFF
--- a/frontend/src/components/ui/ChatBubble.tsx
+++ b/frontend/src/components/ui/ChatBubble.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useTranslation } from "@/hooks/useTranslation";
 import { cn } from "@/lib/utils";
 import { Avatar } from "./Avatar";
@@ -214,18 +214,78 @@ export function ChatBubble({
   const { activeProfilePopover, setActiveProfilePopover } = useChat();
   const showPopover = messageId ? activeProfilePopover?.instanceId === messageId : false;
 
+  const menuOpenedAtRef = useRef(0);
+  const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const touchStartPosRef = useRef<{ x: number; y: number } | null>(null);
+  const longPressTriggeredRef = useRef(false);
+
   useEffect(() => {
     if (!menuPosition) return;
-    const close = () => setMenuPosition(null);
-    window.addEventListener("click", close);
-    window.addEventListener("keydown", close);
-    window.addEventListener("scroll", close, true);
+    // Mobile browsers fire a synthetic "click" shortly after the touchend that
+    // triggered a long-press open; ignore clicks right after opening so the
+    // menu doesn't close itself immediately.
+    const closeOnClick = () => {
+      if (Date.now() - menuOpenedAtRef.current < 300) return;
+      setMenuPosition(null);
+    };
+    const closeImmediately = () => setMenuPosition(null);
+    window.addEventListener("click", closeOnClick);
+    window.addEventListener("keydown", closeImmediately);
+    window.addEventListener("scroll", closeImmediately, true);
     return () => {
-      window.removeEventListener("click", close);
-      window.removeEventListener("keydown", close);
-      window.removeEventListener("scroll", close, true);
+      window.removeEventListener("click", closeOnClick);
+      window.removeEventListener("keydown", closeImmediately);
+      window.removeEventListener("scroll", closeImmediately, true);
     };
   }, [menuPosition]);
+
+  useEffect(() => {
+    return () => {
+      if (longPressTimerRef.current) clearTimeout(longPressTimerRef.current);
+    };
+  }, []);
+
+  const openMenuAt = (x: number, y: number) => {
+    const menuWidth = 160;
+    const menuHeight = 170;
+    const clampedX = Math.min(Math.max(x, 8), window.innerWidth - menuWidth - 8);
+    const clampedY = Math.min(Math.max(y, 8), window.innerHeight - menuHeight - 8);
+    menuOpenedAtRef.current = Date.now();
+    setMenuPosition({ x: clampedX, y: clampedY });
+  };
+
+  const clearLongPressTimer = () => {
+    if (longPressTimerRef.current) {
+      clearTimeout(longPressTimerRef.current);
+      longPressTimerRef.current = null;
+    }
+  };
+
+  const handleTouchStart = (event: React.TouchEvent) => {
+    if (isRecalled) return;
+    const touch = event.touches[0];
+    touchStartPosRef.current = { x: touch.clientX, y: touch.clientY };
+    longPressTriggeredRef.current = false;
+    clearLongPressTimer();
+    longPressTimerRef.current = setTimeout(() => {
+      longPressTriggeredRef.current = true;
+      openMenuAt(touch.clientX, touch.clientY);
+    }, 500);
+  };
+
+  const handleTouchMove = (event: React.TouchEvent) => {
+    if (!touchStartPosRef.current) return;
+    const touch = event.touches[0];
+    const dx = touch.clientX - touchStartPosRef.current.x;
+    const dy = touch.clientY - touchStartPosRef.current.y;
+    if (Math.hypot(dx, dy) > 10) {
+      clearLongPressTimer();
+    }
+  };
+
+  const handleTouchEnd = () => {
+    clearLongPressTimer();
+  };
 
   const handleTogglePopover = (event: React.MouseEvent) => {
     if (!senderId) {
@@ -344,12 +404,21 @@ export function ChatBubble({
           <div
             onContextMenu={(event) => {
               event.preventDefault();
-              if (!isRecalled) {
-                setMenuPosition({ x: event.clientX, y: event.clientY });
+              if (isRecalled) return;
+              // Some Android browsers also fire contextmenu after a long-press;
+              // skip it so it doesn't reposition the menu we already opened.
+              if (longPressTriggeredRef.current) {
+                longPressTriggeredRef.current = false;
+                return;
               }
+              openMenuAt(event.clientX, event.clientY);
             }}
+            onTouchStart={handleTouchStart}
+            onTouchMove={handleTouchMove}
+            onTouchEnd={handleTouchEnd}
+            onTouchCancel={handleTouchEnd}
             className={cn(
-              "border rounded-sm p-3 relative flex flex-col gap-2 max-w-md md:max-w-lg",
+              "border rounded-sm p-3 relative flex flex-col gap-2 max-w-md md:max-w-lg touch-pan-y",
               isOutgoing
                 ? isHighEmphasis
                   ? "bg-primary border-primary text-white"


### PR DESCRIPTION
Closes #297

## 根因分析 (Root Cause)

`frontend/src/components/ui/ChatBubble.tsx` 中，訊息氣泡的回覆/編輯/收回選單唯一的開啟方式是滑鼠右鍵 `onContextMenu`。但 `contextmenu` 事件在觸控裝置上的行為並不可靠：多數 Android 瀏覽器對長按行為不一致，而 iOS Safari 對一般 `div` 元素基本上完全不會觸發此事件。因此純觸控裝置（手機、平板）使用者完全無法叫出這個選單，也就無法回覆、編輯或收回訊息。

搜尋過整個 `frontend/src`，確認除了 `onContextMenu` 之外，沒有任何長按或觸控事件的替代開啟方式。

## 修改內容 (What Changed)

在同一個訊息氣泡的 `div` 上新增觸控長按偵測，與既有的右鍵選單並存、互不影響：

1. **長按偵測**：`onTouchStart` 啟動一個 500ms 計時器；若計時器觸發前手指移動超過 10px（視為捲動手勢），或手指提早放開/取消，則清除計時器不觸發選單。計時器觸發時以觸控座標開啟選單。
2. **合成點擊 (ghost click) 防護**：手機瀏覽器在 `touchend` 之後常會補發一個 `click` 事件；由於既有的 `useEffect` 會在 `menuPosition` 存在時對 `window` 監聽 `click` 以便點外部關閉選單，這個補發的合成點擊原本會讓剛長按開啟的選單立刻自動關閉。修正方式是記錄選單開啟的時間戳記，並讓 `click` 關閉邏輯忽略開啟後 300ms 內收到的點擊；`keydown`／`scroll` 關閉邏輯維持原樣立即生效。
3. **Android 雙重觸發防護**：部分 Android 瀏覽器在長按後仍會額外觸發 `contextmenu`；加入旗標讓長按觸發後的下一次 `contextmenu` 直接略過，避免選單被重新定位而閃爍。
4. **選單邊界夾取**：新增 `openMenuAt` 對選單座標依視窗寬高做夾取，避免在手機螢幕邊緣長按時選單被裁到畫面外看不到（桌面右鍵開啟也一併受益）。
5. `touch-pan-y` class：告知瀏覽器此元素允許垂直捲動手勢，降低長按偵測與訊息列表滾動之間的手勢衝突。

未變動 `onContextMenu`（桌面右鍵）原有行為，也未新增任何依賴、新增 i18n 字串或修改後端。

## 測試計畫 (Test Plan)

- 本專案前端目前沒有設定任何測試執行器（`frontend/package.json` 僅有 `dev`/`build`/`start`/`lint` script，且 `frontend/src` 下沒有任何 `*.test.*` 檔案），因此無法為此變更加入自動化前端測試。
- 已在此環境中執行並全數通過：
  - `npx tsc --noEmit`（型別檢查）
  - `npx eslint src/components/ui/ChatBubble.tsx`（僅有一個與本次修改無關、既有的 `no-img-element` 警告）
  - `npm run build`（Next.js production build 成功）
- 由於此環境沒有實體觸控裝置或瀏覽器可供互動測試，建議 reviewer 在實機或瀏覽器 DevTools 的裝置模擬模式下，於手機/平板驗證：長按訊息氣泡可叫出選單、快速滑動不會誤觸發、選單在螢幕邊緣長按時不會超出畫面、桌面右鍵行為維持不變。

## 顧問意見重點 (Advisor Notes)

在實作前請一位以 opus model 執行的 architect 顧問 agent 審視了根因分析與修復計畫，主要意見如下：
- 原計畫用 `touchend` 呼叫 `preventDefault()` 抑制合成點擊的作法較不穩健，建議改用「開啟時間戳記 + 300ms 內忽略 click」的方式，已採納。
- 部分 Android 瀏覽器長按後仍可能觸發 `contextmenu`，建議加上防護避免選單重新定位造成閃爍，已採納。
- 選單目前的固定座標在手機邊緣長按時容易被裁到畫面外，建議加入視窗邊界夾取，已採納。
- `touch-action: pan-y` 有助於降低長按手勢與捲動手勢的衝突，值得加入，已採納。
- 500ms 長按時間、10px 移動容忍度、以及以行內方式實作（不額外抽出共用 hook）皆判斷為合理，維持原計畫。

Generated with Claude Code (https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QCbNgyEaF5HpEPzk2woDgo)_