### PR TITLE
Potential fix for code scanning alert no. 9: DOM text reinterpreted as HTML

### DIFF
--- a/frontend/src/lib/assets.ts
+++ b/frontend/src/lib/assets.ts
@@ -5,18 +5,23 @@ export const resolveAssetUrl = (value?: string): string | undefined => {
     return undefined;
   }
 
-  if (
-    value.startsWith("http://") ||
-    value.startsWith("https://") ||
-    value.startsWith("blob:") ||
-    value.startsWith("data:")
-  ) {
-    return value;
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
   }
 
-  if (value.startsWith("/")) {
-    return `${getApiBaseUrl()}${value}`;
+  try {
+    if (trimmed.startsWith("/")) {
+      return new URL(trimmed, getApiBaseUrl()).toString();
+    }
+
+    const parsed = new URL(trimmed);
+    if (parsed.protocol === "http:" || parsed.protocol === "https:" || parsed.protocol === "blob:") {
+      return parsed.toString();
+    }
+  } catch {
+    return undefined;
   }
 
-  return value;
+  return undefined;
 };


### PR DESCRIPTION
Potential fix for [https://github.com/nearcsie/near-chat/security/code-scanning/9](https://github.com/nearcsie/near-chat/security/code-scanning/9)

Safest fix: centralize URL sanitization in `frontend/src/lib/assets.ts` so every consumer of `resolveAssetUrl` benefits, including `Avatar`. Keep functionality for normal avatar paths/URLs/blob previews, but reject dangerous protocols and malformed URLs by returning `undefined` so `Avatar` falls back to initials.

Best concrete change:
- Edit `frontend/src/lib/assets.ts`, function `resolveAssetUrl`.
- Replace the current protocol checks (`startsWith`) with strict parsing using `new URL(...)`.
- Allow only:
  - same-origin relative paths (`/path`) resolved against `getApiBaseUrl()`,
  - `http:` / `https:`,
  - `blob:`.
- Disallow `data:` and anything else.
- On parse failure, return `undefined`.
- Preserve existing behavior for API-relative paths by resolving them against `getApiBaseUrl()`.

No other file changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
