### PR TITLE
docs: investigate Turbopack code splitting and document decision

### DIFF
--- a/docs/ZH-TW/frontend-turbopack-code-splitting.md
+++ b/docs/ZH-TW/frontend-turbopack-code-splitting.md
@@ -1,0 +1,127 @@
+# Turbopack 程式碼分割:調查與技術決策 (#380)
+
+本文件記錄 issue #380(#285 前端效能優化的子任務)所要求的調查:Next.js 16 搭配 Turbopack 是否提供受支援、穩定的手動 chunk splitting 設定(等同 Webpack 的 `optimization.splitChunks`),以及此結論對後續效能工作(#381–#383)的意義。
+
+**決策(TL;DR):本專案使用的 Next.js 版本中,Turbopack 沒有任何等同 Webpack `splitChunks` 的公開穩定 API。我們「不會」在 `next.config.ts` 加入任何 chunk splitting 設定。Bundle 體積工作改由受支援的層級進行:App Router 路由分割(自動)、`next/dynamic`(#381)、逐圖示/套件按需匯入(#382)。**
+
+## 本次調查使用的工具鏈版本
+
+| 工具 | 版本 |
+| :--- | :--- |
+| Next.js | 16.2.10(實際安裝版;`package.json` 宣告 `16.2.10`) |
+| Node.js | v22 sandbox(專案 `package.json` engines 要求 Node >=24) |
+| pnpm | 11.13.1 |
+| 分支/日期 | `claude/issue-285-fix-yhe83u`,基於 `dev` `8cffa93`,2026-07-19 |
+
+Issue #380 撰寫時參照「16.2.6」;專案現已升至 16.2.10。以下所有結論皆以實際安裝的 16.2.10 驗證。
+
+## 問題 1:Turbopack 是否提供等同 `splitChunks` 的設定?
+
+**沒有。** 三條獨立證據:
+
+### 1a. 官方文件記載的 `turbopack` 設定面
+
+Next.js 官方對 `next.config.ts` 中 `turbopack` 鍵的參考文件([nextjs.org/docs/app/api-reference/config/next-config-js/turbopack](https://nextjs.org/docs/app/api-reference/config/next-config-js/turbopack))記載的選項僅有:
+
+- `root` — 應用程式根目錄
+- `rules` — 套用 webpack **loaders**(僅檔案轉換,與打包策略無關)
+- `resolveAlias` — 匯入別名
+- `resolveExtensions` — 模組解析副檔名
+- `debugIds` — 在 bundle/source map 產生 debug ID
+- `ignoreIssue` — 抑制特定 Turbopack 診斷訊息
+
+沒有任何一項控制 chunking。Turbopack 指南([nextjs.org/docs/app/api-reference/turbopack](https://nextjs.org/docs/app/api-reference/turbopack)的「Unsupported and unplanned features」)另明確指出:以 Turbopack 建置時,`next.config.js` 中的任何 `webpack()` 設定**不會被識別**——因此把 `splitChunks` 塞進 `webpack()` callback 對 `next build` 完全無效。
+
+### 1b. 實際安裝套件的型別定義
+
+`frontend/node_modules/next/dist/server/config-shared.d.ts`(next@16.2.10)定義的 `TurbopackOptions` 恰好只有上述六個欄位(`resolveAlias`、`resolveExtensions`、`rules`、`root`、`debugIds`、`ignoreIssue`),沒有任何 chunking 相關欄位。
+
+與 chunking 沾邊的開關確實存在,但全部位於同檔案的 `experimental.*` 旗標(例如 `turbopackClientSideNestedAsyncChunking`、`turbopackServerSideNestedAsyncChunking`、`turbopackScopeHoisting`、`turbopackTreeShaking`、`turbopackMinify`、`turbopackModuleIds`)。這些只是 Turbopack 內建行為的布林/列舉開關——不是 `splitChunks` 式的策略語言(沒有 cache groups、沒有大小門檻、沒有手動 vendor 分組)——而且皆為 experimental,不符合 #380「公開且穩定」的門檻。詳見下方「不採用的選項」。
+
+### 1c. 最小可重現測試
+
+在 `frontend/src/__turbopack-splitchunks-spike__.ts` 放入:
+
+```ts
+import type { NextConfig } from "next";
+
+const spikeConfig: NextConfig = {
+  turbopack: {
+    splitChunks: {
+      chunks: "all",
+      cacheGroups: {
+        vendor: { test: /node_modules/, name: "vendors" },
+      },
+    },
+  },
+};
+
+export default spikeConfig;
+```
+
+於 `frontend/` 執行 `pnpm exec tsc --noEmit`,失敗訊息為:
+
+```
+src/__turbopack-splitchunks-spike__.ts(5,5): error TS2353: Object literal may only
+specify known properties, and 'splitChunks' does not exist in type 'TurbopackOptions'.
+```
+
+該測試檔在擷取輸出後即刪除,刻意不納入 commit。
+
+## 問題 2:那麼程式碼分割由誰負責?
+
+在沒有手動 chunking API 的前提下,本專案的分割責任依層級劃分如下,後續 issue 應在此邊界內工作:
+
+| 層級 | 機制 | 本專案現況 |
+| :--- | :--- | :--- |
+| 路由 | App Router 自動逐路由分割:每個路由區段有自己的 chunk,共用模組由 Turbopack 自動去重。 | 已生效;`docs/frontend-bundle-analysis.md` 的逐路由表格即為證據(`/`、`/chat/[chatId]`、`/settings` 各有不同的路由專屬模組)。 |
+| 元件 | `next/dynamic` / `React.lazy` 建立非同步邊界,Turbopack 會輸出獨立 chunk 並於首次渲染時載入。這是**唯一受支援的「手動把程式碼移出路由初始 chunk」方式**。 | #381 的範疇(例如目前同步匯入、但預設隱藏的 `GroupSettings`)。 |
+| 套件 | 匯入衛生:逐圖示 subpath 匯入取代執行期字串查找;Turbopack 原生最佳化 barrel file(官方文件註明 `experimental.optimizePackageImports` 是 Webpack 時代的輔助,「使用 Turbopack 時不需要」)。 | #382 的範疇(`@iconify/react` → `@iconify-react/boxicons/<icon>` subpath 匯入)。 |
+
+換句話說:#381–#383 需要的一切都不會被「缺少 `splitChunks`」擋住。手動 vendor 分組是 Webpack 時代的手段;在 Turbopack 之下,等價效果來自非同步邊界與匯入衛生。
+
+## 問題 3:dev/build bundler 不一致
+
+`frontend/package.json` 目前:
+
+- `dev`:`next dev --webpack` → 開發使用 **Webpack**
+- `build`:`next build` → production 使用 **Turbopack**(Next 16 預設)
+
+影響:
+
+- 未來若加入任何 `turbopack.*` 設定,只會影響 `next build`(及 `pnpm run analyze`),**不影響** dev server;反之 `webpack()` callback 只影響 dev、被 production build 忽略。對任何未來的 bundler 層設定而言,這種分裂是明顯的陷阱——這也是讓 `next.config.ts` 維持 bundler 中立的又一理由(目前它既無 `webpack` 也無 `turbopack` 鍵)。
+- dev/prod 行為漂移(模組解析、HMR 語意、CSS 處理)理論上可能,但目前尚未觀察到實際問題。
+
+**建議:** 統一 dev 也使用 Turbopack(`next dev` 去掉 `--webpack`)——但應另開獨立 issue、附獨立驗證(dev server 的 HMR、CSS、socket.io client 行為煙霧測試),不搭在本文件 PR 上。在那之前,「只有單一 bundler 會讀取的設定」應視為 code review 的警訊。
+
+## 問題 4:約 112 KB 的 `polyfill-nomodule.js`(基準文件候選 3)
+
+`docs/frontend-bundle-analysis.md` 指出分析器在每個路由都列出 `polyfill-nomodule.js`(~112 KB),並把結論交由本調查。
+
+**結論:對現代瀏覽器不構成實際成本,也無法設定移除——不處理。** Next.js 以 `<script noModule>` 標籤注入此檔(已於安裝套件中驗證:`next/dist/server/app-render/app-render.js` 由 `buildManifest.polyfillFiles` 建立 polyfill script 項目並帶 `noModule: true`)。凡支援 `<script type="module">` 的瀏覽器——也就是所有能執行本應用 ES module bundle 的瀏覽器——依規範會跳過 `nomodule` script,因此該檔只會被本來就無法運作的舊瀏覽器下載執行。Next.js 沒有公開設定可移除它;移除只會破壞舊瀏覽器的 fallback,不會改變現代瀏覽器下載或執行的內容。`docs/frontend-bundle-analysis.md` 的量測方法已將其排除於 client-JS 統計之外;維持現狀即可。
+
+## 決策紀錄
+
+### 採用
+
+1. **不在 `next.config.ts` 加入任何 chunk splitting 設定。** 沒有受支援的 API 可加;且在 dev/build 使用不同 bundler 期間,設定檔維持 bundler 中立。
+2. **Bundle 體積工作僅經由受支援層級進行:** `next/dynamic` 邊界(#381)、逐圖示 subpath 匯入(#382)、有量測依據的重新渲染修正(#383),全部以 `docs/frontend-bundle-analysis.md` 的可重現 `pnpm run analyze` 流程驗證。
+3. **`polyfill-nomodule.js` 以「不採取行動」結案:** 排除於 client-JS 統計,非可移除項目,亦非現代瀏覽器的實際成本。
+
+### 不採用的選項(與原因)
+
+- **`experimental.turbopack*` 旗標**(`turbopackClientSideNestedAsyncChunking`、`turbopackScopeHoisting`、`turbopackTreeShaking`、`turbopackMinify`、`turbopackModuleIds` 等):屬 experimental、語意隨版本變動,且目前沒有任何 bundle 證據顯示存在它們能解決的 chunk 問題。現在採用等於無依據的投機調校,還附帶升級風險。
+- **透過 `webpack()` callback 移植 Webpack `optimization.splitChunks`**:官方明示 Turbopack 建置不識別;只會(錯誤地)設定到 dev server。
+- **私有/未文件化 API**:#380 自身的限制條件即禁止。
+
+### 重新評估觸發條件
+
+發生下列任一情況時重新檢視本決策:
+
+1. Next.js 將 Turbopack 的 chunking 控制 API 升為**穩定**(升級時追蹤 `turbopack` 設定參考頁)。
+2. `pnpm run analyze` 顯示存在單一過大的 client chunk,且可證明 `next/dynamic` 邊界無法拆解(例如某共用 vendor 模組始終被拉進初始 chunk)。
+3. dev/build bundler 統一完成,使 bundler 專屬設定對兩個環境同時生效。
+
+### 回退方案
+
+本變更僅新增文件。回退 = 刪除本檔(及英文版 `docs/frontend-turbopack-code-splitting.md`)。未修改任何 production 程式碼或設定。

--- a/docs/frontend-turbopack-code-splitting.md
+++ b/docs/frontend-turbopack-code-splitting.md
@@ -1,0 +1,127 @@
+# Turbopack Code Splitting: Investigation & Technical Decision (#380)
+
+This document records the investigation requested by issue #380 (a sub-task of the #285 frontend performance effort): whether Next.js 16 with Turbopack offers a supported, stable way to configure manual chunk splitting equivalent to Webpack's `optimization.splitChunks`, and what that means for the follow-up performance work (#381–#383).
+
+**Decision (TL;DR): Turbopack in the Next.js version this project uses has no public, stable API equivalent to Webpack's `splitChunks`. We will NOT add any chunk-splitting configuration to `next.config.ts`. Bundle-size work proceeds through the layers that are supported: App Router route splitting (automatic), `next/dynamic` (#381), and per-icon/package imports (#382).**
+
+## Toolchain versions used for this investigation
+
+| Tool | Version |
+| :--- | :--- |
+| Next.js | 16.2.10 (installed; `package.json` declares `16.2.10`) |
+| Node.js | v22 sandbox (project targets Node >=24 per `package.json` engines) |
+| pnpm | 11.13.1 |
+| Branch/date | `claude/issue-285-fix-yhe83u` off `dev` `8cffa93`, 2026-07-19 |
+
+Issue #380 was written against "16.2.6"; the project has since moved to 16.2.10. All findings below were verified against the installed 16.2.10 package.
+
+## Question 1: Does Turbopack expose a `splitChunks`-equivalent config?
+
+**No.** Three independent lines of evidence:
+
+### 1a. The documented `turbopack` config surface
+
+The official Next.js reference for the `turbopack` key in `next.config.ts` ([nextjs.org/docs/app/api-reference/config/next-config-js/turbopack](https://nextjs.org/docs/app/api-reference/config/next-config-js/turbopack)) documents exactly these options:
+
+- `root` — application root directory
+- `rules` — apply webpack **loaders** (file transforms only, not bundling strategy)
+- `resolveAlias` — import aliasing
+- `resolveExtensions` — module resolution extensions
+- `debugIds` — debug IDs in bundles/source maps
+- `ignoreIssue` — suppress specific Turbopack diagnostics
+
+None of these controls chunking. The Turbopack guide ([nextjs.org/docs/app/api-reference/turbopack](https://nextjs.org/docs/app/api-reference/turbopack), "Unsupported and unplanned features") additionally states that any `webpack()` configuration in `next.config.js` is **not recognized** when building with Turbopack — so porting a `splitChunks` block inside a `webpack()` callback would silently do nothing for `next build`.
+
+### 1b. The installed package's type definitions
+
+`frontend/node_modules/next/dist/server/config-shared.d.ts` (next@16.2.10) defines `TurbopackOptions` with exactly the six fields listed above (`resolveAlias`, `resolveExtensions`, `rules`, `root`, `debugIds`, `ignoreIssue`) and nothing chunking-related.
+
+Chunking-adjacent switches do exist, but only as `experimental.*` flags in the same file (e.g. `turbopackClientSideNestedAsyncChunking`, `turbopackServerSideNestedAsyncChunking`, `turbopackScopeHoisting`, `turbopackTreeShaking`, `turbopackMinify`, `turbopackModuleIds`). These are boolean/enum toggles over Turbopack's built-in behavior — not a `splitChunks`-style strategy language (no cache groups, no size thresholds, no manual vendor grouping) — and they are experimental, which fails #380's "public and stable" bar. See "Rejected options" below.
+
+### 1c. Minimal reproducible test
+
+Placing this file at `frontend/src/__turbopack-splitchunks-spike__.ts`:
+
+```ts
+import type { NextConfig } from "next";
+
+const spikeConfig: NextConfig = {
+  turbopack: {
+    splitChunks: {
+      chunks: "all",
+      cacheGroups: {
+        vendor: { test: /node_modules/, name: "vendors" },
+      },
+    },
+  },
+};
+
+export default spikeConfig;
+```
+
+and running `pnpm exec tsc --noEmit` in `frontend/` fails with:
+
+```
+src/__turbopack-splitchunks-spike__.ts(5,5): error TS2353: Object literal may only
+specify known properties, and 'splitChunks' does not exist in type 'TurbopackOptions'.
+```
+
+The spike file was deleted after capturing the output; it is intentionally not committed.
+
+## Question 2: Who is responsible for code splitting, then?
+
+With no manual chunking API, splitting responsibilities in this project break down by layer. This is the boundary map the follow-up issues should work within:
+
+| Layer | Mechanism | Status in this project |
+| :--- | :--- | :--- |
+| Route | App Router automatic per-route code splitting. Each route segment gets its own chunk; shared modules are deduplicated automatically by Turbopack. | Already active; the per-route tables in `docs/frontend-bundle-analysis.md` show it working (`/`, `/chat/[chatId]`, `/settings` each have distinct route-specific modules). |
+| Component | `next/dynamic` / `React.lazy` creates an async boundary; Turbopack emits a separate chunk loaded on first render. This is the **only supported way to manually move code out of a route's initial chunk**. | Scope of #381 (e.g. `GroupSettings`, statically imported today but hidden by default). |
+| Package | Import hygiene: per-icon subpath imports instead of runtime string lookup; Turbopack natively optimizes barrel files (the docs note `experimental.optimizePackageImports` is a Webpack-era aid that is "not needed when using Turbopack"). | Scope of #382 (`@iconify/react` → `@iconify-react/boxicons/<icon>` subpath imports). |
+
+In other words: nothing that #381–#383 need is blocked by the absence of `splitChunks`. Manual vendor grouping was a Webpack-era tactic; under Turbopack the equivalent outcomes come from async boundaries and import hygiene.
+
+## Question 3: dev/build bundler mismatch
+
+`frontend/package.json` currently has:
+
+- `dev`: `next dev --webpack` → development uses **Webpack**
+- `build`: `next build` → production uses **Turbopack** (Next 16 default)
+
+Implications:
+
+- Any `turbopack.*` config we might add would affect `next build` (and `pnpm run analyze`) but **not** the dev server; conversely a `webpack()` callback would affect dev but be ignored by the production build. This split is a real foot-gun for any future bundler-level configuration — one more reason to keep `next.config.ts` bundler-agnostic (as it is today: it currently contains no `webpack` and no `turbopack` key).
+- Dev/prod behavioral drift (module resolution, HMR semantics, CSS handling) is possible but has not caused observed issues so far.
+
+**Recommendation:** unify on Turbopack for dev (`next dev` without `--webpack`) — but as its own follow-up issue with its own verification (dev-server smoke test of HMR, CSS, socket.io client behavior), not as a rider on this documentation PR. Until then, treat "config that only one bundler reads" as a review red flag.
+
+## Question 4: the ~112 KB `polyfill-nomodule.js` (baseline candidate 3)
+
+`docs/frontend-bundle-analysis.md` flagged that the analyzer lists `polyfill-nomodule.js` (~112 KB) for every route and deferred the verdict to this investigation.
+
+**Verdict: not an actual cost for modern browsers, and not configurable — leave it alone.** Next.js injects this file as a `<script noModule>` tag (verified in the installed package: `next/dist/server/app-render/app-render.js` builds the polyfill script entries from `buildManifest.polyfillFiles` with `noModule: true`). Browsers that support `<script type="module">` — i.e. every browser that can run this app's ES-module bundles at all — skip `nomodule` scripts by specification, so the file is downloaded and executed only by legacy browsers that would otherwise not work. There is no public Next.js config to remove it, and removing it would only break the legacy-browser fallback story without changing what modern browsers download or execute. The bundle-analysis method in `docs/frontend-bundle-analysis.md` already excludes it from client-JS totals; keep doing that.
+
+## Decision record
+
+### Adopted
+
+1. **No chunk-splitting configuration is added to `next.config.ts`.** There is no supported API to add, and the config file stays bundler-agnostic while dev and build use different bundlers.
+2. **Bundle-size work proceeds via supported layers only:** `next/dynamic` boundaries (#381), per-icon subpath imports (#382), measured re-render fixes (#383), all validated with the reproducible `pnpm run analyze` process from `docs/frontend-bundle-analysis.md`.
+3. **`polyfill-nomodule.js` is closed as "no action":** excluded from client-JS accounting, not a removable or real modern-browser cost.
+
+### Rejected options (and why)
+
+- **`experimental.turbopack*` flags** (`turbopackClientSideNestedAsyncChunking`, `turbopackScopeHoisting`, `turbopackTreeShaking`, `turbopackMinify`, `turbopackModuleIds`, …): experimental, undocumented semantics per release, and no bundle evidence that any current chunk problem exists for them to solve. Adopting them now would be speculative tuning with upgrade risk.
+- **Porting Webpack `optimization.splitChunks` via a `webpack()` callback**: explicitly not recognized by Turbopack builds; would only (mis)configure the dev server.
+- **Private/undocumented APIs**: out of bounds per #380's own constraints.
+
+### Re-evaluation triggers
+
+Revisit this decision if any of the following happens:
+
+1. Next.js promotes a chunking-control API for Turbopack to **stable** (watch the `turbopack` config reference page across upgrades).
+2. `pnpm run analyze` shows a single oversized client chunk that `next/dynamic` boundaries demonstrably cannot break up (e.g. a shared vendor module that async boundaries keep pulling into the initial chunk).
+3. The dev/build bundler unification lands and makes bundler-specific config meaningful for both environments.
+
+### Rollback
+
+This change is documentation-only. Rollback = delete this file (and its `docs/ZH-TW/` translation). No production code or configuration was modified.


### PR DESCRIPTION
## Summary

This PR documents the investigation and technical decision for issue #380 regarding whether Next.js 16 with Turbopack provides a supported, stable API for manual code splitting equivalent to Webpack's `optimization.splitChunks`.

## Key Changes

- **Added investigation documentation** in both English and Traditional Chinese:
  - `docs/frontend-turbopack-code-splitting.md` (English)
  - `docs/ZH-TW/frontend-turbopack-code-splitting.md` (Traditional Chinese)

## Investigation Findings

The documentation records three independent lines of evidence that Turbopack in the project's Next.js version (16.2.10) has **no public, stable API** for manual chunk splitting:

1. **Official API surface**: The documented `turbopack` config options in `next.config.ts` contain only `root`, `rules`, `resolveAlias`, `resolveExtensions`, `debugIds`, and `ignoreIssue` — nothing for chunking control
2. **Type definitions**: The installed `next@16.2.10` package's `TurbopackOptions` type confirms these six fields only
3. **Reproducible test**: Attempting to add a `splitChunks` property to the `turbopack` config fails TypeScript validation

## Decision

- **No chunk-splitting configuration will be added** to `next.config.ts`
- Bundle-size optimization work proceeds through supported layers:
  - App Router automatic route splitting (already active)
  - `next/dynamic` async boundaries (#381)
  - Per-icon/package subpath imports (#382)
- The ~112 KB `polyfill-nomodule.js` is documented as a non-issue for modern browsers and left unchanged

## Additional Context

The document also addresses:
- The dev/build bundler mismatch (dev uses Webpack via `--webpack` flag; build uses Turbopack by default)
- Why experimental Turbopack flags are not adopted
- Re-evaluation triggers for revisiting this decision in the future
- A rollback plan (documentation-only change)

https://claude.ai/code/session_01G8hjVZ9Ep45LLLRkNCppmC