### PR TITLE
feat: 支援附件圖片燈箱預覽與傳送前縮圖 (#302)

### DIFF
--- a/frontend/src/components/chat/Chatroom.tsx
+++ b/frontend/src/components/chat/Chatroom.tsx
@@ -32,6 +32,17 @@ interface MentionCandidate {
   detail: string;
 }
 
+interface PendingAttachment {
+  file: File;
+  previewUrl: string | null;
+}
+
+const revokePendingAttachments = (attachments: PendingAttachment[]) => {
+  attachments.forEach((attachment) => {
+    if (attachment.previewUrl) URL.revokeObjectURL(attachment.previewUrl);
+  });
+};
+
 const EVERYONE_MENTION = "everyone";
 
 const formatFileSize = (bytes: number) => {
@@ -86,7 +97,7 @@ export default function Chatroom({ roomId, onOpenGroupSettings }: ChatroomProps)
   const [editingMessage, setEditingMessage] = useState<Message | null>(null);
   const [isModifyNickOpen, setIsModifyNickOpen] = useState(false);
   const [nickInputValue, setNickInputValue] = useState("");
-  const [pendingAttachments, setPendingAttachments] = useState<File[]>([]);
+  const [pendingAttachments, setPendingAttachments] = useState<PendingAttachment[]>([]);
   const [isUploadingAttachment, setIsUploadingAttachment] = useState(false);
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const [msgSearchQuery, setMsgSearchQuery] = useState("");
@@ -150,6 +161,7 @@ export default function Chatroom({ roomId, onOpenGroupSettings }: ChatroomProps)
     setPrevRoomId(roomId);
     setIsSearchOpen(false);
     setMsgSearchQuery("");
+    revokePendingAttachments(pendingAttachments);
     setPendingAttachments([]);
     setIsUploadingAttachment(false);
     setInputText("");
@@ -298,6 +310,12 @@ export default function Chatroom({ roomId, onOpenGroupSettings }: ChatroomProps)
     }
     setIsMultiLine(inputText.includes("\n") || textarea.scrollHeight > 48);
   }, [inputText]);
+  const pendingAttachmentsRef = useRef(pendingAttachments);
+  pendingAttachmentsRef.current = pendingAttachments;
+  useEffect(() => {
+    return () => revokePendingAttachments(pendingAttachmentsRef.current);
+  }, []);
+
   const handleToggleSearch = () => {
     if (isSearchOpen) {
       setIsSearchOpen(false);
@@ -336,10 +354,12 @@ export default function Chatroom({ roomId, onOpenGroupSettings }: ChatroomProps)
     try {
       if (pendingAttachments.length > 0) {
         setIsUploadingAttachment(true);
-        await handleUploadAttachments(activeRoom.id, pendingAttachments, {
-          content: inputText,
-          replyTarget,
-        });
+        await handleUploadAttachments(
+          activeRoom.id,
+          pendingAttachments.map((p) => p.file),
+          { content: inputText, replyTarget },
+        );
+        revokePendingAttachments(pendingAttachments);
         setPendingAttachments([]);
       } else {
         handleSendMessage(activeRoom.id, inputText, replyTarget);
@@ -364,12 +384,20 @@ export default function Chatroom({ roomId, onOpenGroupSettings }: ChatroomProps)
     const files = event.target.files ? Array.from(event.target.files) : [];
     event.target.value = "";
     if (files.length === 0) return;
-    setPendingAttachments((prev) => [...prev, ...files]);
+    const newAttachments: PendingAttachment[] = files.map((file) => ({
+      file,
+      previewUrl: file.type.startsWith("image/") ? URL.createObjectURL(file) : null,
+    }));
+    setPendingAttachments((prev) => [...prev, ...newAttachments]);
   };
 
   const handleRemovePendingAttachment = (index: number) => {
     if (isUploadingAttachment) return;
-    setPendingAttachments((prev) => prev.filter((_, i) => i !== index));
+    setPendingAttachments((prev) => {
+      const removed = prev[index];
+      if (removed?.previewUrl) URL.revokeObjectURL(removed.previewUrl);
+      return prev.filter((_, i) => i !== index);
+    });
   };
 
   const handleModifyNick = () => {
@@ -829,8 +857,18 @@ export default function Chatroom({ roomId, onOpenGroupSettings }: ChatroomProps)
                   {t("chatroom.attachmentPreview")} ({pendingAttachments.length})
                 </span>
                 <div className="flex flex-col gap-2.5 max-h-40 overflow-y-auto pr-1">
-                  {pendingAttachments.map((file, idx) => (
+                  {pendingAttachments.map(({ file, previewUrl }, idx) => (
                     <div key={idx} className="flex items-center gap-3 text-xs border-l-2 border-primary pl-2.5 py-0.5">
+                      <div className="h-10 w-10 shrink-0 rounded-sm border border-border-secondary bg-surface-card overflow-hidden flex items-center justify-center">
+                        {previewUrl ? (
+                          /* eslint-disable-next-line @next/next/no-img-element */
+                          <img src={previewUrl} alt={file.name} className="h-full w-full object-cover" />
+                        ) : (
+                          <svg className="h-4 w-4 text-text-muted" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2">
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13" />
+                          </svg>
+                        )}
+                      </div>
                       <div className="flex-1 min-w-0">
                         <p className="text-foreground truncate font-semibold">{file.name}</p>
                         <p className="text-text-muted text-[10px] font-mono truncate mt-0.5">

--- a/frontend/src/components/chat/Chatroom.tsx
+++ b/frontend/src/components/chat/Chatroom.tsx
@@ -311,7 +311,9 @@ export default function Chatroom({ roomId, onOpenGroupSettings }: ChatroomProps)
     setIsMultiLine(inputText.includes("\n") || textarea.scrollHeight > 48);
   }, [inputText]);
   const pendingAttachmentsRef = useRef(pendingAttachments);
-  pendingAttachmentsRef.current = pendingAttachments;
+  useEffect(() => {
+    pendingAttachmentsRef.current = pendingAttachments;
+  }, [pendingAttachments]);
   useEffect(() => {
     return () => revokePendingAttachments(pendingAttachmentsRef.current);
   }, []);

--- a/frontend/src/components/ui/ChatBubble.tsx
+++ b/frontend/src/components/ui/ChatBubble.tsx
@@ -87,12 +87,14 @@ function ImageAttachmentPreview({
   isOutgoing,
   isHighEmphasis,
   onDownload,
+  onView,
   isDownloading,
 }: {
   file: Attachment;
   isOutgoing: boolean;
   isHighEmphasis: boolean;
   onDownload: () => void;
+  onView: (blobUrl: string) => void;
   isDownloading: boolean;
 }) {
   const [blobUrl, setBlobUrl] = useState<string | null>(null);
@@ -175,12 +177,82 @@ function ImageAttachmentPreview({
         src={blobUrl}
         alt={file.filename}
         className="max-w-full max-h-64 rounded-sm object-contain cursor-pointer"
-        onClick={onDownload}
-        title="Click to download"
+        onClick={() => onView(blobUrl)}
+        title="Click to view"
       />
       <p className={cn("text-[9px] font-mono truncate", isOutgoing && isHighEmphasis ? "text-white/60" : "text-text-muted")}>
         {file.filename}
       </p>
+    </div>
+  );
+}
+
+function AttachmentLightbox({
+  filename,
+  blobUrl,
+  onClose,
+  onDownload,
+  isDownloading,
+}: {
+  filename: string;
+  blobUrl: string;
+  onClose: () => void;
+  onDownload: () => void;
+  isDownloading: boolean;
+}) {
+  useEffect(() => {
+    document.body.style.overflow = "hidden";
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.body.style.overflow = "unset";
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [onClose]);
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={filename}
+      className="fixed inset-0 z-[120] flex items-center justify-center p-4"
+    >
+      <div className="fixed inset-0 bg-black/80" onClick={onClose} />
+      <button
+        type="button"
+        onClick={onClose}
+        title="Close preview"
+        aria-label="Close preview"
+        className="absolute top-4 right-4 z-10 p-1.5 border border-white/30 text-white hover:bg-white/10 transition-colors cursor-pointer rounded-sm"
+      >
+        <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
+      <div className="relative z-10 flex flex-col items-center gap-3 max-w-full max-h-full" onClick={(event) => event.stopPropagation()}>
+        <img
+          src={blobUrl}
+          alt={filename}
+          className="max-w-full max-h-[80vh] rounded-sm object-contain"
+        />
+        <div className="flex items-center gap-3 max-w-full">
+          <p className="text-white/70 text-xs font-mono truncate">{filename}</p>
+          <button
+            type="button"
+            onClick={onDownload}
+            disabled={isDownloading}
+            title={isDownloading ? "Downloading attachment" : "Download attachment"}
+            aria-label="Download attachment"
+            className="shrink-0 p-1.5 border border-white/30 text-white hover:bg-white/10 transition-colors cursor-pointer rounded-sm disabled:cursor-wait disabled:opacity-70"
+          >
+            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1M7 10l5 5 5-5M12 15V3" />
+            </svg>
+          </button>
+        </div>
+      </div>
     </div>
   );
 }
@@ -210,6 +282,7 @@ export function ChatBubble({
   const [popoverStyle, setPopoverStyle] = useState<React.CSSProperties>({});
   const [downloadingUrl, setDownloadingUrl] = useState<string | null>(null);
   const [downloadError, setDownloadError] = useState("");
+  const [lightboxAttachment, setLightboxAttachment] = useState<{ file: Attachment; blobUrl: string } | null>(null);
 
   const { activeProfilePopover, setActiveProfilePopover } = useChat();
   const showPopover = messageId ? activeProfilePopover?.instanceId === messageId : false;
@@ -354,10 +427,19 @@ export function ChatBubble({
     }
   };
 
+  const handleViewAttachment = (file: Attachment, blobUrl: string) => {
+    if (longPressTriggeredRef.current) {
+      longPressTriggeredRef.current = false;
+      return;
+    }
+    setLightboxAttachment({ file, blobUrl });
+  };
+
   const menuItemClass =
     "w-full px-3 py-2 text-left text-xs hover:bg-surface-muted";
 
   return (
+    <>
     <div
       className={cn(
         "flex gap-2 max-w-[85%] font-sans",
@@ -472,6 +554,7 @@ export function ChatBubble({
                         isOutgoing={isOutgoing}
                         isHighEmphasis={isHighEmphasis}
                         onDownload={() => void handleDownloadAttachment(file)}
+                        onView={(blobUrl) => handleViewAttachment(file, blobUrl)}
                         isDownloading={downloadingUrl === file.url}
                       />
                     );
@@ -597,5 +680,15 @@ export function ChatBubble({
 
       </div>
     </div>
+    {lightboxAttachment && (
+      <AttachmentLightbox
+        filename={lightboxAttachment.file.filename}
+        blobUrl={lightboxAttachment.blobUrl}
+        onClose={() => setLightboxAttachment(null)}
+        onDownload={() => void handleDownloadAttachment(lightboxAttachment.file)}
+        isDownloading={downloadingUrl === lightboxAttachment.file.url}
+      />
+    )}
+    </>
   );
 }


### PR DESCRIPTION
## 變更描述 (Description)

Issue #302 指出附件處理缺少兩項預覽功能：

1. **傳送後預覽 (A)**：聊天室訊息氣泡中的圖片附件已經會顯示縮圖（`ImageAttachmentPreview`），但點擊縮圖目前會直接觸發下載（`onClick={onDownload}`），使用者無法只是「看大圖」而不下載檔案。
2. **上傳前預覽 (B)**：傳送前的 `pendingAttachments` 列表（`Chatroom.tsx` 約第 854-883 行）只顯示檔名、類型與大小的文字列，沒有任何縮圖，使用者無法在傳送前確認選到的圖片內容。

本 PR 依 issue 提出的兩個方向實作：

- **(A) 燈箱預覽**：在 `ChatBubble.tsx` 新增 `AttachmentLightbox` 元件。點擊已傳送的圖片附件縮圖會開啟全螢幕燈箱顯示原圖，燈箱內另外提供「下載」與「關閉」按鈕；點擊背景或按 `Escape` 鍵可關閉燈箱。
- **(B) 傳送前縮圖**：在 `Chatroom.tsx` 中，`pendingAttachments` 的型別由 `File[]` 改為 `{ file: File; previewUrl: string | null }[]`；選取圖片檔案時透過 `URL.createObjectURL` 產生縮圖 URL，並在待傳附件列表中以 40x40 縮圖呈現（非圖片檔案維持原本的檔案圖示）。

沒有變更任何後端程式碼、API 路由或資料庫結構，純粹是前端 UI 變更。

## 相關的 Issue (Related Issue)
Closes #302

## 變更類型 (Type of Change)
- [x] `feat`: 新增功能 (Feature)
- [ ] `fix`: 修復 Bug
- [ ] `refactor`: 重構代碼
- [ ] `docs`: 修改文件
- [ ] `test`: 新增或修正測試案例
- [ ] `chore`: 建置流程或輔助工具變更
- [ ] `perf`: 效能優化
- [ ] `ci`: CI 設定變更

## 驗證與測試計畫 (Verification & Test Plan)

### 本地測試 (Local Tests)
此雲端環境沒有可用的 Docker daemon（`docker ps` 回報無法連線至 socket），因此無法在 `docker compose` 容器內執行下列檢查；已改在本機環境（`frontend/` 目錄，`npm install` 後）直接執行對等指令：

- [x] 前端型別檢查：`npx tsc --noEmit`（通過，無錯誤）
- [x] 前端 production build：`npm run build`（Next.js production build 成功）
- [ ] 前端 Linter 檢查（`npx eslint ...`）：**未能執行** — 本機環境的 `eslint` 執行時對 `zod-validation-error` 套件解析 `exports` 失敗（`ERR_PACKAGE_PATH_NOT_EXPORTED`），已確認此問題在**完全沒有改動的檔案**上也會重現，屬於既有環境問題，與本次改動無關。建議 reviewer 在 Docker 環境中執行 `pnpm run lint` 確認。
- [ ] 後端型別檢查 / 單元測試 / 整合測試：本次未修改任何後端程式碼，不適用。

### 手動測試 (Manual Verification)
此雲端環境沒有可用的 Docker daemon，無法啟動完整的 backend + PostgreSQL + Redis 堆疊來以真實資料手動操作聊天室，因此**未能**在真實瀏覽器中互動測試。建議 reviewer 在本機或 CI 的 Docker 開發環境中驗證：

- 傳送一張圖片附件，於聊天室中點擊該圖片縮圖 → 應開啟全螢幕燈箱顯示原圖，而不是直接下載檔案。
- 在燈箱中點擊「下載」按鈕 → 應正常下載檔案；點擊「關閉」按鈕、點擊背景、或按 `Escape` 鍵 → 燈箱應關閉。
- 在觸控裝置（或瀏覽器 DevTools 裝置模擬）上對圖片附件長按 → 應正常開啟回覆/編輯/收回選單（既有功能，來自 PR #322/#326），且選單開啟後不應該同時意外開啟燈箱（用來驗證本次新增的 `longPressTriggeredRef` 防護是否有效）。
- 選取一張圖片作為待傳附件 → 傳送前的附件預覽列表中應顯示該圖片的縮圖，而非僅有檔名文字。
- 選取多張圖片與非圖片檔案 → 圖片顯示縮圖，非圖片維持原本的檔案圖示；移除單一附件、清空全部附件、切換聊天室、送出訊息後，開啟瀏覽器 DevTools 確認沒有殘留未釋放的 `blob:` URL（避免記憶體洩漏）。

## 資料庫變更 (Database Changes)
* 此變更是否包含資料庫 Schema 修改？ **否**

## API 與 WebSocket 協定一致性 (API & WebSocket Contract Check)
* 此變更是否涉及 API 路由或 WebSocket 事件的資料結構變更？ **否**

## 顧問審查意見 (Advisor Notes)

實作前已請一位以 `opus` model 執行的 architect 顧問 agent 審視根因分析與修復方案，主要意見與採納情形：

- **長按與燈箱衝突（已採納，屬於必要修正）**：顧問指出行動裝置上長按圖片會先觸發既有的操作選單，但 `touchend` 後瀏覽器仍會補發合成 `click` 事件，若燈箱的開啟邏輯沒有檢查這個情況，選單開啟後燈箱會緊接著疊在選單上方一起跳出。修正方式是讓 `handleViewAttachment` 比照既有 `onContextMenu` 的做法，檢查並重置 `longPressTriggeredRef`，長按觸發後的下一次點擊直接略過不開啟燈箱。
- **待傳附件 blob URL 釋放策略（已採納並簡化）**：原草案打算用 `useEffect` 對 `pendingAttachments` 陣列做差異比對來建立/釋放 URL，顧問指出這會漏掉「傳送成功清空」與「切換聊天室重置」兩個既有的清空點，且差異比對本身容易在 StrictMode 下重複觸發、造成短暫指向已釋放 URL 的風險。改為在 `handleFileSelected` 選取當下就建立一次 URL，並在唯一移除、傳送成功、切換聊天室與元件卸載這幾個既有的清空點都明確呼叫 `revokePendingAttachments`，讓建立與釋放對稱、不依賴 effect 的差異比對。
- **燈箱狀態應留在 `ChatBubble`（維持原案）**：顧問確認把 `lightboxAttachment` 狀態放在 `ChatBubble`（而非下沉到 `ImageAttachmentPreview`）是正確的，因為長按防護用的 `longPressTriggeredRef` 本來就活在 `ChatBubble` 的作用域，回呼需要能存取到它。
- **不重用 `Modal.tsx`（維持原案）**：`Modal.tsx` 有標題列與內距版面，不適合全螢幕圖片檢視，因此新增一個獨立的 `AttachmentLightbox` 元件；同時比 `Modal.tsx` 多補上 `Escape` 鍵關閉（`Modal.tsx` 目前只有背景點擊關閉，沒有鍵盤事件與 focus trap），但沒有加入 focus trap，維持與現有 `Modal.tsx` 一致的無障礙水準，避免過度工程。
- **一個 PR 涵蓋 A、B 兩項（維持原案）**：兩者程式碼路徑完全獨立（已傳送圖片 vs. 待傳圖片），顧問建議可視情況拆成兩個獨立 commit 以利個別 revert；本次因兩者皆為同一 issue 的直接對應項目且改動範圍小，最終以單一 commit、單一 PR 提交，方便 reviewer 一次檢視。

Generated with Claude Code (https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UgyYVLA67GP7rJ2EKugZmL)_