### PR TITLE
refactor(frontend): 以 next/dynamic 懶載入 GroupSettings

### DIFF
--- a/docs/ZH-TW/frontend-turbopack-code-splitting.md
+++ b/docs/ZH-TW/frontend-turbopack-code-splitting.md
@@ -92,7 +92,7 @@ specify known properties, and 'splitChunks' does not exist in type 'TurbopackOpt
 - 未來若加入任何 `turbopack.*` 設定,只會影響 `next build`(及 `pnpm run analyze`),**不影響** dev server;反之 `webpack()` callback 只影響 dev、被 production build 忽略。對任何未來的 bundler 層設定而言,這種分裂是明顯的陷阱——這也是讓 `next.config.ts` 維持 bundler 中立的又一理由(目前它既無 `webpack` 也無 `turbopack` 鍵)。
 - dev/prod 行為漂移(模組解析、HMR 語意、CSS 處理)理論上可能,但目前尚未觀察到實際問題。
 
-**建議:** 統一 dev 也使用 Turbopack(`next dev` 去掉 `--webpack`)——但應另開獨立 issue、附獨立驗證(dev server 的 HMR、CSS、socket.io client 行為煙霧測試),不搭在本文件 PR 上。在那之前,「只有單一 bundler 會讀取的設定」應視為 code review 的警訊。
+**建議:** 統一 dev 也使用 Turbopack(`next dev` 去掉 `--webpack`)——已由 #387 獨立追蹤,並附獨立驗證(dev server 的 HMR、CSS、Socket.IO client 行為煙霧測試),不搭在本文件 PR 上。在那之前,「只有單一 bundler 會讀取的設定」應視為 code review 的警訊。
 
 ## 問題 4:約 112 KB 的 `polyfill-nomodule.js`(基準文件候選 3)
 

--- a/docs/frontend-turbopack-code-splitting.md
+++ b/docs/frontend-turbopack-code-splitting.md
@@ -92,7 +92,7 @@ Implications:
 - Any `turbopack.*` config we might add would affect `next build` (and `pnpm run analyze`) but **not** the dev server; conversely a `webpack()` callback would affect dev but be ignored by the production build. This split is a real foot-gun for any future bundler-level configuration — one more reason to keep `next.config.ts` bundler-agnostic (as it is today: it currently contains no `webpack` and no `turbopack` key).
 - Dev/prod behavioral drift (module resolution, HMR semantics, CSS handling) is possible but has not caused observed issues so far.
 
-**Recommendation:** unify on Turbopack for dev (`next dev` without `--webpack`) — but as its own follow-up issue with its own verification (dev-server smoke test of HMR, CSS, socket.io client behavior), not as a rider on this documentation PR. Until then, treat "config that only one bundler reads" as a review red flag.
+**Recommendation:** unify on Turbopack for dev (`next dev` without `--webpack`) — tracked separately in #387 with its own verification (dev-server smoke test of HMR, CSS, and Socket.IO client behavior), not as a rider on this documentation PR. Until then, treat "config that only one bundler reads" as a review red flag.
 
 ## Question 4: the ~112 KB `polyfill-nomodule.js` (baseline candidate 3)
 

--- a/frontend/src/components/pages/ChatroomPageContent.tsx
+++ b/frontend/src/components/pages/ChatroomPageContent.tsx
@@ -2,11 +2,35 @@
 
 import { useState, useEffect } from "react";
 import { useParams } from "next/navigation";
+import dynamic from "next/dynamic";
 import { useChat } from "@/context/ChatContext";
+import { useTranslation } from "@/hooks/useTranslation";
 import Chatroom from "@/components/chat/Chatroom";
-import GroupSettings from "@/components/settings/GroupSettings";
 import RoomMembersPanel from "@/components/chat/RoomMembersPanel";
 import FriendInfoPanel from "@/components/chat/FriendInfoPanel";
+
+// GroupSettings starts hidden and most sessions never open it, so it is
+// loaded on demand to keep it out of the chat route's initial client chunk.
+// RoomMembersPanel renders in the default group-chat view and FriendInfoPanel
+// is statically imported by the persistent Sidebar, so lazy-loading them here
+// would not reduce the initial bundle (see docs/frontend-bundle-analysis.md).
+const GroupSettings = dynamic(() => import("@/components/settings/GroupSettings"), {
+  ssr: false,
+  loading: () => <GroupSettingsLoading />,
+});
+
+function GroupSettingsLoading() {
+  const { t } = useTranslation();
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="flex-1 flex items-center justify-center bg-background h-full text-text-muted font-sans"
+    >
+      {t("common.loading")}
+    </div>
+  );
+}
 
 export default function ChatroomPageContent() {
   const params = useParams();


### PR DESCRIPTION
## 摘要

- 使用 `next/dynamic` 將預設隱藏的 `GroupSettings` 改為按需載入
- 加入支援 i18n 與無障礙語意的載入狀態
- 保留預設顯示或常駐側欄使用的 `RoomMembersPanel`、`FriendInfoPanel` 靜態匯入
- 更新英／繁中 Turbopack code-splitting 文件，將 dev Turbopack 統一工作連結至獨立 issue #387

## 原因

`GroupSettings` 預設不會顯示，只有使用者開啟群組設定時才需要。原本的靜態匯入會讓元件進入聊天室路由的初始 client bundle；改成動態匯入後，可建立明確 async boundary，在首次開啟時才載入對應程式碼。

## 影響

- 降低聊天室路由初始載入不必要的元件程式碼
- 首次開啟群組設定時會短暫顯示本地化 loading UI
- 不新增 `next.config.ts` chunk 設定
- dev server 改用 Turbopack 的工作維持獨立於本 PR，並由 #387 追蹤

## 驗證

- [x] TypeScript：`node node_modules/typescript/bin/tsc --noEmit`
- [x] ESLint：`node node_modules/eslint/bin/eslint.js .`
- [x] `git diff --check`
- [x] 英文與繁體中文文件同步更新

Closes #381