### PR TITLE
fix: 訊息操作選單支援行動裝置長按與桌面懸停三點觸發 (#300)

### DIFF
--- a/frontend/src/components/ui/ChatBubble.tsx
+++ b/frontend/src/components/ui/ChatBubble.tsx
@@ -225,14 +225,17 @@ export function ChatBubble({
       if (Date.now() - menuOpenedAtRef.current < 300) return;
       setMenuPosition(null);
     };
-    const closeImmediately = () => setMenuPosition(null);
+    const closeOnScroll = () => setMenuPosition(null);
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setMenuPosition(null);
+    };
     window.addEventListener("click", closeOnClick);
-    window.addEventListener("keydown", closeImmediately);
-    window.addEventListener("scroll", closeImmediately, true);
+    window.addEventListener("keydown", closeOnEscape);
+    window.addEventListener("scroll", closeOnScroll, true);
     return () => {
       window.removeEventListener("click", closeOnClick);
-      window.removeEventListener("keydown", closeImmediately);
-      window.removeEventListener("scroll", closeImmediately, true);
+      window.removeEventListener("keydown", closeOnEscape);
+      window.removeEventListener("scroll", closeOnScroll, true);
     };
   }, [menuPosition]);
 
@@ -406,6 +409,24 @@ export function ChatBubble({
             </div>
           )}
 
+          {isOutgoing && !isRecalled && (
+            <button
+              type="button"
+              aria-label={t("chatroom.messageActions")}
+              onClick={(event) => {
+                const rect = event.currentTarget.getBoundingClientRect();
+                openMenuAt(rect.left, rect.bottom + 4);
+              }}
+              className="hidden md:inline-flex opacity-0 group-hover/msg:opacity-100 focus-visible:opacity-100 transition-opacity shrink-0 self-center p-1 rounded-sm text-text-muted hover:text-foreground hover:bg-surface-muted mb-0.5"
+            >
+              <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
+                <circle cx="5" cy="12" r="2" />
+                <circle cx="12" cy="12" r="2" />
+                <circle cx="19" cy="12" r="2" />
+              </svg>
+            </button>
+          )}
+
           <div
             onContextMenu={(event) => {
               event.preventDefault();
@@ -541,6 +562,24 @@ export function ChatBubble({
               </div>
             )}
           </div>
+
+          {!isOutgoing && !isRecalled && (
+            <button
+              type="button"
+              aria-label={t("chatroom.messageActions")}
+              onClick={(event) => {
+                const rect = event.currentTarget.getBoundingClientRect();
+                openMenuAt(rect.left, rect.bottom + 4);
+              }}
+              className="hidden md:inline-flex opacity-0 group-hover/msg:opacity-100 focus-visible:opacity-100 transition-opacity shrink-0 self-center p-1 rounded-sm text-text-muted hover:text-foreground hover:bg-surface-muted mb-0.5"
+            >
+              <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
+                <circle cx="5" cy="12" r="2" />
+                <circle cx="12" cy="12" r="2" />
+                <circle cx="19" cy="12" r="2" />
+              </svg>
+            </button>
+          )}
 
           {menuPosition && (
             <div

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -215,6 +215,7 @@
     "pendingApproval": "Pending Approval",
     "pendingApprovalBanner": "Your request to join this group is pending approval. You will be able to read and send messages once an owner or admin approves your request.",
     "editingMessageBanner": "Editing message (Press Esc to cancel)",
+    "messageActions": "Message actions",
     "replyMessage": "Reply Message",
     "editMessage": "Edit Message",
     "recallMessage": "Recall Message",

--- a/frontend/src/locales/zh-TW.json
+++ b/frontend/src/locales/zh-TW.json
@@ -207,6 +207,7 @@
     "pendingApproval": "審核中",
     "pendingApprovalBanner": "您加入此群組的申請正在審核中。在 owner 或 admin 核准您的申請後，您就可以閱讀與傳送訊息。",
     "editingMessageBanner": "正在修改訊息 (按 Esc 取消)",
+    "messageActions": "訊息操作",
     "replyMessage": "回覆訊息",
     "editMessage": "修改訊息",
     "recallMessage": "收回訊息",


### PR DESCRIPTION
## 相關的 Issue (Related Issue)

Closes #300

## 根因分析 (Root Cause)

Issue #300 是一個涵蓋範圍較廣的提案，同時要求：(A) 行動端長按氣泡彈出工具列、(B) 工具列頂部的 Emoji 快速反應欄、(C) 桌面端懸停三點按鈕、(D) 桌面端右鍵原生選單。

> **更新（2026-07-18）**：本 PR 的第一版分支是從錯誤的 base（`main` 系分支）建立的，導致早期版本的 diff 誤把 `main`／`dev` 間長期累積的既有差異一併帶入（包含審查機器人指出的 `.github/ISSUE_TEMPLATE/bug.yml`），也讓實作是針對 `dev` 分支已經演進過、較舊版本的 `ChatBubble.tsx` 撰寫的。已將分支從 `origin/dev` 重新建立並強制推送，現在的 diff 僅包含下方所述的 3 個檔案。同時發現 **`dev` 分支現況其實已經實作了 (A) 行動端長按開啟選單**（含位移閾值取消、多指手勢取消、合成 click 抑制等），因此本 PR 的實際範圍收斂為只需要再補上 (C)。

實作前逐項調查 `dev` 分支現況後確認：

- `dev` 分支的 `ChatBubble.tsx` 已具備完整的長按（long-press）偵測與既有右鍵選單，行動裝置使用者已經可以正常開啟選單，**但完全沒有 (C) 桌面懸停三點按鈕**——桌面使用者仍只能透過右鍵開啟選單，沒有滑鼠懸停即可見的視覺提示，也沒有可用 Tab 鍵聚焦、再用 Enter/Space 開啟選單的可及性入口。
- 全專案（`grep -r "emoji|Emoji|reaction|Reaction" frontend/src`）沒有任何 Emoji／訊息反應相關程式碼——沒有資料模型、沒有 API、沒有 Socket.IO 事件、沒有任何 UI。要做到 (B) 頂部 Emoji 快速反應欄，需要先建立一個全新的「訊息反應」子系統（後端資料表／API／即時事件、前端 Emoji 選擇器 UI），這已經超出「surgical, minimal」單一 PR 的合理範圍，屬於獨立的大型功能。
- 這個判斷與前一天（2026-07-17）同一自動化流程在調查另一個相關 issue #285（前端效能優化）時，由 opus 顧問 agent 已審視過並驗證的結論一致：#285 的留言中明確指出「Emoji Picker / Emoji 反應功能仍是未實作的 #300 提案」，應該從其他工作範疇中「明確排除」而非「延後」，否則會因為依賴一個尚未存在的功能而永遠無法收斂。同樣的推論這次也適用於 #300 本身。

## 變更內容與原因 (What Changed & Why)

本 PR 補齊 (C)，**明確排除 (B) Emoji 快速反應欄**（見下方「範圍排除」說明），全部變更集中在單一元件 `frontend/src/components/ui/ChatBubble.tsx` 與 2 份語系檔：

- **新增桌面懸停三點按鈕**：沿用 `Chatroom.tsx` 既有的 `group-hover/msg:opacity-100` 樣式慣例（與同檔案中既有的 hover 顯示區塊一致），在氣泡旁新增一個滑鼠懸停才顯示的「...」按鈕（僅於 `md` 以上寬度顯示，行動裝置以既有的長按為主要互動方式，避免多餘的常駐按鈕）。點擊後於按鈕位置呼叫既有的 `openMenuAt()` 開啟同一套選單，`dev` 既有的視窗邊界夾限、右鍵行為、長按行為完全維持不變。
- **修正選單鍵盤可用性（審查回饋）**：新增的按鈕是第一個「可被鍵盤聚焦」的選單觸發入口，這讓 `dev` 既有程式碼中「任何 `keydown` 都會立即關閉選單」的行為第一次會實際影響到鍵盤操作流程——用 Enter/Space 開啟選單後，接下來按 Tab 或方向鍵瀏覽選單項目會被立即中斷而無法使用。已改為只有按下 `Escape` 才會關閉選單（點擊外部、捲動關閉的既有行為維持不變）。
- **新增 i18n 鍵**：`chatroom.messageActions`（zh-TW：「訊息操作」／en：「Message actions」），供三點按鈕的 `aria-label` 使用（可及性文字亦屬使用者可見文字，依專案慣例需走 i18n，不可寫死）。

沒有任何後端、API、資料庫或 WebSocket 事件變更，純前端 UI 變更。

### 範圍排除說明 (Explicitly Out of Scope)

**Emoji 快速反應欄（issue 原文的 (B) 項）未包含在本次變更中**。原因如上述根因分析：該功能需要一個全新的「訊息反應」子系統（後端資料模型、API、即時事件、Emoji 選擇器 UI），風險與範圍都遠超本次「桌面選單觸發機制」修復。建議另外開立獨立 issue 追蹤 Emoji 反應功能本身，待該功能落地後，再視需要將快速反應入口整合進選單觸發位置。本 PR 仍標記 `Closes #300`，是因為 issue 標題與核心痛點聚焦於「操作選單跨端 UI 觸發設計」，(A)(C)(D) 三項觸發機制皆已到位（(A)(D) 已存在於 `dev`，(C) 由本 PR 補齊）；Emoji 反應則是 issue 內文提出、但本質獨立的延伸功能，比照本 repo 既有慣例（例如 PR #370 對 issue #278 的範圍收斂、PR #366 對 issue #302 的範圍收斂）以留言方式明確記錄排除原因，而非讓 issue 因依賴未落地的子功能而無法收斂。

## 驗證與測試計畫 (Verification & Test Plan)

此雲端環境沒有可用的 Docker daemon，無法啟動完整 backend + PostgreSQL + Redis 堆疊做真實瀏覽器互動測試（本專案亦無前端自動化測試框架可供新增測試案例）；已於 `frontend/` 目錄（以 `dev` 分支的 lockfile `pnpm install --frozen-lockfile` 後）執行下列檢查：

- [x] 前端型別檢查 `npx tsc --noEmit`：通過，無錯誤
- [x] 前端 Linter `npx eslint src/components/ui/ChatBubble.tsx`：0 errors、1 warning（既有、與本次改動無關的 `<img>` 建議改用 `next/image` 警告）
- [x] 前端 production build `npm run build`（Next.js 16 Turbopack）：成功
- [x] CI（`frontend-typecheck`、`frontend-lint`）：通過（`backend-build`／`unit-tests`／`integration-tests`／`e2e-tests` 因本次僅變更前端檔案，依專案既有的 path-filter 規則被跳過，非失敗）
- [ ] 手動瀏覽器／裝置驗證：本環境無 Docker，**尚未執行**，建議 reviewer 於本機或 CI 的 Docker 開發環境中驗證：
  - **桌面瀏覽器**：滑鼠懸停於任一氣泡上 → 應在 `md` 以上寬度顯示「...」按鈕；點擊該按鈕應開啟選單，且選單位置錨定於按鈕下方；右鍵點擊氣泡的既有行為應維持不變。
  - **鍵盤操作**：Tab 鍵聚焦到「...」按鈕 → 按 Enter 或 Space 開啟選單 → 按 Tab 或方向鍵應能在選單項目間移動並用 Enter 觸發，選單不應在按下這些鍵時被意外關閉；按 `Escape` 應關閉選單。
  - **收回訊息**：對已收回（`isRecalled`）的訊息懸停 → 不應顯示三點按鈕。
  - **行動裝置既有行為迴歸測試**：長按氣泡開啟選單、放開後選單不應被立即關閉、捲動時長按應被取消——確認本次變更未影響 `dev` 既有的長按邏輯。
  - **切換語系**：切換為英文 → 三點按鈕的 `aria-label`（可用瀏覽器 Accessibility Inspector 或螢幕閱讀器確認）應顯示對應英文字串。

## 資料庫變更 (Database Changes)

* 此變更是否包含資料庫 Schema 修改？ **否**

## API 與 WebSocket 協定一致性 (API & WebSocket Contract Check)

* 此變更是否涉及 API 路由或 WebSocket 事件的資料結構變更？ **否**

## 顧問審查意見 (Advisor Notes)

實作前已請一位以 `opus` model 執行的 architect 顧問 agent 審視根因分析與修復方案（當時是基於尚未發現「分支 base 錯誤」問題前的初版分析，但主要結論在重新對齊 `dev` 分支現況後依然成立）：

- **範圍收斂是正確判斷**：顧問指出這類「操作選單觸發設計」的修復應聚焦在真正缺失的觸發機制，而非強行把整個提案（含未落地的 Emoji 反應功能）塞進單一 PR——已採納，決定只補齊桌面三點按鈕。
- **選單定位策略統一**：顧問建議不要讓右鍵座標與按鈕/長按錨點成為兩套獨立邏輯，應統一成單一函式、多個呼叫端——`dev` 既有的 `openMenuAt()` 已經是這樣的設計，本次新增的按鈕直接重用，未額外新增第二套定位邏輯。
- **`aria-label` 需走 i18n**：顧問確認可及性文字屬於使用者可見文字，不應寫死中/英文——已採納，新增 `chatroom.messageActions` 翻譯鍵。
- **Emoji 反應欄應「明確排除」而非「延後」**：顧問援引 #285 留言中已驗證過的相同推論，若只是「延後」而不明確記錄排除原因，issue 會因依賴未落地的子功能而永遠無法收斂——已採納，於本 PR 「範圍排除說明」段落明確記錄，並建議另開獨立 issue 追蹤 Emoji 反應功能。
- **審查機器人（`chatgpt-codex-connector`）事後發現的鍵盤可及性問題**：在 PR 開出後，自動審查機器人正確指出新按鈕作為第一個可鍵盤聚焦的選單觸發點，會讓既有的「任何 `keydown` 關閉選單」邏輯導致鍵盤使用者無法操作選單——已修正為僅 `Escape` 才關閉選單，並已於審查討論串中回覆說明。

Generated with Claude Code (https://claude.com/claude-code)