### PR TITLE
feat: 新增聊天室一鍵分類篩選與排序 (#294)

### DIFF
--- a/frontend/src/components/layout/ChatList.tsx
+++ b/frontend/src/components/layout/ChatList.tsx
@@ -15,6 +15,9 @@ interface ChatListProps {
   searchQuery: string;
 }
 
+type FilterMode = "all" | "dm" | "group" | "unread";
+type SortMode = "custom" | "unread";
+
 export default function ChatList({ searchQuery }: ChatListProps) {
   const router = useRouter();
   const params = useParams();
@@ -256,11 +259,137 @@ export default function ChatList({ searchQuery }: ChatListProps) {
     }
   };
 
+  // One-tap category filter (resets per session) and sort preset (persisted).
+  const [filterMode, setFilterMode] = React.useState<FilterMode>("all");
+  const [sortMode, setSortMode] = React.useState<SortMode>(() => {
+    try {
+      const saved = typeof window !== "undefined" ? localStorage.getItem("near:chatSort") : null;
+      if (saved === "custom" || saved === "unread") return saved;
+    } catch {}
+    return "custom";
+  });
+
+  const changeSortMode = (mode: SortMode) => {
+    setSortMode(mode);
+    try {
+      localStorage.setItem("near:chatSort", mode);
+    } catch {}
+  };
+
+  // The grouped folder view (with drag-and-drop custom ordering) is only meaningful
+  // for the default all + custom combination; any other preset renders a flat list.
+  const isFlatMode = filterMode !== "all" || sortMode !== "custom";
+
+  const resolveRoomAvatar = (room: ChatRoom): string | undefined => {
+    if (room.avatarUrl) {
+      return resolveAssetUrl(room.avatarUrl);
+    }
+    if (room.type === "msg") {
+      const otherMember = room.members?.find((m) => m.userId !== user.userId);
+      if (otherMember?.avatarUrl) {
+        return resolveAssetUrl(otherMember.avatarUrl);
+      }
+      const friend = friends.find((f) => f.id === room.otherMemberId || f.name === room.name);
+      if (friend?.avatarUrl) {
+        return resolveAssetUrl(friend.avatarUrl);
+      }
+    }
+    return getAvatarForUser(room.name, user.avatar, user.username);
+  };
+
+  const flatRooms = React.useMemo(() => {
+    if (!isFlatMode) return [];
+    const query = searchQuery.toLowerCase();
+    const matchesSearch = (room: ChatRoom) => room.name.toLowerCase().includes(query);
+    const matchesFilter = (room: ChatRoom) => {
+      switch (filterMode) {
+        case "dm":
+          return room.type === "msg";
+        case "group":
+          return room.type === "group";
+        case "unread":
+          return (room.unreadCount ?? 0) > 0;
+        default:
+          return true;
+      }
+    };
+    let list = rooms.filter((room) => matchesSearch(room) && matchesFilter(room));
+    if (sortMode === "unread") {
+      list = [...list].sort((a, b) => (b.unreadCount ?? 0) - (a.unreadCount ?? 0));
+    }
+    // Keep the currently open room visible even if the active filter would hide it.
+    if (activeRoomId && isChatPage) {
+      const active = rooms.find((room) => room.id === activeRoomId);
+      if (active && matchesSearch(active) && !list.some((room) => room.id === active.id)) {
+        list = [active, ...list];
+      }
+    }
+    return list;
+  }, [isFlatMode, rooms, searchQuery, filterMode, sortMode, activeRoomId, isChatPage]);
+
+  const filterOptions: { value: FilterMode; label: string }[] = [
+    { value: "all", label: t("chatFilter.filterAll") },
+    { value: "dm", label: t("chatFilter.filterDm") },
+    { value: "group", label: t("chatFilter.filterGroup") },
+    { value: "unread", label: t("chatFilter.filterUnread") },
+  ];
+
   return (
     <>
       <SectionLabel label={t("sidebar.chats")} />
 
-      {rootRooms.length > 0 && (
+      <div className="px-4 pb-2 flex items-center justify-between gap-2">
+        <div className="flex items-center gap-1 flex-wrap">
+          {filterOptions.map((option) => (
+            <button
+              key={option.value}
+              type="button"
+              onClick={() => setFilterMode(option.value)}
+              className={`px-2 py-0.5 rounded-sm text-[10px] font-semibold border transition-colors ${
+                filterMode === option.value
+                  ? "border-primary bg-primary/10 text-primary"
+                  : "border-border-secondary text-text-muted hover:text-foreground hover:border-border-primary"
+              }`}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+        <button
+          type="button"
+          onClick={() => changeSortMode(sortMode === "custom" ? "unread" : "custom")}
+          title={t("chatFilter.sortLabel")}
+          className="shrink-0 flex items-center gap-1 px-2 py-0.5 rounded-sm text-[10px] font-semibold border border-border-secondary text-text-muted hover:text-foreground hover:border-border-primary transition-colors"
+        >
+          <span className="rotate-90 leading-none">{"⇅"}</span>
+          {sortMode === "unread" ? t("chatFilter.sortUnread") : t("chatFilter.sortCustom")}
+        </button>
+      </div>
+
+      {isFlatMode && (
+        flatRooms.length > 0 ? (
+          <div className="flex flex-col">
+            {flatRooms.map((room) => (
+              <RoomItem
+                key={room.id}
+                room={room}
+                isActive={room.id === activeRoomId && isChatPage}
+                draggable={false}
+                onClick={() => router.push(`/chat/${room.id}`)}
+                avatarSrc={resolveRoomAvatar(room)}
+                noMessagesText={t("sidebar.noMessages")}
+                isPending={room.myRole === "pending"}
+              />
+            ))}
+          </div>
+        ) : (
+          <div className="px-4 py-8 text-center text-[11px] text-text-muted">
+            {t("chatFilter.emptyResult")}
+          </div>
+        )
+      )}
+
+      {!isFlatMode && rootRooms.length > 0 && (
         <div>
           <button
             type="button"
@@ -370,7 +499,7 @@ export default function ChatList({ searchQuery }: ChatListProps) {
         </div>
       )}
 
-      {visibleFolders.length > 0 && (
+      {!isFlatMode && visibleFolders.length > 0 && (
         <div className="flex flex-col gap-0.5 pb-2">
           {visibleFolders.map((folder) => {
             const folderRooms = getFolderRooms(folder.id);
@@ -639,19 +768,21 @@ function RoomItem({
   avatarSrc,
   noMessagesText,
   isPending,
+  draggable = true,
 }: {
   room: ChatRoom;
   isActive: boolean;
   isDropTarget?: boolean;
   dropPlacement?: "above" | "below" | null;
   onClick: () => void;
-  onDragStart: (event: React.DragEvent<HTMLButtonElement>) => void;
-  onDragEnd: () => void;
+  onDragStart?: (event: React.DragEvent<HTMLButtonElement>) => void;
+  onDragEnd?: () => void;
   onDragOver?: (event: React.DragEvent<HTMLDivElement>) => void;
   onDrop?: (event: React.DragEvent<HTMLDivElement>) => void;
   avatarSrc?: string;
   noMessagesText: string;
   isPending?: boolean;
+  draggable?: boolean;
 }) {
   const { t } = useTranslation();
 
@@ -674,7 +805,7 @@ function RoomItem({
       <button
         type="button"
         onClick={onClick}
-        draggable
+        draggable={draggable}
         onDragStart={onDragStart}
         onDragEnd={onDragEnd}
         className="flex min-w-0 flex-1 items-center gap-2.5 text-left select-none cursor-pointer"

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -329,5 +329,15 @@
     "renameFailed": "Failed to rename folder",
     "deleteFailed": "Failed to delete folder",
     "confirmAction": "Confirm"
+  },
+  "chatFilter": {
+    "filterAll": "All",
+    "filterDm": "DM",
+    "filterGroup": "Group",
+    "filterUnread": "Unread",
+    "sortLabel": "Sort",
+    "sortCustom": "Custom",
+    "sortUnread": "Unread first",
+    "emptyResult": "No matching chats"
   }
 }

--- a/frontend/src/locales/zh-TW.json
+++ b/frontend/src/locales/zh-TW.json
@@ -329,5 +329,15 @@
     "renameFailed": "修改資料夾名稱失敗",
     "deleteFailed": "刪除資料夾失敗",
     "confirmAction": "確定"
+  },
+  "chatFilter": {
+    "filterAll": "全部",
+    "filterDm": "私聊",
+    "filterGroup": "群組",
+    "filterUnread": "未讀",
+    "sortLabel": "排序",
+    "sortCustom": "自定義",
+    "sortUnread": "未讀優先",
+    "emptyResult": "沒有符合的聊天室"
   }
 }


### PR DESCRIPTION
## 相關的 Issue (Related Issue)

Closes #294

## 根因摘要 (Root Cause / Background)

目前側邊欄聊天室列表只支援「自行新增資料夾分類」與「手動拖曳自定義排序」（排序狀態持久化於 `localStorage` 的 `near:roomOrder` 與後端 `updateRoomSorting`）。使用者無法一鍵依「私聊 / 群組 / 未讀」快速篩選，也無法一鍵切換為「未讀優先」排序，必須手動翻找或拖曳，這正是 issue #294 提出的痛點。

本次變更為**純前端、加法式**功能，不涉及任何後端、API 路由、WebSocket 事件或資料庫結構變更。

## 變更類型 (Type of Change)

- [x] `feat`: 新增功能 (Feature)

## 變更內容與原因 (What Changed & Why)

全部集中在 `frontend/src/components/layout/ChatList.tsx`（外加兩個語系檔的 i18n 字串），將功能內聚於單一元件，降低耦合與回歸風險：

- **新增控制列**：在列表標題下方加入一列篩選晶片（全部 / 私聊 / 群組 / 未讀）與一個排序切換鈕（自定義 ⇄ 未讀優先），沿用既有的 `text-xs`、`border-border-*`、`text-primary` 樣式語彙。
- **兩種顯示模式**：
  - 預設的「全部 + 自定義」組合 → **完全維持既有的資料夾分組視圖與拖曳排序**（該區塊 JSX 原封不動，僅在外層條件加上 `!isFlatMode`），確保零回歸。
  - 其餘任一組合（非「全部」篩選或「未讀優先」排序）→ 改以**扁平列表**呈現：先依搜尋字串與篩選條件過濾，再依排序方式排序；扁平模式下停用拖曳自定義排序（跨篩選視圖的手動排序沒有明確語意）。
- **篩選狀態**：`filterMode`（`all`/`dm`/`group`/`unread`）每次工作階段重置為「全部」，避免下次開啟時聊天室「憑空消失」的支援陷阱；作用中的篩選晶片以主色明顯標示。
- **排序狀態**：`sortMode`（`custom`/`unread`）持久化於 `localStorage` 的 `near:chatSort`，比照既有 `roomOrderMap` 的 lazy `useState` 初始化慣例（含 `typeof window` SSR 防護與 `try/catch`、列舉值驗證），避免 hydration 不一致與髒資料卡死。
- **作用中聊天室保護**：即使目前篩選會過濾掉正在開啟的聊天室，仍會將其保留在扁平列表中，避免「正在看的對話卻從列表消失」。
- **空狀態**：扁平模式下無符合結果時顯示「沒有符合的聊天室」提示。
- **小重構**：抽出 `resolveRoomAvatar()` 供扁平列表重用頭像解析邏輯；`RoomItem` 的拖曳處理改為可選並新增 `draggable` 參數，供扁平模式關閉拖曳。

i18n：於 `zh-TW.json` 與 `en.json` 新增 `chatFilter` 區塊（篩選/排序標籤與空狀態字串），兩檔對稱。

## 驗證與測試計畫 (Verification & Test Plan)

此雲端環境沒有可用的 Docker daemon，無法啟動完整 backend + PostgreSQL + Redis 堆疊做真實瀏覽器互動測試；已於 `frontend/` 目錄（以 dev 分支的 lockfile `pnpm install --frozen-lockfile` 後）執行對等靜態檢查：

- [x] 前端型別檢查 `npx tsc --noEmit`：通過，無錯誤
- [x] 前端 Linter `npx eslint src/components/layout/ChatList.tsx`：0 errors、0 warnings（已修正 React Compiler 因 `eslint-disable` 而略過優化的問題，改用正確依賴）
- [x] 前端 production build `npm run build`（Next.js 16 Turbopack + React Compiler）：成功
- [ ] 手動瀏覽器驗證：本環境無 Docker，**尚未執行**，建議 reviewer 於本機或 CI 的 Docker 開發環境中驗證：
  - 點擊「私聊 / 群組 / 未讀」晶片 → 列表切換為對應扁平清單；點回「全部」且排序為「自定義」→ 回到原本的資料夾分組與拖曳排序視圖。
  - 切換「未讀優先」→ 列表依未讀數由多到少排序；重新整理頁面後排序偏好維持，篩選則回到「全部」。
  - 在某聊天室內切換到會過濾掉它的篩選 → 該聊天室仍保留在列表中且維持 active 標示。
  - 搜尋字串與篩選同時作用時，結果為兩者交集；無結果時顯示空狀態文字。

## 資料庫變更 (Database Changes)

* 此變更是否包含資料庫 Schema 修改？ **否**

## API 與 WebSocket 協定一致性 (API & WebSocket Contract Check)

* 此變更是否涉及 API 路由或 WebSocket 事件的資料結構變更？ **否**

## 顧問審查意見 (Advisor Notes)

實作前已請一位以 `opus` model 執行的 architect 顧問 agent 審視根因分析與方案，主要意見與採納情形：

- **作用中聊天室被篩選隱藏（已採納）**：顧問點出最尖銳的邊界情況是「使用者正在看某 DM，切到『群組』篩選時該 DM 從列表消失卻仍在路由中」。已實作為扁平模式一律保留 active 聊天室。
- **持久化策略（已採納）**：建議「排序持久化、篩選每次工作階段重置」，因為跨重載持久化篩選會讓聊天室看似「消失」，是典型的支援陷阱；並提醒作用中篩選要明顯標示。已據此實作。
- **Hydration 風險（已採納）**：提醒在 `use client` 元件中以 `useState` 初始器讀取 `localStorage` 可能造成 server/client 不一致，需 `try/catch` 並驗證解析值屬於允許的列舉字串。已比照既有 `roomOrderMap` 慣例並加上列舉驗證。
- **空狀態（已採納）**：現有三個列表在無資料時皆直接不渲染，扁平模式需明確空狀態字串。已新增。
- **搜尋 × 篩選的行為差異（已知悉）**：既有分組模式在「資料夾名稱」命中搜尋時會顯示該資料夾內所有聊天室；扁平模式僅以聊天室名稱比對，屬預期差異，非缺陷。分組模式維持原行為未動。
- **回歸風險（維持零回歸）**：顧問確認只要「全部 + 自定義」分支回傳原本的 JSX、且新控制列不置於拖放容器內、不造成列表 remount，回歸風險即為低。已據此保留原分組區塊不變。

Generated with Claude Code (https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01F6rMC9gUEFzKLEBpLYLdi6)_