### PR TITLE
docs: record re-evaluation of Turbopack chunking decision

### DIFF
--- a/docs/ZH-TW/frontend-turbopack-code-splitting.md
+++ b/docs/ZH-TW/frontend-turbopack-code-splitting.md
@@ -4,6 +4,8 @@
 
 **決策(TL;DR):本專案使用的 Next.js 版本中,Turbopack 沒有任何等同 Webpack `splitChunks` 的公開穩定 API。我們「不會」在 `next.config.ts` 加入任何 chunk splitting 設定。Bundle 體積工作改由受支援的層級進行:App Router 路由分割(自動)、`next/dynamic`(#381)、逐圖示/套件按需匯入(#382)。**
 
+> **2026-07-19 更新:** 重新評估觸發條件 3(dev/build bundler 統一)已由 #387 達成(PR #388,commit `7322545`)。已依約重新檢視本決策——**決策維持不變**,因為主要依據(觸發條件 1:沒有公開穩定的 chunking API)仍然成立。詳見文末〈重新評估紀錄〉。
+
 ## 本次調查使用的工具鏈版本
 
 | 工具 | 版本 |
@@ -80,9 +82,9 @@ specify known properties, and 'splitChunks' does not exist in type 'TurbopackOpt
 
 換句話說:#381–#383 需要的一切都不會被「缺少 `splitChunks`」擋住。手動 vendor 分組是 Webpack 時代的手段;在 Turbopack 之下,等價效果來自非同步邊界與匯入衛生。
 
-## 問題 3:dev/build bundler 不一致
+## 問題 3:dev/build bundler 不一致(已於 2026-07-19 解決)
 
-`frontend/package.json` 目前:
+本調查當時,`frontend/package.json` 為:
 
 - `dev`:`next dev --webpack` → 開發使用 **Webpack**
 - `build`:`next build` → production 使用 **Turbopack**(Next 16 預設)
@@ -94,6 +96,8 @@ specify known properties, and 'splitChunks' does not exist in type 'TurbopackOpt
 
 **建議:** 統一 dev 也使用 Turbopack(`next dev` 去掉 `--webpack`)——已由 #387 獨立追蹤,並附獨立驗證(dev server 的 HMR、CSS、Socket.IO client 行為煙霧測試),不搭在本文件 PR 上。在那之前,「只有單一 bundler 會讀取的設定」應視為 code review 的警訊。
 
+**後續(2026-07-19):** #387 已完成——commit `7322545`(PR #388)自 `dev` script 移除 `--webpack`,dev 與 build 現在皆使用 Turbopack。本節描述的設定分裂陷阱不復存在:未來任何 `turbopack.*` 設定會同時作用於兩個環境;反之,`webpack()` callback 如今 dev 與 build 都不會讀取,屬純粹的死設定。此事件即〈重新評估觸發條件〉第 3 項,重新評估結果見下方〈重新評估紀錄〉。
+
 ## 問題 4:約 112 KB 的 `polyfill-nomodule.js`(基準文件候選 3)
 
 `docs/frontend-bundle-analysis.md` 指出分析器在每個路由都列出 `polyfill-nomodule.js`(~112 KB),並把結論交由本調查。
@@ -104,7 +108,7 @@ specify known properties, and 'splitChunks' does not exist in type 'TurbopackOpt
 
 ### 採用
 
-1. **不在 `next.config.ts` 加入任何 chunk splitting 設定。** 沒有受支援的 API 可加;且在 dev/build 使用不同 bundler 期間,設定檔維持 bundler 中立。
+1. **不在 `next.config.ts` 加入任何 chunk splitting 設定。** 沒有受支援的 API 可加;且在 dev/build 使用不同 bundler 期間,設定檔維持 bundler 中立。(2026-07-19 更新:bundler 已統一,後半「bundler 中立」理由退役;前半「沒有受支援的 API」仍成立,決策不變——見〈重新評估紀錄〉。)
 2. **Bundle 體積工作僅經由受支援層級進行:** `next/dynamic` 邊界(#381)、逐圖示 subpath 匯入(#382)、有量測依據的重新渲染修正(#383),全部以 `docs/frontend-bundle-analysis.md` 的可重現 `pnpm run analyze` 流程驗證。
 3. **`polyfill-nomodule.js` 以「不採取行動」結案:** 排除於 client-JS 統計,非可移除項目,亦非現代瀏覽器的實際成本。
 
@@ -120,7 +124,24 @@ specify known properties, and 'splitChunks' does not exist in type 'TurbopackOpt
 
 1. Next.js 將 Turbopack 的 chunking 控制 API 升為**穩定**(升級時追蹤 `turbopack` 設定參考頁)。
 2. `pnpm run analyze` 顯示存在單一過大的 client chunk,且可證明 `next/dynamic` 邊界無法拆解(例如某共用 vendor 模組始終被拉進初始 chunk)。
-3. dev/build bundler 統一完成,使 bundler 專屬設定對兩個環境同時生效。
+3. ~~dev/build bundler 統一完成,使 bundler 專屬設定對兩個環境同時生效。~~ → **已於 2026-07-19 觸發並完成重新評估**(見下方〈重新評估紀錄〉);後續重新評估以條件 1、2 為準。
+
+### 重新評估紀錄
+
+#### 2026-07-19:觸發條件 3(dev/build bundler 統一)
+
+**觸發事實:** issue #387 由 PR #388 合併完成(commit `7322545`),自 `frontend/package.json` 的 `dev` script 移除 `--webpack`。dev 與 build 現在皆由 Turbopack 驅動,bundler 專屬設定自此對兩個環境同時生效。
+
+**重新驗證(於 next@16.2.10,lockfile 實際安裝版):**
+
+- `frontend/node_modules/next/dist/server/config-shared.d.ts` 的 `TurbopackOptions` 仍恰好只有原六個欄位(`resolveAlias`、`resolveExtensions`、`rules`、`root`、`debugIds`、`ignoreIssue`),沒有任何 chunking 相關欄位——觸發條件 1 仍未發生。
+- `next.config.ts` 維持既無 `webpack` 也無 `turbopack` 鍵,與原決策一致。
+
+**結論:決策維持不變。** bundler 統一移除的是「設定分裂陷阱」這個**次要**理由,不是主要理由——主要理由(Turbopack 沒有公開穩定的 chunking API)在 next@16.2.10 仍然成立,因此仍然沒有任何受支援的 chunk splitting 設定可加。本次觸發帶來的實際變化:
+
+1. 「維持 `next.config.ts` bundler 中立」不再是防禦性要求。日後若 Next.js 將 chunking 控制升為穩定(觸發條件 1),`turbopack.*` 設定可直接採用,並同時作用於 dev 與 build,不再有「只影響單邊」的陷阱。
+2. Code review 警訊從「只有單一 bundler 會讀取的設定」更新為:`webpack()` callback 如今不被任何環境讀取,任何新增皆為死設定,應直接拒絕。
+3. 觸發條件 3 已消耗;本決策的後續重新評估以觸發條件 1、2 為準。
 
 ### 回退方案
 

--- a/docs/frontend-turbopack-code-splitting.md
+++ b/docs/frontend-turbopack-code-splitting.md
@@ -4,6 +4,8 @@ This document records the investigation requested by issue #380 (a sub-task of t
 
 **Decision (TL;DR): Turbopack in the Next.js version this project uses has no public, stable API equivalent to Webpack's `splitChunks`. We will NOT add any chunk-splitting configuration to `next.config.ts`. Bundle-size work proceeds through the layers that are supported: App Router route splitting (automatic), `next/dynamic` (#381), and per-icon/package imports (#382).**
 
+> **Update 2026-07-19:** re-evaluation trigger 3 (dev/build bundler unification) has occurred via #387 (PR #388, commit `7322545`). The decision was revisited as promised — **it stands unchanged**, because the primary basis (trigger 1: no public, stable chunking API) still holds. See "Re-evaluation record" at the end of this document.
+
 ## Toolchain versions used for this investigation
 
 | Tool | Version |
@@ -80,9 +82,9 @@ With no manual chunking API, splitting responsibilities in this project break do
 
 In other words: nothing that #381–#383 need is blocked by the absence of `splitChunks`. Manual vendor grouping was a Webpack-era tactic; under Turbopack the equivalent outcomes come from async boundaries and import hygiene.
 
-## Question 3: dev/build bundler mismatch
+## Question 3: dev/build bundler mismatch (resolved 2026-07-19)
 
-`frontend/package.json` currently has:
+At the time of this investigation, `frontend/package.json` had:
 
 - `dev`: `next dev --webpack` → development uses **Webpack**
 - `build`: `next build` → production uses **Turbopack** (Next 16 default)
@@ -94,6 +96,8 @@ Implications:
 
 **Recommendation:** unify on Turbopack for dev (`next dev` without `--webpack`) — tracked separately in #387 with its own verification (dev-server smoke test of HMR, CSS, and Socket.IO client behavior), not as a rider on this documentation PR. Until then, treat "config that only one bundler reads" as a review red flag.
 
+**Follow-up (2026-07-19):** #387 is done — commit `7322545` (PR #388) removed `--webpack` from the `dev` script, so dev and build both run Turbopack now. The config-split foot-gun described above no longer exists: any future `turbopack.*` config applies to both environments, and conversely a `webpack()` callback is now read by neither dev nor build — pure dead config. This event is re-evaluation trigger 3; the outcome is recorded in "Re-evaluation record" below.
+
 ## Question 4: the ~112 KB `polyfill-nomodule.js` (baseline candidate 3)
 
 `docs/frontend-bundle-analysis.md` flagged that the analyzer lists `polyfill-nomodule.js` (~112 KB) for every route and deferred the verdict to this investigation.
@@ -104,7 +108,7 @@ Implications:
 
 ### Adopted
 
-1. **No chunk-splitting configuration is added to `next.config.ts`.** There is no supported API to add, and the config file stays bundler-agnostic while dev and build use different bundlers.
+1. **No chunk-splitting configuration is added to `next.config.ts`.** There is no supported API to add, and the config file stays bundler-agnostic while dev and build use different bundlers. (Update 2026-07-19: the bundlers are now unified, retiring the "bundler-agnostic" half of this rationale; the "no supported API" half still holds, so the decision is unchanged — see "Re-evaluation record".)
 2. **Bundle-size work proceeds via supported layers only:** `next/dynamic` boundaries (#381), per-icon subpath imports (#382), measured re-render fixes (#383), all validated with the reproducible `pnpm run analyze` process from `docs/frontend-bundle-analysis.md`.
 3. **`polyfill-nomodule.js` is closed as "no action":** excluded from client-JS accounting, not a removable or real modern-browser cost.
 
@@ -120,7 +124,24 @@ Revisit this decision if any of the following happens:
 
 1. Next.js promotes a chunking-control API for Turbopack to **stable** (watch the `turbopack` config reference page across upgrades).
 2. `pnpm run analyze` shows a single oversized client chunk that `next/dynamic` boundaries demonstrably cannot break up (e.g. a shared vendor module that async boundaries keep pulling into the initial chunk).
-3. The dev/build bundler unification lands and makes bundler-specific config meaningful for both environments.
+3. ~~The dev/build bundler unification lands and makes bundler-specific config meaningful for both environments.~~ → **Fired 2026-07-19 and re-evaluated** (see "Re-evaluation record" below); future re-evaluations are governed by triggers 1 and 2.
+
+### Re-evaluation record
+
+#### 2026-07-19: trigger 3 (dev/build bundler unification)
+
+**What fired:** issue #387 was completed by PR #388 (commit `7322545`), removing `--webpack` from the `dev` script in `frontend/package.json`. Dev and build are now both driven by Turbopack, so bundler-specific config applies to both environments from here on.
+
+**Re-verified (against next@16.2.10, the version actually installed per the lockfile):**
+
+- `TurbopackOptions` in `frontend/node_modules/next/dist/server/config-shared.d.ts` still has exactly the original six fields (`resolveAlias`, `resolveExtensions`, `rules`, `root`, `debugIds`, `ignoreIssue`) and nothing chunking-related — trigger 1 has not occurred.
+- `next.config.ts` still contains no `webpack` and no `turbopack` key, consistent with the original decision.
+
+**Outcome: the decision stands unchanged.** The unification removed the **secondary** rationale (the config-split foot-gun), not the primary one — the primary rationale (Turbopack exposes no public, stable chunking API) still holds in next@16.2.10, so there is still no supported chunk-splitting configuration to add. What actually changes as a result of this trigger:
+
+1. Keeping `next.config.ts` bundler-neutral is no longer a defensive requirement. If Next.js later promotes chunking control to stable (trigger 1), a `turbopack.*` config can be adopted directly and will apply to dev and build alike, with no "only affects one side" trap.
+2. The code-review red flag updates from "config that only one bundler reads" to: a `webpack()` callback is now read by neither environment — any addition of one is dead config and should simply be rejected.
+3. Trigger 3 is consumed; future re-evaluations of this decision are governed by triggers 1 and 2.
 
 ### Rollback
 


### PR DESCRIPTION
## Summary

This PR documents the re-evaluation of the Turbopack code-splitting decision (from issue #380) following the completion of bundler unification work (#387, PR #388). The decision itself remains unchanged, but the rationale and future evaluation criteria are updated to reflect the new state.

## Key Changes

- **Added re-evaluation trigger completion:** Documents that trigger 3 (dev/build bundler unification) has been satisfied by commit `7322545`, which removed `--webpack` from the dev script. Dev and build now both use Turbopack.

- **Updated decision rationale:** Clarifies that the primary reason for the decision (no public, stable Turbopack chunking API) still holds, while the secondary reason (config-split foot-gun) is now retired since bundlers are unified.

- **Updated code-review guidance:** Changes the red flag from "config that only one bundler reads" to "a `webpack()` callback is now read by neither environment — any addition is dead config."

- **Simplified future re-evaluation criteria:** Removes trigger 3 from the list of conditions that would cause re-evaluation, since it has been consumed. Future re-evaluations depend only on triggers 1 and 2 (stable chunking API or demonstrable need for manual splitting).

- **Added re-evaluation record section:** New subsection documenting the 2026-07-19 re-evaluation with verification against next@16.2.10, confirming the decision stands unchanged.

## Notable Details

- Both English and Traditional Chinese versions of the document are updated in parallel
- The re-evaluation confirms that `TurbopackOptions` still lacks any chunking-related fields, validating the continued applicability of the original decision
- The documentation now explicitly tracks that the decision was revisited as promised, improving transparency of the decision-making process

https://claude.ai/code/session_01JD1REeasnwAiEpjxyM5Zs7