### PR TITLE
chore: 建立 Express／Node 舊後端封存與維護流程

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,27 +2,14 @@ name: CI
 
 on:
   push:
-    branches: [main, dev]
-    paths-ignore:
-      - 'docs/**'
-      - 'README.md'
-      - 'README.zh-TW.md'
-      - '.github/ISSUE_TEMPLATE/**'
-      - 'LICENSE'
-      - 'AGENTS.md'
+    branches: [main, dev, 'legacy/backend-express-node']
   pull_request:
-    branches: [main, dev]
-    paths-ignore:
-      - 'docs/**'
-      - 'README.md'
-      - 'README.zh-TW.md'
-      - '.github/ISSUE_TEMPLATE/**'
-      - 'LICENSE'
-      - 'AGENTS.md'
+    branches: [main, dev, 'legacy/backend-express-node']
   workflow_dispatch:
 
 permissions:
   contents: read
+  pull-requests: read
   security-events: write
 
 jobs:
@@ -41,14 +28,26 @@ jobs:
               - 'frontend/**'
               - 'shared/**'
               - 'tsconfig.base.json'
+              - 'package.json'
+              - 'pnpm-workspace.yaml'
+              - '.env.example'
+              - '.dockerignore'
+              - 'docker-compose*.yml'
+              - '.github/workflows/**'
             backend:
               - 'backend/**'
               - 'shared/**'
               - 'tsconfig.base.json'
+              - 'package.json'
+              - 'pnpm-workspace.yaml'
+              - '.env.example'
+              - '.dockerignore'
+              - 'docker-compose*.yml'
+              - '.github/workflows/**'
 
   frontend-lint:
     needs: changes
-    if: needs.changes.outputs.frontend == 'true' || github.event_name == 'workflow_dispatch'
+    if: needs.changes.outputs.frontend == 'true' || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/legacy/backend-express-node' || github.base_ref == 'legacy/backend-express-node'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -65,7 +64,7 @@ jobs:
 
   frontend-typecheck:
     needs: changes
-    if: needs.changes.outputs.frontend == 'true' || github.event_name == 'workflow_dispatch'
+    if: needs.changes.outputs.frontend == 'true' || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/legacy/backend-express-node' || github.base_ref == 'legacy/backend-express-node'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -82,7 +81,7 @@ jobs:
 
   frontend-build:
     needs: changes
-    if: (needs.changes.outputs.frontend == 'true' || github.event_name == 'workflow_dispatch') && (github.ref == 'refs/heads/main' || github.base_ref == 'main')
+    if: ((needs.changes.outputs.frontend == 'true' || github.event_name == 'workflow_dispatch') && (github.ref == 'refs/heads/main' || github.base_ref == 'main')) || github.ref == 'refs/heads/legacy/backend-express-node' || github.base_ref == 'legacy/backend-express-node'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -99,7 +98,7 @@ jobs:
 
   backend-build:
     needs: changes
-    if: (needs.changes.outputs.backend == 'true' || github.event_name == 'workflow_dispatch') && (github.ref == 'refs/heads/main' || github.base_ref == 'main')
+    if: ((needs.changes.outputs.backend == 'true' || github.event_name == 'workflow_dispatch') && (github.ref == 'refs/heads/main' || github.base_ref == 'main')) || github.ref == 'refs/heads/legacy/backend-express-node' || github.base_ref == 'legacy/backend-express-node'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -116,7 +115,7 @@ jobs:
 
   unit-tests:
     needs: changes
-    if: needs.changes.outputs.backend == 'true' || github.event_name == 'workflow_dispatch'
+    if: needs.changes.outputs.backend == 'true' || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/legacy/backend-express-node' || github.base_ref == 'legacy/backend-express-node'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -133,7 +132,7 @@ jobs:
 
   integration-tests:
     needs: changes
-    if: needs.changes.outputs.backend == 'true' || github.event_name == 'workflow_dispatch'
+    if: needs.changes.outputs.backend == 'true' || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/legacy/backend-express-node' || github.base_ref == 'legacy/backend-express-node'
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -167,7 +166,7 @@ jobs:
 
   e2e-tests:
     needs: changes
-    if: needs.changes.outputs.backend == 'true' || github.event_name == 'workflow_dispatch'
+    if: needs.changes.outputs.backend == 'true' || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/legacy/backend-express-node' || github.base_ref == 'legacy/backend-express-node'
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -201,7 +200,7 @@ jobs:
 
   security-scan:
     needs: changes
-    if: (needs.changes.outputs.frontend == 'true' || needs.changes.outputs.backend == 'true' || github.event_name == 'workflow_dispatch') && (github.ref == 'refs/heads/main' || github.base_ref == 'main')
+    if: ((needs.changes.outputs.frontend == 'true' || needs.changes.outputs.backend == 'true' || github.event_name == 'workflow_dispatch') && (github.ref == 'refs/heads/main' || github.base_ref == 'main')) || github.ref == 'refs/heads/legacy/backend-express-node' || github.base_ref == 'legacy/backend-express-node'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -248,3 +247,64 @@ jobs:
         with:
           sarif_file: frontend.sarif
           category: frontend
+
+  legacy-required:
+    name: Legacy required checks
+    needs:
+      - changes
+      - frontend-lint
+      - frontend-typecheck
+      - frontend-build
+      - backend-build
+      - unit-tests
+      - integration-tests
+      - e2e-tests
+      - security-scan
+    if: always()
+    runs-on: ubuntu-latest
+    env:
+      NEEDS_JSON: ${{ toJSON(needs) }}
+      LEGACY_RUN: ${{ github.ref == 'refs/heads/legacy/backend-express-node' || github.base_ref == 'legacy/backend-express-node' }}
+    steps:
+      - name: 驗證所有必要工作
+        shell: bash
+        run: |
+          set -euo pipefail
+          failed="$(jq -r '
+            to_entries[]
+            | select(.value.result != "success" and .value.result != "skipped")
+            | "\(.key)=\(.value.result)"
+          ' <<< "$NEEDS_JSON")"
+
+          if [[ -n "$failed" ]]; then
+            echo "下列必要工作未成功：" >&2
+            echo "$failed" >&2
+            exit 1
+          fi
+
+          if [[ "$LEGACY_RUN" == "true" ]]; then
+            incomplete="$(jq -r '
+              to_entries[]
+              | .key as $job
+              | select([
+                  "frontend-lint",
+                  "frontend-typecheck",
+                  "frontend-build",
+                  "backend-build",
+                  "unit-tests",
+                  "integration-tests",
+                  "e2e-tests",
+                  "security-scan"
+                ] | index($job))
+              | select(.value.result != "success")
+              | "\(.key)=\(.value.result)"
+            ' <<< "$NEEDS_JSON")"
+
+            if [[ -n "$incomplete" ]]; then
+              echo "Legacy push／PR 的完整檢查不得 skipped 或未成功：" >&2
+              echo "$incomplete" >&2
+              exit 1
+            fi
+          fi
+
+          echo "所有必要工作皆為 success 或 skipped。"

--- a/.github/workflows/release-legacy-backend.yml
+++ b/.github/workflows/release-legacy-backend.yml
@@ -55,6 +55,9 @@ jobs:
           set -euo pipefail
           tag_ref="refs/tags/${GITHUB_REF_NAME}"
 
+          git fetch --force origin \
+            "${tag_ref}:${tag_ref}"
+
           object_type="$(git cat-file -t "$tag_ref")"
           if [[ "$object_type" != "tag" ]]; then
             echo "封存版本必須使用 annotated tag；實際 object type：$object_type" >&2

--- a/.github/workflows/release-legacy-backend.yml
+++ b/.github/workflows/release-legacy-backend.yml
@@ -1,0 +1,309 @@
+name: 發布 Express／Node 舊後端
+
+on:
+  push:
+    tags:
+      - 'backend-express-node-v*'
+
+concurrency:
+  group: release-legacy-backend-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: nearcsie/near-chat-backend
+
+jobs:
+  publish:
+    name: 驗證、建置映像並建立封存 Release
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: write
+      packages: write
+      attestations: write
+      id-token: write
+    steps:
+      - name: 取出完整封存歷史
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: 驗證版本標籤並計算映像標籤
+        id: image
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! "$GITHUB_REF_NAME" =~ ^backend-express-node-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "標籤格式必須是 backend-express-node-vX.Y.Z：$GITHUB_REF_NAME" >&2
+            exit 1
+          fi
+
+          version="${GITHUB_REF_NAME#backend-}"
+          short_sha="${GITHUB_SHA:0:12}"
+          {
+            echo "version=$version"
+            echo "sha_tag=sha-$short_sha"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: 驗證 annotated tag、legacy HEAD 與成功 CI
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tag_ref="refs/tags/${GITHUB_REF_NAME}"
+
+          object_type="$(git cat-file -t "$tag_ref")"
+          if [[ "$object_type" != "tag" ]]; then
+            echo "封存版本必須使用 annotated tag；實際 object type：$object_type" >&2
+            exit 1
+          fi
+
+          peeled_sha="$(git rev-parse "${tag_ref}^{}")"
+          peeled_type="$(git cat-file -t "$peeled_sha")"
+          if [[ "$peeled_type" != "commit" || "$peeled_sha" != "$GITHUB_SHA" ]]; then
+            echo "Tag peeled commit 必須等於 workflow commit：tag=$peeled_sha workflow=$GITHUB_SHA" >&2
+            exit 1
+          fi
+
+          git fetch --no-tags origin \
+            '+refs/heads/legacy/backend-express-node:refs/remotes/origin/legacy/backend-express-node'
+          legacy_sha="$(git rev-parse refs/remotes/origin/legacy/backend-express-node)"
+          if [[ "$legacy_sha" != "$GITHUB_SHA" ]]; then
+            echo "Tag 必須指向 legacy/backend-express-node HEAD：legacy=$legacy_sha tag=$GITHUB_SHA" >&2
+            exit 1
+          fi
+
+          runs="$(gh api --method GET \
+            -H 'Accept: application/vnd.github+json' \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "/repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs" \
+            -f head_sha="$GITHUB_SHA" \
+            -f branch=legacy/backend-express-node \
+            -f event=push \
+            -f status=completed \
+            -f per_page=100)"
+          run_id="$(jq -r '
+            [.workflow_runs[] | select(.conclusion == "success")]
+            | first
+            | .id // empty
+          ' <<< "$runs")"
+          if [[ -z "$run_id" ]]; then
+            echo "找不到此 commit 在 legacy branch 已完成且成功的 ci.yml push run：$GITHUB_SHA" >&2
+            exit 1
+          fi
+
+          jobs="$(gh api --method GET \
+            -H 'Accept: application/vnd.github+json' \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "/repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/jobs" \
+            -f per_page=100)"
+          if ! jq -e '
+            .jobs
+            | any(.name == "Legacy required checks" and .conclusion == "success")
+          ' <<< "$jobs" >/dev/null; then
+            echo "成功的 CI run 未包含通過的 Legacy required checks gate：run_id=$run_id" >&2
+            exit 1
+          fi
+
+      - name: 檢查既有 GitHub Release
+        id: release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          release_json="$RUNNER_TEMP/existing-legacy-release.json"
+          release_error="$RUNNER_TEMP/existing-legacy-release.error"
+
+          if gh api "/repos/${GITHUB_REPOSITORY}/releases/tags/${GITHUB_REF_NAME}" \
+            > "$release_json" 2> "$release_error"; then
+            echo 'exists=true' >> "$GITHUB_OUTPUT"
+            echo "Release 已存在；後續只驗證，不會覆寫。"
+          elif grep -q 'HTTP 404' "$release_error"; then
+            echo 'exists=false' >> "$GITHUB_OUTPUT"
+            echo "Release 尚未建立。"
+          else
+            cat "$release_error" >&2
+            exit 1
+          fi
+
+      - name: 登入 GitHub Container Registry
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 設定 Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: 檢查不可變映像參照
+        id: registry
+        shell: bash
+        env:
+          VERSION_REF: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.image.outputs.version }}
+          SHA_REF: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.image.outputs.sha_tag }}
+          RELEASE_EXISTS: ${{ steps.release.outputs.exists }}
+        run: |
+          set -euo pipefail
+
+          inspect_digest() {
+            local ref="$1"
+            local output digest
+            local error_file="$RUNNER_TEMP/imagetools-inspect.error"
+
+            if output="$(docker buildx imagetools inspect "$ref" 2> "$error_file")"; then
+              digest="$(awk '$1 == "Digest:" { print $2; exit }' <<< "$output")"
+              if [[ ! "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+                echo "無法從映像參照解析 digest：$ref" >&2
+                exit 1
+              fi
+              printf '%s' "$digest"
+              return 0
+            fi
+
+            if grep -Eiq '(manifest unknown|name unknown|not found|no such manifest)' "$error_file"; then
+              echo "映像參照不存在：$ref" >&2
+              return 0
+            fi
+
+            cat "$error_file" >&2
+            return 1
+          }
+
+          version_digest="$(inspect_digest "$VERSION_REF")"
+          sha_digest="$(inspect_digest "$SHA_REF")"
+
+          if [[ -z "$version_digest" && -z "$sha_digest" ]]; then
+            if [[ "$RELEASE_EXISTS" == "true" ]]; then
+              echo "Release 已存在但兩個映像參照皆遺失；拒絕以新建置取代既有 digest。" >&2
+              exit 1
+            fi
+            echo 'build_required=true' >> "$GITHUB_OUTPUT"
+            echo 'resolved_digest=' >> "$GITHUB_OUTPUT"
+            echo "兩個映像參照皆不存在，允許首次建置。"
+          elif [[ -n "$version_digest" && -n "$sha_digest" ]]; then
+            if [[ "$version_digest" != "$sha_digest" ]]; then
+              echo "版本與 commit 映像的 digest 不一致，拒絕覆寫。" >&2
+              echo "version=$version_digest sha=$sha_digest" >&2
+              exit 1
+            fi
+            if [[ "$RELEASE_EXISTS" != "true" ]]; then
+              echo "兩個映像參照已存在但 Release 不存在；拒絕替既有 artifact 補簽 provenance 或自動建立 Release。" >&2
+              exit 1
+            fi
+            echo 'build_required=false' >> "$GITHUB_OUTPUT"
+            echo "resolved_digest=$version_digest" >> "$GITHUB_OUTPUT"
+            echo "兩個映像參照已存在且一致，沿用 $version_digest。"
+          else
+            echo "只存在一個映像參照，屬於不完整發布；拒絕自動修補或覆寫。" >&2
+            echo "version=${version_digest:-missing} sha=${sha_digest:-missing}" >&2
+            exit 1
+          fi
+
+      - name: 首次建置並推送後端映像
+        if: steps.registry.outputs.build_required == 'true'
+        id: push
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          file: ./backend/Dockerfile.prod
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.image.outputs.version }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.image.outputs.sha_tag }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.image.outputs.version }}
+
+      - name: 解析最終映像 Digest
+        id: resolved
+        shell: bash
+        env:
+          BUILD_REQUIRED: ${{ steps.registry.outputs.build_required }}
+          EXISTING_DIGEST: ${{ steps.registry.outputs.resolved_digest }}
+          BUILT_DIGEST: ${{ steps.push.outputs.digest }}
+        run: |
+          set -euo pipefail
+          if [[ "$BUILD_REQUIRED" == "true" ]]; then
+            digest="$BUILT_DIGEST"
+          else
+            digest="$EXISTING_DIGEST"
+          fi
+
+          if [[ ! "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "最終映像 digest 無效：$digest" >&2
+            exit 1
+          fi
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+
+      - name: 驗證既有 Release 不可變內容
+        if: steps.release.outputs.exists == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          IMAGE_DIGEST: ${{ steps.resolved.outputs.digest }}
+        run: |
+          set -euo pipefail
+          body="$(gh release view "$GITHUB_REF_NAME" \
+            --repo "$GITHUB_REPOSITORY" \
+            --json body \
+            --jq .body)"
+
+          if [[ "$body" != *"$GITHUB_SHA"* ]]; then
+            echo "既有 Release body 未包含預期 commit SHA，拒絕修改。" >&2
+            exit 1
+          fi
+          if [[ "$body" != *"$IMAGE_DIGEST"* ]]; then
+            echo "既有 Release body 未包含預期映像 digest，拒絕修改。" >&2
+            exit 1
+          fi
+          echo "既有 Release 與 commit／digest 一致；不進行任何修改。"
+
+      - name: 建立映像來源證明
+        if: steps.release.outputs.exists == 'false' && steps.registry.outputs.build_required == 'true'
+        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.resolved.outputs.digest }}
+          push-to-registry: true
+          create-storage-record: false
+
+      - name: 建立 GitHub Release
+        if: steps.release.outputs.exists == 'false' && steps.registry.outputs.build_required == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          IMAGE_VERSION: ${{ steps.image.outputs.version }}
+          IMAGE_SHA_TAG: ${{ steps.image.outputs.sha_tag }}
+          IMAGE_DIGEST: ${{ steps.resolved.outputs.digest }}
+        run: |
+          set -euo pipefail
+          notes_file="$RUNNER_TEMP/legacy-backend-release-notes.md"
+          image="${REGISTRY}/${IMAGE_NAME}"
+
+          {
+            echo '# Express／Node 舊後端封存版本'
+            echo
+            printf -- '- 封存標籤：`%s`\n' "$GITHUB_REF_NAME"
+            printf -- '- 程式 Commit：`%s`\n' "$GITHUB_SHA"
+            printf -- '- 容器映像：`%s:%s`\n' "$image" "$IMAGE_VERSION"
+            printf -- '- Commit 映像標籤：`%s:%s`\n' "$image" "$IMAGE_SHA_TAG"
+            printf -- '- 映像 Digest：`%s@%s`\n' "$image" "$IMAGE_DIGEST"
+            echo
+            echo '此版本只接受安全漏洞、資料損壞、無法啟動與阻斷性相容問題的修補，不再新增功能。資料庫異動必須遵守 expand-and-contract，直到 Hono 穩定上線後 30 天的維護期結束。'
+            echo
+            printf -- '操作與維護文件：[繁體中文](https://github.com/%s/blob/%s/docs/ZH-TW/legacy-backend.md)／[English](https://github.com/%s/blob/%s/docs/legacy-backend.md)\n' \
+              "$GITHUB_REPOSITORY" "$GITHUB_REF_NAME" "$GITHUB_REPOSITORY" "$GITHUB_REF_NAME"
+          } > "$notes_file"
+
+          gh release create "$GITHUB_REF_NAME" \
+            --repo "$GITHUB_REPOSITORY" \
+            --verify-tag \
+            --title "Express／Node 舊後端 $IMAGE_VERSION" \
+            --notes-file "$notes_file" \
+            --latest=false

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A real-time group chat application built as an NTNU Database Theories course pro
 - [Getting Started](#getting-started)
 - [Production Deployment](#production-deployment)
 - [Testing](#testing)
+- [Legacy Express Backend](#legacy-express-backend)
 
 ---
 
@@ -139,3 +140,6 @@ docker compose -f docker-compose.prod.yml down
 
 For detailed instructions on running unit, integration, and E2E tests, please refer directly to the [Developer & Testing Guide](docs/DEVELOPMENT.md#5-testing-guide).
 
+## Legacy Express Backend
+
+The frozen Express / Node backend baseline, rollback procedure, and critical-fix-only maintenance policy are documented in the [Legacy Backend Archive](docs/legacy-backend.md).

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -15,6 +15,7 @@
 - [快速開始](#快速開始)
 - [生產環境部署](#生產環境部署)
 - [測試指令](#測試指令)
+- [Express 舊後端封存](#express-舊後端封存)
 
 ---
 
@@ -138,3 +139,6 @@ docker compose -f docker-compose.prod.yml down
 
 關於如何執行單元測試、整合測試與 E2E 測試的詳細說明，請直接參閱 [開發者與測試指南](docs/ZH-TW/DEVELOPMENT.md#5-測試指南)。
 
+## Express 舊後端封存
+
+Express／Node 後端的凍結基線、回滾方式與僅限重大修補的維護政策，請參閱 [舊後端封存文件](docs/ZH-TW/legacy-backend.md)。

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -2,7 +2,7 @@ services:
   db:
     image: postgres:18-alpine
     ports:
-      - "5435:5432"
+      - "${POSTGRES_HOST_PORT:-5435}:5432"
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
@@ -20,7 +20,7 @@ services:
       context: .
       dockerfile: ./backend/Dockerfile.prod
     ports:
-      - "4005:4000"
+      - "${BACKEND_HOST_PORT:-4005}:4000"
     environment:
       - NODE_ENV=${NODE_ENV}
       - PORT=${PORT}
@@ -47,7 +47,7 @@ services:
       args:
         - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
     ports:
-      - "3005:3000"
+      - "${FRONTEND_HOST_PORT:-3005}:3000"
     environment:
       - NODE_ENV=${NODE_ENV}
       - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -2,7 +2,7 @@ services:
   db-test:
     image: postgres:18-alpine
     ports:
-      - "5436:5432"
+      - "${TEST_POSTGRES_HOST_PORT:-5436}:5432"
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
@@ -20,4 +20,4 @@ services:
 networks:
   app_network:
     external: true
-    name: near-chat_network
+    name: ${COMPOSE_NETWORK_NAME:-near-chat_network}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   db:
     image: postgres:18-alpine
     ports:
-      - "5435:5432"
+      - "${POSTGRES_HOST_PORT:-5435}:5432"
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
@@ -20,7 +20,7 @@ services:
       context: ./backend
       dockerfile: Dockerfile
     ports:
-      - "4005:4000"
+      - "${BACKEND_HOST_PORT:-4005}:4000"
     environment:
       - NODE_ENV=${NODE_ENV}
       - PORT=${PORT}
@@ -51,7 +51,7 @@ services:
       context: ./frontend
       dockerfile: Dockerfile
     ports:
-      - "3005:3000"
+      - "${FRONTEND_HOST_PORT:-3005}:3000"
     environment:
       - NODE_ENV=${NODE_ENV}
       - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
@@ -72,4 +72,4 @@ volumes:
 
 networks:
   default:
-    name: near-chat_network
+    name: ${COMPOSE_NETWORK_NAME:-near-chat_network}

--- a/docs/ZH-TW/legacy-backend.md
+++ b/docs/ZH-TW/legacy-backend.md
@@ -1,0 +1,115 @@
+# Express／Node 舊後端封存
+
+[English](../legacy-backend.md) | 繁體中文
+
+本文件定義 Express 後端的凍結基線、允許用途與維護政策。封存範圍是完整 Monorepo，因為後端仍依賴共享型別、PostgreSQL migration、Docker 設定、前端合約及文件。
+
+## 封存識別資訊
+
+| 項目 | 凍結值 |
+| --- | --- |
+| 應用程式碼基線 | `f6debb622da60afcdd8071fe32c7f327cf6b2933`（`f6debb6`） |
+| Annotated Release tag | `backend-express-node-v1.0.0` |
+| 維護分支 | `legacy/backend-express-node` |
+| Runtime | Node.js 24 |
+| 套件管理器 | pnpm 11 |
+| HTTP framework | Express 5.2.1 |
+| 即時通訊伺服器 | Socket.IO 4.8.3 |
+| 資料庫 | PostgreSQL 18 |
+
+Release tag 會指向包含本政策與封存 workflow 的 freeze merge commit；該 commit 中的正式應用程式碼仍以 `f6debb6` 為基線。
+
+## 啟動封存版本
+
+請使用獨立 clone 或 worktree，以免 checkout 封存版本時干擾 Hono 原始碼。Worktree 只隔離 checkout，**不會**自動隔離 Docker container、volume、network 或 host port；只要封存 stack 會與其他 checkout 同時執行，就必須設定下列 Compose 變數：
+
+```bash
+export COMPOSE_PROJECT_NAME=near-chat-express-node
+export COMPOSE_NETWORK_NAME=near-chat-express-node_network
+export POSTGRES_HOST_PORT=55435
+export BACKEND_HOST_PORT=44005
+export FRONTEND_HOST_PORT=43005
+export TEST_POSTGRES_HOST_PORT=55436
+export NEXT_PUBLIC_API_URL=http://localhost:44005
+export CORS_ORIGINS=http://localhost:43005
+git fetch origin --tags
+git worktree add ../near-chat-express-node backend-express-node-v1.0.0
+cd ../near-chat-express-node
+cp .env.example .env
+docker compose up -d --build
+docker compose ps
+```
+
+只要不是純本機開發，就必須先替換 `.env` 內的開發用密鑰。不得對需要保留的資料執行 `db:seed`，因為 seed 指令會重設應用資料。
+
+`COMPOSE_PROJECT_NAME` 會讓此 checkout 使用獨立的 `near-chat-express-node_pgdata` 與 `near-chat-express-node_app_uploads` named volume；`COMPOSE_NETWORK_NAME` 與 host-port 變數則避免 network 和 port 衝突。每次執行 Compose 指令都必須維持同一組 shell exports。
+
+套用上述設定後，後端位於 `http://localhost:44005`、前端位於 `http://localhost:43005`、PostgreSQL 位於 `localhost:55435`。後端容器啟動時會先套用尚未執行的 migration。
+
+## 驗證與測試
+
+Legacy CI 使用 Node.js 24 與 pnpm 11。每次 push 到 `legacy/backend-express-node`，以及每個以該分支為 target 的 Pull Request，都會忽略 changed paths，完整執行前端 lint／type／build、後端 build／type、unit test、PostgreSQL 18 integration test、E2E test 與 security scan；path filter 只用於減少 `main`／`dev` 的工作。若要在本機透過 Docker 重現檢查、同時隔離開發資料庫，請執行：
+
+```bash
+export COMPOSE_PROJECT_NAME=near-chat-express-node
+export COMPOSE_NETWORK_NAME=near-chat-express-node_network
+export POSTGRES_HOST_PORT=55435
+export BACKEND_HOST_PORT=44005
+export FRONTEND_HOST_PORT=43005
+export TEST_POSTGRES_HOST_PORT=55436
+export NEXT_PUBLIC_API_URL=http://localhost:44005
+export CORS_ORIGINS=http://localhost:43005
+cp backend/.env.test.example backend/.env.test
+docker compose up -d --build
+docker compose -f docker-compose.test.yml up -d --wait
+docker compose exec backend pnpm run build
+docker compose exec backend pnpm exec tsc --noEmit
+docker compose exec frontend pnpm run lint
+docker compose exec frontend pnpm exec tsc --noEmit
+docker compose exec backend pnpm run test:unit
+docker compose exec -e DATABASE_URL=postgresql://postgres:postgres@db-test:5432/ntnu_test backend pnpm run migrate:up
+docker compose exec backend pnpm run test:integration
+docker compose exec backend pnpm run test:e2e
+docker compose -f docker-compose.test.yml down
+```
+
+測試資料庫位於 `localhost:55436`、使用 tmpfs，並與封存專案自己的 `pgdata` volume 隔離。封存驗證期間不得執行 `docker compose down -v`，因為該指令會刪除此封存專案的持久化開發資料與 uploads。
+
+## Release 映像與回滾
+
+推送符合 `backend-express-node-v*` 的 tag 後，workflow 會以 repo root 為 build context、使用 `backend/Dockerfile.prod` 發布下列兩個映像參照：
+
+- `ghcr.io/nearcsie/near-chat-backend:express-node-v1.0.0`
+- `ghcr.io/nearcsie/near-chat-backend:sha-<12-character-commit>`
+
+雖然 trigger 使用 glob，實際發布只接受完全符合 `backend-express-node-vX.Y.Z` 的格式。該 ref 必須是 annotated tag，其 peeled commit 必須同時等於遠端 `legacy/backend-express-node` HEAD，並且已有一筆 completed 且 successful 的 `ci.yml` run。
+
+GitHub Release 會記錄完整 commit SHA 與內容 digest。需要確定性回滾時，應使用 digest 而非可變 tag：
+
+```bash
+docker pull ghcr.io/nearcsie/near-chat-backend@sha256:<digest-from-release>
+```
+
+替換 Hono 前，必須先備份 PostgreSQL 與 uploads 掛載來源、確認目前 schema 仍與 Express 相容，並且只停止 backend service，不得刪除 volume。部署 digest-pinned 映像時，沿用既有後端環境變數、network、`4000` port 與 `/app/uploads` mount。映像啟動 Express 前會先執行 legacy migration。若 schema 已超過下節定義的相容期，請還原經測試的資料庫備份，不得臨時嘗試未規劃的 `migrate:down`。
+
+若採原始碼回滾，請從 `backend-express-node-v1.0.0` 的乾淨 checkout 搭配 `docker-compose.prod.yml` 部署，並在部署變更紀錄中填入 Release 的實際 digest，以便日後稽核執行檔來源。
+
+發布 workflow 將版本與 commit 兩個映像參照都視為不可變，只允許乾淨的首次發布（Release 不存在且兩個映像參照都不存在），或驗證完整的既有發布（Release 已存在且兩個參照解析為相同 digest）。任何只有映像、沒有 Release 的 partial publish 都必須人工調查；workflow 不會替既有 artifact 補簽 provenance，也不會以它自動建立缺少的 Release。既有 Release 絕不編輯，其 body 必須已包含預期 commit SHA 與 digest。若 Release 已存在但任一映像參照遺失，workflow 不會自動重建，因為新 build 可能產生不同 digest。
+
+## 維護與資料庫相容規則
+
+- 維護分支只接受安全漏洞、資料遺失或毀損、無法啟動，以及阻斷性相容問題的修補；不接受新功能。
+- 所有變更都必須透過 Pull Request、通過必要 CI 並取得至少一人核准。Branch protection 只要求固定的 `Legacy required checks` status；任何適用的 lint、type、build、test 或 security job 失敗或取消時，該 gate 都會失敗。禁止直接 push、force-push 或刪除分支。
+- 每次接受的修補都建立 patch tag，例如 `backend-express-node-v1.0.1`。適用的修補再以 cherry-pick 或獨立實作同步到 Hono；禁止將 Hono 變更反向 merge 到 legacy 分支。
+- 在 Hono 被宣告於 production 穩定後的 30 個日曆天內，migration 必須維持 Express 向後相容。先加入 additive schema、再遷移 reader／writer，最後才在相容期結束後移除或重新命名（expand-and-contract）。
+- Hono production 穩定日期與推算出的 EOL 日期必須記錄在專案 Release 或追蹤 Issue。EOL 時將維護分支設為唯讀；tag、Release、digest 與 provenance attestation 永久保留。
+
+## 已知限制與封存衛生
+
+- 此版本是凍結的相容目標，不是平行產品線；功能需求應在 Hono 實作。
+- 可透過文件指定的 project、network 與 host-port 變數隔離 Compose 資源，但獨立 worktree 不會自動完成隔離。未設定時，仍可能與其他 checkout 的 port 或 `near-chat_network` 衝突。
+- 開發與正式 Dockerfile 目前追蹤 `node:lts-slim` 並啟用 `pnpm@latest`。Node 24／pnpm 11 是驗證基線；已發布映像的 digest 才是可重現部署的最終依據。
+- Partial publish 一律不自動修復。既有映像沒有 Release、只存在單一參照、digest mismatch、既有 Release 不一致，或 Release 已存在但映像遺失時，都必須人工調查。Workflow 不替既有 artifact 簽署 provenance、不以它新建 Release、不覆寫已發布參照或 Release，也不會在既有 Release 下重建遺失映像。
+- Uploads 使用檔案系統儲存，不屬於 Git 或容器映像的一部分，必須另行備份與還原。
+- 資料庫相容性只保證到定義的過渡期結束；EOL 後的 Hono-only 破壞性 migration 可能使 Express 無法啟動。
+- 封存 tag 與 Release 只能包含原始碼及產生的 metadata。禁止提交或附加 `.env`、包含真實資料的 database volume／dump、uploads、token、credential 或任何其他 secret。

--- a/docs/legacy-backend.md
+++ b/docs/legacy-backend.md
@@ -1,0 +1,115 @@
+# Express / Node Legacy Backend Archive
+
+[繁體中文](ZH-TW/legacy-backend.md) | English
+
+This document defines the frozen Express backend baseline, its supported use cases, and its maintenance policy. The archive covers the complete monorepo because the backend depends on shared types, PostgreSQL migrations, Docker configuration, frontend contracts, and documentation.
+
+## Archive identity
+
+| Item | Frozen value |
+| --- | --- |
+| Application-code baseline | `f6debb622da60afcdd8071fe32c7f327cf6b2933` (`f6debb6`) |
+| Annotated release tag | `backend-express-node-v1.0.0` |
+| Maintenance branch | `legacy/backend-express-node` |
+| Runtime | Node.js 24 |
+| Package manager | pnpm 11 |
+| HTTP framework | Express 5.2.1 |
+| Realtime server | Socket.IO 4.8.3 |
+| Database | PostgreSQL 18 |
+
+The release tag points to the freeze merge commit containing this policy and the archive workflows. Production application code at that commit remains based on `f6debb6`.
+
+## Start the archived stack
+
+Use a separate clone or worktree so that checking out the archive does not disturb Hono source files. A worktree isolates only the checkout; it does **not** isolate Docker containers, volumes, networks, or host ports. The Compose variables below are therefore required whenever this archived stack is started alongside another checkout:
+
+```bash
+export COMPOSE_PROJECT_NAME=near-chat-express-node
+export COMPOSE_NETWORK_NAME=near-chat-express-node_network
+export POSTGRES_HOST_PORT=55435
+export BACKEND_HOST_PORT=44005
+export FRONTEND_HOST_PORT=43005
+export TEST_POSTGRES_HOST_PORT=55436
+export NEXT_PUBLIC_API_URL=http://localhost:44005
+export CORS_ORIGINS=http://localhost:43005
+git fetch origin --tags
+git worktree add ../near-chat-express-node backend-express-node-v1.0.0
+cd ../near-chat-express-node
+cp .env.example .env
+docker compose up -d --build
+docker compose ps
+```
+
+Replace the development secrets in `.env` before any non-local deployment. Do not run `db:seed` against data that must be preserved; the seed command resets application data.
+
+`COMPOSE_PROJECT_NAME` gives this checkout its own `near-chat-express-node_pgdata` and `near-chat-express-node_app_uploads` named volumes, while `COMPOSE_NETWORK_NAME` and the host-port variables prevent network and port collisions. Keep these exports in the same shell for every Compose command.
+
+With these values, the backend is available at `http://localhost:44005`, the frontend at `http://localhost:43005`, and PostgreSQL at `localhost:55435`. The backend applies pending migrations when its container starts.
+
+## Verification and tests
+
+The legacy CI uses Node.js 24 and pnpm 11. Every push to `legacy/backend-express-node` and every pull request targeting it runs the full frontend lint/type/build, backend build/type, unit, PostgreSQL 18 integration, E2E, and security suite regardless of changed paths. Path filters reduce work only for `main` and `dev`. To reproduce the Docker-based checks locally without using the development database:
+
+```bash
+export COMPOSE_PROJECT_NAME=near-chat-express-node
+export COMPOSE_NETWORK_NAME=near-chat-express-node_network
+export POSTGRES_HOST_PORT=55435
+export BACKEND_HOST_PORT=44005
+export FRONTEND_HOST_PORT=43005
+export TEST_POSTGRES_HOST_PORT=55436
+export NEXT_PUBLIC_API_URL=http://localhost:44005
+export CORS_ORIGINS=http://localhost:43005
+cp backend/.env.test.example backend/.env.test
+docker compose up -d --build
+docker compose -f docker-compose.test.yml up -d --wait
+docker compose exec backend pnpm run build
+docker compose exec backend pnpm exec tsc --noEmit
+docker compose exec frontend pnpm run lint
+docker compose exec frontend pnpm exec tsc --noEmit
+docker compose exec backend pnpm run test:unit
+docker compose exec -e DATABASE_URL=postgresql://postgres:postgres@db-test:5432/ntnu_test backend pnpm run migrate:up
+docker compose exec backend pnpm run test:integration
+docker compose exec backend pnpm run test:e2e
+docker compose -f docker-compose.test.yml down
+```
+
+The test database listens on `localhost:55436`, uses tmpfs, and is isolated from the archive's project-scoped `pgdata` volume. Never use `docker compose down -v` during archive verification because it deletes this archive project's persistent development data and uploads.
+
+## Release image and rollback
+
+Pushing a tag matching `backend-express-node-v*` publishes both of these references from the repository-root build context and `backend/Dockerfile.prod`:
+
+- `ghcr.io/nearcsie/near-chat-backend:express-node-v1.0.0`
+- `ghcr.io/nearcsie/near-chat-backend:sha-<12-character-commit>`
+
+Although the trigger uses a glob, publishing accepts only the exact `backend-express-node-vX.Y.Z` format. The ref must be an annotated tag whose peeled commit is both the remote `legacy/backend-express-node` HEAD and a commit with a completed successful `ci.yml` run.
+
+The GitHub Release records the full commit SHA and content digest. Use the digest, rather than a mutable tag, for a deterministic rollback:
+
+```bash
+docker pull ghcr.io/nearcsie/near-chat-backend@sha256:<digest-from-release>
+```
+
+Before replacing Hono, back up PostgreSQL and the uploads mount, confirm the current schema is still Express-compatible, and stop only the backend service. Do not delete volumes. Deploy the digest-pinned image with the existing backend environment variables, network, port `4000`, and `/app/uploads` mount. The image runs pending legacy migrations before starting Express. If the schema has crossed the compatibility window described below, restore a tested database backup instead of attempting an unplanned `migrate:down`.
+
+For a source-based rollback, deploy from a clean checkout of `backend-express-node-v1.0.0` with `docker-compose.prod.yml`. Record the actual Release digest in the deployment change so the binary can be audited later.
+
+The publishing workflow treats both version and commit image references as immutable. It permits only a clean first publication (no Release and neither image reference exists) or verification of a complete existing publication (the Release exists and both references resolve to the same digest). Any image-only partial publication requires manual investigation: the workflow does not attest an existing artifact or create a missing Release around it. An existing Release is never edited; its body must already contain the expected commit SHA and digest. If a Release exists but either image reference is missing, the workflow does not rebuild because a new build could produce a different digest.
+
+## Maintenance and database compatibility
+
+- The maintenance branch accepts only fixes for security vulnerabilities, data loss or corruption, startup failures, and blocking compatibility defects. It does not accept features.
+- Every change must use a pull request, pass the required CI, and receive at least one approval. Protect the branch by requiring only the `Legacy required checks` status; this fixed gate fails when any applicable lint, type, build, test, or security job fails or is cancelled. Direct pushes, force-pushes, and branch deletion are prohibited.
+- Each accepted fix receives a patch tag such as `backend-express-node-v1.0.1`. Applicable fixes are then cherry-picked or independently ported to Hono; Hono changes are never merged back into the legacy branch.
+- Until 30 calendar days after Hono is declared stable in production, migrations must remain backward-compatible with Express. Additive changes land first; readers and writers are migrated next; destructive removal or renaming occurs only after the compatibility window (expand-and-contract).
+- Record the Hono stable-production date and the resulting EOL date in the project Release or tracking issue. At EOL, make the maintenance branch read-only. Tags, Releases, digests, and provenance attestations remain permanently available.
+
+## Known limitations and archive hygiene
+
+- This is a frozen compatibility target, not a parallel product line; feature requests belong to Hono.
+- Compose resources can be isolated by the documented project, network, and host-port variables, but a separate worktree does not provide that isolation automatically. Omitting the variables may collide with another checkout's ports or `near-chat_network`.
+- The development and production Dockerfiles track `node:lts-slim` and activate `pnpm@latest`. Node 24 and pnpm 11 are the validated baseline, while the published image digest is the authoritative reproducible artifact.
+- Partial publication is never repaired automatically. Existing images without a Release, a single existing reference, a digest mismatch, an inconsistent existing Release, or an existing Release with missing images all require manual investigation. The workflow never signs provenance for a pre-existing artifact, never wraps it in a new Release, never overwrites published references or Releases, and never rebuilds missing images beneath an existing Release.
+- Uploads are filesystem-backed and are not part of Git or the container image. They require a separate backup and restore procedure.
+- Database compatibility is guaranteed only during the defined transition window. Post-EOL Hono-only destructive migrations may prevent the Express backend from starting.
+- Archive tags and Releases must contain source and generated metadata only. Never commit or attach `.env` files, database volumes or dumps containing real data, uploads, tokens, credentials, or other secrets.


### PR DESCRIPTION
## 摘要

- 以 `f6debb6` 為 Express／Node 應用程式碼基線，封存完整 monorepo。
- 新增中英文 legacy 操作、回滾、維護期限與資料庫相容政策。
- Legacy PR／push 強制執行 frontend lint／type／build、backend build／type、unit、integration、E2E 與 security scan。
- 新增 annotated tag 驗證、不可變 GHCR 映像、digest、provenance 與繁中 GitHub Release workflow。
- 以 Compose project、network、volume 與 host port 變數隔離封存環境，避免碰觸既有開發資料。

## 基線與分支說明

遠端 `dev` 已在規劃後前進，因此本 PR 直接以固定在 `f6debb6` 的 `legacy/backend-express-node` 為 target，避免封存 tag 混入基線後的新程式碼。CI 全綠並合併後，annotated tag 與 Release 將指向該 merge commit。

## 驗證

- `git diff --check`
- 兩份 GitHub Actions YAML parse
- 所有 workflow `run` block 通過 `bash -n`
- dev／test／production 三份 Compose config 驗證
- Legacy gate success／skipped／failure 行為模擬
- Production backend／frontend Docker build 與 backend unit tests
- 獨立 code review：APPROVE

Release 不包含 `.env`、真實資料庫 volume、uploads 或秘密；驗證流程不執行 `db:seed` 或 `docker compose down -v`。