### PR TITLE
docs: API 文件與合併變更同步 (週期: 2026-07-06)

### DIFF
--- a/docs/ZH-TW/api-documentation.md
+++ b/docs/ZH-TW/api-documentation.md
@@ -48,7 +48,6 @@
 | **緊急聯絡** | `GET` | [`/users/me/emergency-contacts`](#get-usersmeemergency-contacts) | 需驗證 | 取得緊急聯絡人列表 |
 | | `POST` | [`/users/me/emergency-contacts`](#post-usersmeemergency-contacts) | 需驗證 | 新增或更新緊急聯絡人設定 |
 | | `DELETE` | [`/users/me/emergency-contacts/:contactId`](#delete-usersmeemergency-contactscontactid) | 需驗證 | 刪除緊急聯絡人設定 |
-| | `POST` | [`/users/me/emergency-alert`](#post-usersmeemergency-alert) | 需驗證 | 立即向所有緊急聯絡人發送警報 |
 | | `POST` | [`/users/me/emergency-alert/check-inactivity`](#post-usersmeemergency-alertcheck-inactivity) | 需驗證 | 檢查不活躍狀態以判定是否發送警報 |
 
 ### Socket.io 即時通訊
@@ -1313,24 +1312,6 @@ NEXT_PUBLIC_API_URL=http://localhost:4005
     "success": true
   }
   ```
-
----
-
-#### `POST /users/me/emergency-alert`
-- **說明**: 立即手動觸發緊急警報，並向設定的所有緊急聯絡人發送警報訊息。
-- **驗證與權限**: 需驗證。
-- **請求主體**:
-  | 欄位 | 型別 | 必填 | 說明 |
-  | :--- | :--- | :---: | :--- |
-  | `message` | 字串 | 否 | 用於覆蓋預設警報的自訂訊息內容 |
-- **請求範例**:
-  ```json
-  {
-    "message": "This is a manually triggered instant emergency alert!"
-  }
-  ```
-- **回應**:
-  - `202 Accepted`: 警報發送請求已被接受，於背景處理。
 
 ---
 

--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -48,7 +48,6 @@ This document defines the RESTful API and Socket.IO real-time communication inte
 | **Emergency Contacts** | `GET` | [`/users/me/emergency-contacts`](#get-usersmeemergency-contacts) | Yes | Get emergency contacts list |
 | | `POST` | [`/users/me/emergency-contacts`](#post-usersmeemergency-contacts) | Yes | Add or update emergency contact |
 | | `DELETE` | [`/users/me/emergency-contacts/:contactId`](#delete-usersmeemergency-contactscontactid) | Yes | Delete emergency contact |
-| | `POST` | [`/users/me/emergency-alert`](#post-usersmeemergency-alert) | Yes | Trigger emergency alert immediately to contacts |
 | | `POST` | [`/users/me/emergency-alert/check-inactivity`](#post-usersmeemergency-alertcheck-inactivity) | Yes | Check inactivity to trigger alert automatically |
 
 ### Socket.IO Real-Time Communication
@@ -1313,24 +1312,6 @@ All errors return the following JSON structure:
     "success": true
   }
   ```
-
----
-
-#### `POST /users/me/emergency-alert`
-- **Description**: Instantly trigger an emergency alert and send a message to all emergency contacts.
-- **Authentication & Authorization**: Authentication required.
-- **Request Body**:
-  | Field | Type | Required | Description |
-  | :--- | :--- | :---: | :--- |
-  | `message` | String | No | Custom message to override the default template |
-- **Request Example**:
-  ```json
-  {
-    "message": "This is a manually triggered instant emergency alert!"
-  }
-  ```
-- **Response**:
-  - `202 Accepted`: Request accepted for processing in the background.
 
 ---
 


### PR DESCRIPTION
## 摘要

本 PR 掃描過去 7 天內合併的拉取請求，找出 API 變更並更新相應文件，確保文件與實現同步。

## 掃描涵蓋的合併 PR

| PR 編號 | 標題 | 合併時間 | 連結 |
| :--- | :--- | :--- | :--- |
| #296 | fix: hide and revoke access to attachments on recalled messages | 2026-07-10 | https://github.com/nearcsie/near-chat/pull/296 |
| #266 | feat(chat): display image attachments inline in chatroom | 2026-07-10 | https://github.com/nearcsie/near-chat/pull/266 |
| #291 | Issue 275 remove demo emergency contact | 2026-07-10 | https://github.com/nearcsie/near-chat/pull/291 |

## 文件變更清單

| 檔案 | 變更說明 | 觸發 PR | 變更類型 |
| :--- | :--- | :--- | :--- |
| docs/api-documentation.md | 移除 `POST /users/me/emergency-alert` 端點文件 | #291 | 移除已刪除的 API 端點 |
| docs/ZH-TW/api-documentation.md | 移除 `POST /users/me/emergency-alert` 端點文件 | #291 | 移除已刪除的 API 端點 |

## 變更詳情

### PR #291: 移除示範緊急聯絡功能

此 PR 移除了手動觸發緊急警報的 API 端點 (`POST /users/me/emergency-alert`) 及相關的示範警告功能 (`demoWarningEnabled`、`demoWarningSeconds`)。

**API 變更:**
- 移除端點: `POST /users/me/emergency-alert` (手動觸發警報)
- 保留端點: `POST /users/me/emergency-alert/check-inactivity` (自動檢查不活躍)

**文件更新:**
- 從 API 概覽表移除已移除的端點
- 從第 G 節「緊急聯絡人」移除 `POST /users/me/emergency-alert` 完整文件

### PR #296 與 #266

這兩個 PR 的變更主要為內部實現修改，不涉及公開 API 簽名變更或需要文件更新的部分。

## 驗證

此掃描已完成下列檢查:
- 識別 7 天內合併的 PR (2026-07-06 至 2026-07-13)
- 檢查各 PR 的差異以找出 API 變更
- 掃描文件檔案以找出過時的參考

Generated with Claude Code (https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01QurnDum6xJve5PK2r19nUT)_