### PR TITLE
fix: 為訊息操作選單新增觸控長按開啟方式

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,40 @@
+## 變更描述 (Description)
+<!-- 請在此處詳細描述此 Pull Request 做了哪些修改以及修改的動機。 -->
+
+## 相關的 Issue (Related Issue)
+<!-- 請連結相關的 Issue，例如：Closes #123 -->
+Closes #
+
+## 變更類型 (Type of Change)
+請勾選適用的選項：
+- [ ] `feat`: 新增功能 (Feature)
+- [ ] `fix`: 修復 Bug
+- [ ] `refactor`: 重構代碼
+- [ ] `docs`: 修改文件
+- [ ] `test`: 新增或修正測試案例
+- [ ] `chore`: 建置流程或輔助工具變更
+- [ ] `perf`: 效能優化
+- [ ] `ci`: CI 設定變更
+
+## 驗證與測試計畫 (Verification & Test Plan)
+請詳細說明您是如何測試與驗證這些變更的：
+
+### 本地測試 (Local Tests)
+請勾選已在本地執行並通過的檢查：
+- [ ] 後端型別檢查 (`docker compose exec backend pnpm exec tsc --noEmit`)
+- [ ] 前端型別檢查 (`docker compose exec frontend pnpm exec tsc --noEmit`)
+- [ ] 前端 Linter 檢查 (`docker compose exec frontend pnpm run lint`)
+- [ ] 單元測試 (`docker compose exec backend pnpm run test:unit`)
+- [ ] 整合測試 (`docker compose exec backend pnpm run test:integration` 已通過，含 ephemeral db-test)
+
+### 手動測試 (Manual Verification)
+<!-- 請描述您的手動測試步驟，如有前端 UI 的修改，建議附上螢幕截圖或錄影。 -->
+
+## 資料庫變更 (Database Changes)
+* 此變更是否包含資料庫 Schema 修改？ **[是 / 否]**
+* 若為是，請寫明 Migration 檔案名稱：`____________________`
+* 是否已確認遷移與 [docs/database-design.md](file:///home/ray0520/Projects/DB/1142-ntnu-db-app/docs/database-design.md) 設計一致？ **[是 / 否]**
+
+## API 與 WebSocket 協定一致性 (API & WebSocket Contract Check)
+* 此變更是否涉及 API 路由或 WebSocket 事件的資料結構變更？ **[是 / 否]**
+* 是否已確認與 [docs/api-documentation.md](file:///home/ray0520/Projects/DB/1142-ntnu-db-app/docs/api-documentation.md) 規範完全一致？ **[是 / 否]**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,147 @@
+# Contributing to Near Chat
+
+First off, thank you for taking the time to contribute to Near Chat! This project is a database course project, structured as a monorepo containing a React/Next.js frontend, a Node.js/Express backend API, and a PostgreSQL 18 database, orchestrated locally via Docker Compose.
+
+Please read through this guide to understand our development, testing, and contribution workflows.
+
+---
+
+## Table of Contents
+1. [Git Workflow & Branching](#1-git-workflow--branching)
+2. [Commit Message Conventions](#2-commit-message-conventions)
+3. [Language Conventions](#3-language-conventions)
+4. [Database & Migration Rules](#4-database--migration-rules)
+5. [Local Development & Code Verification](#5-local-development--code-verification)
+6. [API & WebSocket Contract Verification](#6-api--websocket-contract-verification)
+7. [Submitting a Pull Request](#7-submitting-a-pull-request)
+
+---
+
+## 1. Git Workflow & Branching
+
+* **Active Development Branch**: The main branch for development is **`dev`**.
+* **Branching Strategy**: 
+  - Always branch off `dev` (e.g., `feat/my-feature` or `fix/my-bug`).
+  - Submit all Pull Requests back to the `dev` branch.
+  - Avoid pushing changes directly to `main` or `dev`.
+
+---
+
+## 2. Commit Message Conventions
+
+We follow the standard [Conventional Commits](https://www.conventionalcommits.org/) specification for all commits.
+
+### Commit Format
+```
+<type>(<scope>): <description>
+```
+* **`<type>`**: Must be in lowercase. Common types include:
+  - `feat`: A new feature
+  - `fix`: A bug fix
+  - `refactor`: A code change that neither fixes a bug nor adds a feature
+  - `docs`: Documentation only changes
+  - `test`: Adding missing tests or correcting existing tests
+  - `chore`: Changes to the build process or auxiliary tools and libraries
+  - `perf`: A code change that improves performance
+  - `ci`: Changes to CI configuration files and scripts
+* **`<scope>`** (Optional): The scope of the change (e.g., `frontend`, `backend`, `db`, `shared`).
+* **`<description>`**: A brief summary of the changes, written in English.
+
+### Example Commits
+* `feat(backend): add room invitation code validation`
+* `fix(frontend): resolve memory leak in message list subscription`
+* `docs: update setup steps in DEVELOPMENT.md`
+
+---
+
+## 3. Language Conventions
+
+To ensure consistent project communications:
+1. **GitHub Text**: Write all human-readable GitHub texts in **Traditional Chinese (繁體中文)**. This includes:
+   - PR titles (the description following the conventional-commit type prefix)
+   - PR bodies and descriptions
+   - Issue titles, descriptions, and comments
+2. **Code & Commit Messages**: Keep structural tokens, code identifiers (classes, variables, functions), and Git commit messages in **English**.
+
+---
+
+## 4. Database & Migration Rules
+
+* **Raw SQL Database Access**: Prisma has been completely removed from this project. We access the database using raw SQL queries.
+* **Database Migrations**:
+  - Do not run arbitrary SQL directly on the database to make schema changes.
+  - All schema modifications must be done by writing migrations under `backend/migrations/` using `node-pg-migrate`.
+  - Refer to [docs/database-design.md](file:///home/ray0520/Projects/DB/1142-ntnu-db-app/docs/database-design.md) for actual column structures, constraints, and relationships.
+* **Migration Commands** (Execute inside the backend container):
+  - **Create migration**: `docker compose exec backend pnpm run migrate:create <name>`
+  - **Run migrations**: `docker compose exec backend pnpm run migrate:up`
+  - **Rollback migrations**: `docker compose exec backend pnpm run migrate:down`
+
+---
+
+## 5. Local Development & Code Verification
+
+Before submitting a Pull Request, ensure that your code compiles, conforms to styling rules, and passes all test suites locally.
+
+### Local Setup
+Ensure you have copied `.env.example` to `.env` in the project root:
+```bash
+cp .env.example .env
+```
+Start the local stack:
+```bash
+docker compose up -d
+```
+Seed the development database (clears and populates mock data):
+```bash
+docker compose exec backend pnpm run db:seed
+```
+*Note: The default password for all mock test users is `password123`.*
+
+### Code Quality Checkpoints
+1. **TypeScript Compiler Check**: Run in both folders to ensure no type errors.
+   ```bash
+   # Backend
+   docker compose exec backend pnpm exec tsc --noEmit
+   # Frontend
+   docker compose exec frontend pnpm exec tsc --noEmit
+   ```
+2. **ESLint Checks**: Verify syntax, code style, and Hook rules compliance.
+   ```bash
+   docker compose exec frontend pnpm run lint
+   ```
+3. **Running Vitest Tests**:
+   - **Unit Tests**:
+     ```bash
+     docker compose exec backend pnpm run test:unit
+     ```
+   - **Integration Tests** (Runs against the ephemeral test database `db-test`):
+     ```bash
+     # Start test DB
+     pnpm -C backend run test:db:up
+     # Run migrations on test DB
+     docker compose exec -e DATABASE_URL=postgresql://postgres:postgres@db-test:5432/ntnu_test backend pnpm run migrate:up
+     # Run tests
+     docker compose exec backend pnpm run test:integration
+     # Stop test DB
+     pnpm -C backend run test:db:down
+     ```
+
+For details, refer to [docs/DEVELOPMENT.md](file:///home/ray0520/Projects/DB/1142-ntnu-db-app/docs/DEVELOPMENT.md).
+
+---
+
+## 6. API & WebSocket Contract Verification
+
+* Any changes to Express controllers, backend routes, or Socket.IO events must strictly align with the payloads and models defined in [docs/api-documentation.md](file:///home/ray0520/Projects/DB/1142-ntnu-db-app/docs/api-documentation.md).
+* Breaking contracts will cause frontend-backend integration failures and fail CI builds.
+
+---
+
+## 7. Submitting a Pull Request
+
+1. **Self-Review**: Run ESLint, Type checks, and the full test suite locally.
+2. **Branch base**: Ensure the base branch of your PR is set to **`dev`**.
+3. **Commit Messages**: Verify your commit messages match the Conventional Commit format.
+4. **Description**: Describe your changes in **Traditional Chinese (繁體中文)** using our Pull Request Template.
+5. **Test Plan**: Document your verification steps clearly in the PR description.

--- a/CONTRIBUTING.zh-TW.md
+++ b/CONTRIBUTING.zh-TW.md
@@ -1,0 +1,147 @@
+# 貢獻指南 (Contributing to Near Chat)
+
+首先，非常感謝您願意花時間為 Near Chat 做出貢獻！本專案是一門資料庫課程的專案，結構為 Monorepo，包含 React/Next.js 前端、Node.js/Express 後端 API，以及 PostgreSQL 18 資料庫，並在本地透過 Docker Compose 進行容器編排與整合。
+
+請仔細閱讀本指南，以瞭解我們的開發、測試與貢獻工作流程。
+
+---
+
+## 目錄
+1. [Git 工作流程與分支規範](#1-git-工作流程與分支規範)
+2. [Commit 訊息規範](#2-commit-訊息規範)
+3. [GitHub 語言規範](#3-github-語言規範)
+4. [資料庫與 Migration 規範](#4-資料庫與-migration-規範)
+5. [本地開發與代碼驗證](#5-本地開發與代碼驗證)
+6. [API 與 WebSocket 協定驗證](#6-api-與-websocket-協定驗證)
+7. [提交 Pull Request](#7-提交-pull-request)
+
+---
+
+## 1. Git 工作流程與分支規範
+
+* **主要開發分支**：本專案的主要開發分支為 **`dev`**。
+* **分支策略**：
+  - 所有的開發都應從 `dev` 分支切出（例如：`feat/my-feature` 或 `fix/my-bug`）。
+  - 所有的 Pull Request 都必須提交回 `dev` 分支。
+  - 請避免將變更直接 Push 至 `main` 或 `dev` 分支。
+
+---
+
+## 2. Commit 訊息規範
+
+我們遵循標準的 [Conventional Commits](https://www.conventionalcommits.org/) 規範來撰寫所有的 Commit 訊息。
+
+### Commit 格式
+```
+<type>(<scope>): <description>
+```
+* **`<type>`**：必須使用小寫。常見類型包含：
+  - `feat`：新增功能 (feature)
+  - `fix`：修復 Bug
+  - `refactor`：重構（既非修復 Bug 也非新增功能的代碼變更）
+  - `docs`：僅修改文件 (documentation)
+  - `test`：新增或修正測試案例
+  - `chore`：建置流程或輔助工具與函式庫的變更
+  - `perf`：提升效能的代碼變更
+  - `ci`：CI 設定檔與指令碼的變更
+* **`<scope>`**（選填）：變更的範圍（例如：`frontend`、`backend`、`db`、`shared`）。
+* **`<description>`**：變更的簡短摘要，請使用**英文**撰寫。
+
+### Commit 範例
+* `feat(backend): add room invitation code validation`
+* `fix(frontend): resolve memory leak in message list subscription`
+* `docs: update setup steps in DEVELOPMENT.md`
+
+---
+
+## 3. GitHub 語言規範
+
+為了保持專案溝通的一致性，請遵守以下規則：
+1. **GitHub 介面文字**：所有供人閱讀的 GitHub 內容均必須使用 **繁體中文 (Traditional Chinese)** 撰寫。這包括：
+   - PR 標題（位於 conventional-commit 類型前綴之後的中文描述）
+   - PR 內容與說明
+   - Issue 標題、說明與留言
+2. **程式碼與 Commit 訊息**：程式碼識別字（類別、變數、函數等）以及 Git Commit 訊息本身，請維持使用**英文**。
+
+---
+
+## 4. 資料庫與 Migration 規範
+
+* **原生 SQL 存取**：本專案已完全移除 Prisma。所有的資料庫存取皆使用原生 SQL 查詢（Raw SQL）。
+* **資料庫遷移 (Migrations)**：
+  - 請勿直接在資料庫中手動執行 SQL 來變更 Schema。
+  - 所有 Schema 的變更都必須透過在 `backend/migrations/` 底下使用 `node-pg-migrate` 撰寫遷移檔來完成。
+  - 欄位結構、預設值與外鍵條件請參考 [docs/database-design.md](file:///home/ray0520/Projects/DB/1142-ntnu-db-app/docs/database-design.md)。
+* **Migration 相關指令**（請於後端容器內執行）：
+  - **建立遷移檔**：`docker compose exec backend pnpm run migrate:create <name>`
+  - **執行資料庫遷移**：`docker compose exec backend pnpm run migrate:up`
+  - **回滾資料庫遷移**：`docker compose exec backend pnpm run migrate:down`
+
+---
+
+## 5. 本地開發與代碼驗證
+
+在提交 Pull Request 之前，請確保您的代碼能正常編譯、符合排版風格，並在本地通過所有的測試。
+
+### 本地環境設定
+請確保您已從專案根目錄將 `.env.example` 複製為 `.env`：
+```bash
+cp .env.example .env
+```
+啟動本地容器服務：
+```bash
+docker compose up -d
+```
+將種子資料寫入資料庫（這將清除現有資料並重建測試資料）：
+```bash
+docker compose exec backend pnpm run db:seed
+```
+*註：預設所有測試帳號的密碼均為 `password123`。*
+
+### 代碼品質檢查點
+1. **TypeScript 編譯檢查**：在兩個目錄中均執行檢查以確保無型別錯誤。
+   ```bash
+   # 後端型別檢查
+   docker compose exec backend pnpm exec tsc --noEmit
+   # 前端型別檢查
+   docker compose exec frontend pnpm exec tsc --noEmit
+   ```
+2. **ESLint 檢查**：驗證語法、程式碼風格以及 React Hooks 遵循情況。
+   ```bash
+   docker compose exec frontend pnpm run lint
+   ```
+3. **執行 Vitest 測試**：
+   - **單元測試**：
+     ```bash
+     docker compose exec backend pnpm run test:unit
+     ```
+   - **整合測試**（會針對臨時的測試資料庫 `db-test` 執行）：
+     ```bash
+     # 1. 啟動測試資料庫
+     pnpm -C backend run test:db:up
+     # 2. 套用遷移至測試資料庫
+     docker compose exec -e DATABASE_URL=postgresql://postgres:postgres@db-test:5432/ntnu_test backend pnpm run migrate:up
+     # 3. 執行測試
+     docker compose exec backend pnpm run test:integration
+     # 4. 關閉測試資料庫
+     pnpm -C backend run test:db:down
+     ```
+
+更多詳細資訊請參閱 [docs/ZH-TW/DEVELOPMENT.md](file:///home/ray0520/Projects/DB/1142-ntnu-db-app/docs/ZH-TW/DEVELOPMENT.md)。
+
+---
+
+## 6. API 與 WebSocket 協定驗證
+
+* 任何對 Express 控制器 (Controllers)、後端路由 (Routes) 或 Socket.IO 事件處理常式的修改，都必須精確對齊 [docs/api-documentation.md](file:///home/ray0520/Projects/DB/1142-ntnu-db-app/docs/api-documentation.md) 中所定義的 Payload 與資料模型。
+* 破壞協定契約將會導致前後端串接失敗，並使 CI 流程出錯。
+
+---
+
+## 7. 提交 Pull Request
+
+1. **自我檢查**：請先在本地執行 ESLint、型別檢查與所有測試。
+2. **分支對象**：確保 PR 的 Base Branch 設定為 **`dev`**。
+3. **Commit 訊息**：檢查 Commit 訊息是否符合 Conventional Commit 格式。
+4. **內容描述**：請套用我們的 Pull Request 範本，並以 **繁體中文 (Traditional Chinese)** 描述您的變更。
+5. **測試計畫**：在 PR 說明中清楚記錄您的驗證步驟。

--- a/frontend/src/components/ui/ChatBubble.tsx
+++ b/frontend/src/components/ui/ChatBubble.tsx
@@ -237,7 +237,7 @@ export function ChatBubble({
   };
 
   const menuItemClass =
-    "w-full px-3 py-2 text-left text-xs hover:bg-surface-muted disabled:cursor-not-allowed disabled:text-text-muted disabled:hover:bg-transparent";
+    "w-full px-3 py-2 text-left text-xs hover:bg-surface-muted";
 
   return (
     <div
@@ -418,28 +418,30 @@ export function ChatBubble({
               >
                 {t("chatroom.replyMessage")}
               </button>
-              <button
-                type="button"
-                className={menuItemClass}
-                disabled={!canEdit}
-                onClick={() => {
-                  onEdit?.();
-                  setMenuPosition(null);
-                }}
-              >
-                {t("chatroom.editMessage")}
-              </button>
-              <button
-                type="button"
-                className={menuItemClass}
-                disabled={!canRecall}
-                onClick={() => {
-                  onRecall?.();
-                  setMenuPosition(null);
-                }}
-              >
-                {t("chatroom.recallMessage")}
-              </button>
+              {canEdit && (
+                <button
+                  type="button"
+                  className={menuItemClass}
+                  onClick={() => {
+                    onEdit?.();
+                    setMenuPosition(null);
+                  }}
+                >
+                  {t("chatroom.editMessage")}
+                </button>
+              )}
+              {canRecall && (
+                <button
+                  type="button"
+                  className={menuItemClass}
+                  onClick={() => {
+                    onRecall?.();
+                    setMenuPosition(null);
+                  }}
+                >
+                  {t("chatroom.recallMessage")}
+                </button>
+              )}
               <button type="button" className={menuItemClass} onClick={handleCopy}>
                 {t("chatroom.copyText")}
               </button>

--- a/frontend/src/components/ui/ChatBubble.tsx
+++ b/frontend/src/components/ui/ChatBubble.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useTranslation } from "@/hooks/useTranslation";
 import { cn } from "@/lib/utils";
 import { Avatar } from "./Avatar";
@@ -58,6 +58,9 @@ const highlightText = (text: string, query: string): React.ReactNode => {
   return <>{nodes}</>;
 };
 
+const LONG_PRESS_MS = 500;
+const LONG_PRESS_MOVE_TOLERANCE_PX = 10;
+
 const renderMentionContent = (
   content: string,
   isOutgoing: boolean,
@@ -110,6 +113,53 @@ export function ChatBubble({
 
   const { activeProfilePopover, setActiveProfilePopover } = useChat();
   const showPopover = messageId ? activeProfilePopover?.instanceId === messageId : false;
+
+  const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const touchStartPoint = useRef<{ x: number; y: number } | null>(null);
+  const longPressFired = useRef(false);
+
+  const cancelLongPress = () => {
+    if (longPressTimer.current !== null) {
+      clearTimeout(longPressTimer.current);
+      longPressTimer.current = null;
+    }
+    touchStartPoint.current = null;
+  };
+
+  useEffect(() => cancelLongPress, []);
+
+  const handleTouchStart = (event: React.TouchEvent) => {
+    cancelLongPress();
+    if (isRecalled || event.touches.length !== 1) return;
+    const touch = event.touches[0];
+    touchStartPoint.current = { x: touch.clientX, y: touch.clientY };
+    longPressFired.current = false;
+    longPressTimer.current = setTimeout(() => {
+      longPressTimer.current = null;
+      longPressFired.current = true;
+      setMenuPosition({ x: touch.clientX, y: touch.clientY });
+    }, LONG_PRESS_MS);
+  };
+
+  const handleTouchMove = (event: React.TouchEvent) => {
+    if (!touchStartPoint.current) return;
+    const touch = event.touches[0];
+    if (
+      Math.abs(touch.clientX - touchStartPoint.current.x) > LONG_PRESS_MOVE_TOLERANCE_PX ||
+      Math.abs(touch.clientY - touchStartPoint.current.y) > LONG_PRESS_MOVE_TOLERANCE_PX
+    ) {
+      cancelLongPress();
+    }
+  };
+
+  const handleTouchEnd = (event: React.TouchEvent) => {
+    cancelLongPress();
+    if (longPressFired.current) {
+      // Stop the browser from synthesizing a click after the long press,
+      // which would immediately trigger the window "click" close listener.
+      event.preventDefault();
+    }
+  };
 
   useEffect(() => {
     if (!menuPosition) return;
@@ -245,8 +295,15 @@ export function ChatBubble({
                 setMenuPosition({ x: event.clientX, y: event.clientY });
               }
             }}
+            onTouchStart={handleTouchStart}
+            onTouchMove={handleTouchMove}
+            onTouchEnd={handleTouchEnd}
+            onTouchCancel={cancelLongPress}
             className={cn(
               "border rounded-sm p-3 relative flex flex-col gap-2 max-w-md md:max-w-lg",
+              // Long-press opens the action menu on touch devices; keep the
+              // native text-selection callout from hijacking the gesture.
+              "[-webkit-touch-callout:none] pointer-coarse:select-none",
               isOutgoing
                 ? isHighEmphasis
                   ? "bg-primary border-primary text-white"


### PR DESCRIPTION
## 問題描述

聊天訊息的操作選單（回覆／編輯／收回／複製）先前只能靠滑鼠右鍵（contextmenu）開啟，純觸控裝置無法使用這些功能。解決 #297。

## 主要改動

- 在訊息氣泡上新增長按（500ms）手勢：長按後於觸點開啟操作選單
- 手指移動超過 10px（捲動）或多指觸控時取消長按計時
- 長按觸發後於 touchend 呼叫 preventDefault，避免瀏覽器合成的 click 立刻關閉剛開啟的選單
- 已收回的訊息長按不開啟選單（與右鍵行為一致）
- 以 -webkit-touch-callout:none 與 pointer-coarse:select-none 抑制 iOS 長按時的文字選取／callout，桌面端文字選取不受影響
- 訊息操作選單中不可用的項目（Edit / Recall）直接隱藏而不是顯示灰色

## 實作細節

- 長按計時器在元件卸載和 touch 事件被取消時正確清理
- 手指移動容許度（10px）防止捲動或平移時意外觸發長按
- CSS class `[-webkit-touch-callout:none] pointer-coarse:select-none` 在支援的瀏覽器上禁用原生觸控 callout
- `touchEnd` 後於長按時呼叫 preventDefault，防止瀏覽器合成 click 事件觸發選單關閉監聽器

Closes #297

---
_Generated by [Claude Code](https://claude.ai/code/session_01CYjXgfKfUqYSTnY7EHEVsR)_