### PR TITLE
fix: 上傳可預覽附件時不再產生自動說明文字 (#301)

### DIFF
--- a/backend/src/validators/messageSchemas.ts
+++ b/backend/src/validators/messageSchemas.ts
@@ -2,12 +2,17 @@ import { z } from 'zod';
 
 const idSchema = z.string().trim().min(1, 'Id cannot be empty');
 
-export const sendMessageSchema = z.object({
-  roomId: idSchema,
-  content: z.string().trim().min(1, 'Message content cannot be empty'),
-  replyToId: idSchema.optional(),
-  attachmentIds: z.array(z.string().uuid()).optional(),
-});
+export const sendMessageSchema = z
+  .object({
+    roomId: idSchema,
+    content: z.string().trim(),
+    replyToId: idSchema.optional(),
+    attachmentIds: z.array(z.string().uuid()).optional(),
+  })
+  .refine((data) => data.content.length > 0 || (data.attachmentIds?.length ?? 0) > 0, {
+    message: 'Message content cannot be empty',
+    path: ['content'],
+  });
 
 export const listMessagesSchema = z.object({
   roomId: idSchema,

--- a/backend/tests/unit/services/messageService.test.ts
+++ b/backend/tests/unit/services/messageService.test.ts
@@ -254,6 +254,22 @@ describe('messageService', () => {
     });
   });
 
+  it('sendMessage allows empty content when attachmentIds are provided', async () => {
+    const attachmentId = '550e8400-e29b-41d4-a716-446655440000';
+    roomRepo.findById.mockResolvedValue(room);
+    roomMemberRepo.findMember.mockResolvedValue(member);
+    messageRepo.create.mockResolvedValue({ ...messageWithSender, content: '' });
+
+    await messageService.sendMessage('user-1', 'room-1', '', { attachmentIds: [attachmentId] });
+
+    expect(messageRepo.create).toHaveBeenCalledWith({
+      roomId: 'room-1',
+      senderId: 'user-1',
+      content: '',
+      attachmentIds: [attachmentId],
+    });
+  });
+
   it('listForRoom applies join time when room history is hidden', async () => {
     const hiddenHistoryRoom = { ...room, viewHistory: false };
     roomRepo.findById.mockResolvedValue(hiddenHistoryRoom);

--- a/backend/tests/unit/validators/messageSchemas.test.ts
+++ b/backend/tests/unit/validators/messageSchemas.test.ts
@@ -20,6 +20,20 @@ describe('message validation schemas', () => {
     expect(sendMessageSchema.safeParse({ roomId: '', content: 'hello' }).success).toBe(false);
   });
 
+  it('allows empty content when attachments are provided, but not without them', () => {
+    expect(sendMessageSchema.safeParse({
+      roomId: 'room-1',
+      content: '',
+      attachmentIds: ['550e8400-e29b-41d4-a716-446655440000'],
+    }).success).toBe(true);
+    expect(sendMessageSchema.safeParse({
+      roomId: 'room-1',
+      content: '   ',
+      attachmentIds: [],
+    }).success).toBe(false);
+    expect(sendMessageSchema.safeParse({ roomId: 'room-1', content: '' }).success).toBe(false);
+  });
+
   it('validates list messages payloads and bounds limit', () => {
     expect(listMessagesSchema.parse({ roomId: 'room-1' })).toEqual({
       roomId: 'room-1',

--- a/frontend/src/components/chat/Chatroom.tsx
+++ b/frontend/src/components/chat/Chatroom.tsx
@@ -778,7 +778,9 @@ export default function Chatroom({ roomId, onOpenGroupSettings }: ChatroomProps)
         <div className="bg-surface-muted border-t border-border-primary px-3 md:px-6 py-2 flex items-center justify-between text-xs select-none">
           <div className="flex-1 min-w-0 border-l-2 border-primary pl-2">
             <span className="font-bold text-foreground block">{t("chatroom.replyTo", { name: activeRoom.members?.find((m) => m.userId === replyTarget.senderId)?.nickname || replyTarget.senderName })}</span>
-            <p className="text-text-muted truncate mt-0.5">{replyTarget.content}</p>
+            <p className="text-text-muted truncate mt-0.5">
+              {replyTarget.content || replyTarget.attachments?.[0]?.filename}
+            </p>
           </div>
           <button
             onClick={() => setReplyTarget(null)}

--- a/frontend/src/components/ui/ChatBubble.tsx
+++ b/frontend/src/components/ui/ChatBubble.tsx
@@ -371,17 +371,24 @@ export function ChatBubble({
               </div>
             )}
 
-            <div
-              className={cn(
-                "text-sm break-words whitespace-pre-wrap",
-                isRecalled && "italic text-text-muted/70",
-              )}
-            >
-              {isRecalled ? t("chatroom.messageRecalled") : renderMentionContent(content, isOutgoing, isHighEmphasis, searchHighlight)}
-            </div>
+            {(isRecalled || content) && (
+              <div
+                className={cn(
+                  "text-sm break-words whitespace-pre-wrap",
+                  isRecalled && "italic text-text-muted/70",
+                )}
+              >
+                {isRecalled ? t("chatroom.messageRecalled") : renderMentionContent(content, isOutgoing, isHighEmphasis, searchHighlight)}
+              </div>
+            )}
 
             {!isRecalled && attachments.length > 0 && (
-              <div className="flex flex-col gap-1.5 mt-1 border-t border-border-secondary/40 pt-2">
+              <div
+                className={cn(
+                  "flex flex-col gap-1.5",
+                  content && "mt-1 border-t border-border-secondary/40 pt-2",
+                )}
+              >
                 {attachments.map((file, idx) => {
                   const isImage = file.filetype?.startsWith("image/");
 

--- a/frontend/src/context/ChatContext.tsx
+++ b/frontend/src/context/ChatContext.tsx
@@ -435,7 +435,9 @@ const hydrateReplyTargets = (items: Message[]): Message[] => {
 
     const nextReplyTo = {
       senderName: replyTarget.senderName,
-      content: replyTarget.isRecalled ? "" : replyTarget.content,
+      content: replyTarget.isRecalled
+        ? ""
+        : replyTarget.content || replyTarget.attachments?.[0]?.filename || "",
     };
 
     if (
@@ -529,13 +531,6 @@ const mapFolders = (apiFolders: ApiFolder[], currentFolders: Folder[]): Folder[]
 
 const normalizeLanguage = (language?: string): UiLanguage =>
   language === "zh-TW" || language === "en" ? language : "en";
-
-const formatUploadedAttachmentsMessage = (language: UiLanguage, fileNames: string[]) => {
-  if (fileNames.length === 1) {
-    return language === "zh-TW" ? `已上傳附件：${fileNames[0]}` : `Shared attachment: ${fileNames[0]}`;
-  }
-  return language === "zh-TW" ? `已上傳了 ${fileNames.length} 個附件` : `Shared ${fileNames.length} attachments`;
-};
 
 const mapFriend = (item: FriendResponse, emergencyContactIds: Set<string>): Friend => ({
   id: item.friend.userId,
@@ -1309,10 +1304,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
     );
     const attachmentIds = uploadedResults.map((res) => res.attachmentId);
 
-    const fileNames = files.map((file) => file.name);
-    const content = options?.content?.trim()
-      ? options.content.trim()
-      : formatUploadedAttachmentsMessage(uiLanguage, fileNames);
+    const content = options?.content?.trim() ?? "";
 
     sendMessage(socketRef.current, {
       roomId,


### PR DESCRIPTION
Closes #301

## 根因分析 (Root Cause)

上傳附件（圖片、檔案等）時，若使用者沒有輸入任何文字，`frontend/src/context/ChatContext.tsx` 的 `handleUploadAttachments` 會呼叫 `formatUploadedAttachmentsMessage` 自動產生一段預設說明文字（例如「已上傳附件：IMG_7863.png」）並當作訊息內容送出。由於聊天畫面本來就會直接渲染附件的預覽縮圖，這段自動產生的文字因此顯得重複、累贅。

另外，後端 `backend/src/validators/messageSchemas.ts` 的 `sendMessageSchema` 原本強制要求 `content` 不能為空字串，這也是前端必須生成這段替代文字的直接原因——如果不生成，空字串會被後端拒絕。

## 修改內容 (What Changed)

1. **後端驗證放寬** (`backend/src/validators/messageSchemas.ts`)：將 `content` 的 `.min(1)` 限制改為物件層級的 `.refine()`：只要 `attachmentIds` 有值且不為空，`content` 就可以是空字串；沒有附件時仍必須有非空內容。`updateMessage`（編輯訊息）從不傳入 `attachmentIds`，因此編輯訊息為空內容時的行為完全不受影響，維持原本會被拒絕的行為。
2. **前端上傳邏輯調整** (`frontend/src/context/ChatContext.tsx`)：`handleUploadAttachments` 不再於使用者未輸入文字時呼叫 `formatUploadedAttachmentsMessage` 產生預設文字，改為直接送出空字串；已移除的 `formatUploadedAttachmentsMessage` 函式除此處外沒有其他呼叫端，也未被任何語系檔引用，可安全刪除。
3. **訊息氣泡渲染調整** (`frontend/src/components/ui/ChatBubble.tsx`)：當訊息沒有文字內容且非收回狀態時，不渲染存放文字的 `div`；同時讓附件容器原本固定的 `mt-1 border-t pt-2`（用來與上方文字分隔的邊界線與留白）只在有文字內容時才套用，避免內容為空時，附件預覽上方仍留下一條分隔線與多餘留白。
4. **回覆預覽補上檔名備援**：因為附件訊息的 `content` 現在可能為空字串，「回覆某則訊息」的兩個預覽位置——`ChatContext.tsx` 的 `hydrateReplyTargets`（氣泡內的引用預覽）與 `Chatroom.tsx` 輸入框上方的回覆橫幅——都補上 `content || attachments?.[0]?.filename` 的備援邏輯，避免回覆一則「純附件訊息」時顯示空白行。這個備援模式與既有的聊天室列表最後訊息預覽 (`summarizeMessagePreview`) 邏輯一致，該函式本來就已經會 fallback 到檔名，因此聊天室列表預覽不需要額外修改。

## 已知的次要影響 (Known Trade-off)

聊天室內的訊息搜尋（`Chatroom.tsx` 的 `msgSearchQuery` 過濾邏輯）目前僅比對 `content` 欄位。純附件訊息的 `content` 變成空字串後，將不再能透過搜尋比對到原本包含在自動說明文字中的檔名。這是本次修正範圍之外的既有搜尋邏輯限制，考量到 issue 提出的修改範圍與影響面，未一併擴大處理，留給後續 issue 決定是否需要讓搜尋也涵蓋附件檔名。

## 測試計畫 (Test Plan)

- 後端：已在本環境執行並全數通過
  - `npx vitest run tests/unit`（全部 27 個測試檔、379 個測試皆通過，含新增的 `messageSchemas.test.ts`、`messageService.test.ts` 案例）
  - `npx tsc --noEmit`（後端型別檢查通過）
  - 新增測試涵蓋：「有附件時允許空白 content」「無附件時空白 content 仍被拒絕」「`attachmentIds: []` 視同無附件，仍會被拒絕」
  - 本專案的整合測試與 E2E 測試（`test:integration`、`test:e2e`）需要透過 Docker 啟動測試用資料庫（`DATABASE_URL_TEST`），此環境無法執行 Docker，因此**未執行**，需由 reviewer 於本機或 CI 的 Docker 測試環境中執行確認。
- 前端：已在本環境執行並全數通過
  - `npx tsc --noEmit`（型別檢查）
  - `npx eslint`（僅有既有、與本次修改無關的警告，無新增錯誤）
  - 啟動 `next dev` 開發伺服器確認 `/login` 等頁面可正常編譯、無執行期錯誤
  - 前端目前沒有設定任何測試執行器（`frontend/package.json` 僅有 `dev`/`build`/`start`/`lint` script，`frontend/src` 下沒有任何 `*.test.*` 檔案），因此無法為前端變更加入自動化測試；建議 reviewer 於瀏覽器中手動驗證：上傳圖片/檔案且不輸入文字時，訊息氣泡只顯示附件預覽、沒有多餘的空白文字列或分隔線；回覆一則純附件訊息時，回覆預覽會顯示檔名而非空白。

## 顧問意見重點 (Advisor Notes)

實作前請一位以 opus model 執行的 architect 顧問 agent 審視了根因分析與修復計畫，主要意見如下：

- 後端 `.refine()` 寫法正確、慣用，`path: ['content']` 能正確附加到 `content` 欄位上的錯誤訊息；確認了「空 content + 空 `attachmentIds` 陣列」及「完全不傳 `attachmentIds`」兩種情境都仍會被正確拒絕，無法被繞過送出真正的空白訊息。
- 移除 `formatUploadedAttachmentsMessage` 是安全的：該函式僅在此處被呼叫，也沒有對應的語系檔字串需要一併清理。
- 原始草案僅調整文字 `div` 的渲染條件並不足夠——附件容器本身固定帶有 `mt-1 border-t pt-2` 分隔線樣式，內容為空時仍會在畫面最上方留下一條多餘的分隔線與留白，已依建議一併改為依內容是否存在而條件套用。
- 指出「回覆一則純附件訊息」在兩個回覆預覽渲染位置都會顯示空白行的問題，已依建議加上檔名備援，做法與既有的 `summarizeMessagePreview` 邏輯保持一致。
- 指出「編輯純附件訊息」時輸入框會被預填空字串，若使用者直接按下 Enter 會因既有的空白輸入防呆邏輯而無回應；但確認畫面上本來就有明確的「取消」按鈕與 Escape 鍵可離開編輯模式，並非真正卡死，因此判斷為可接受的次要邊界情況，未在本次修改中一併處理。
- 指出訊息搜尋僅比對 `content` 欄位，純附件訊息的 `content` 變空後將無法再以檔名搜尋到；已於「已知的次要影響」段落中揭露，判斷為超出本次 issue 修改範圍的既有限制，留給後續處理。

Generated with Claude Code (https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LVKNyCU3zPkcBzbeUSfyto)_