### PR TITLE
chore: 統一開發環境使用 Turbopack

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --webpack",
+    "dev": "next dev",
     "build": "next build",
     "start": "next start",
     "lint": "eslint",


### PR DESCRIPTION
## 摘要

- 將 `frontend/package.json` 的 `dev` script 從 `next dev --webpack` 改為 `next dev`
- 讓 Next.js 16 開發伺服器使用預設 Turbopack
- 不調整 production build、`next.config` 或 chunk 設定

## 原因

目前開發指令明確指定 `--webpack`，因此即使 Next.js 16 預設使用 Turbopack，日常開發仍會回退到 webpack。這使 dev 與目前採用的 bundler 方向不一致，也無法在一般開發流程中及早驗證 Turbopack 的 HMR、CSS 與 Socket.IO client 行為。

## 影響

開發者執行 `pnpm dev` 時將改用 Turbopack；production build 與部署行為不受此 PR 影響。

## 驗證環境

- Next.js：16.2.10
- Node.js：v24.14.0
- pnpm：11.9.0

## 驗證結果

- [x] `pnpm dev --port 3005 --hostname 0.0.0.0`
  - 顯示 `Next.js 16.2.10 (Turbopack)`
  - dev server 正常 Ready
- [x] React Fast Refresh / HMR
  - 暫時修改聊天室標題後，頁面無 reload 即時更新
  - 訊息輸入框中的 `hmr-state-387` 狀態保留
- [x] CSS / Tailwind
  - 暫時加入 body outline 後，樣式無 reload 即時套用
  - 清除 `.next` cache 並完整重編後確認測試探針不存在
- [x] 明／深色主題
  - Light → Dark 後 `html.dark` 與背景色正確更新
  - reload 後 Dark 設定仍保留
  - 測試結束後已還原 Light
- [x] Socket.IO client
  - Alice 與 Bob 兩個 client 均完成登入、連線及 room join
  - Bob 發送唯一測試訊息後，Alice 未 reload 即時收到
  - 未發現 Socket.IO、CORS 或 hydration 錯誤
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm lint`
- [x] `git diff --check`

## 已知觀察

- 快速加入再移除 CSS 測試探針時，`.next/dev` 曾保留舊 CSS cache；清除 cache 並完整重編後恢復正常。此現象不會留下原始碼變更。
- 瀏覽器仍會出現既有的 `/near.png` LCP 建議警告，與本 PR 無關。

Closes #387