### PR TITLE
Replace dynamic Icon imports with static Boxicons components

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,6 @@
   },
   "dependencies": {
     "@iconify-react/boxicons": "^1.0.2",
-    "@iconify/react": "^6.0.2",
     "clsx": "^2.1.1",
     "next": "16.2.10",
     "react": "19.2.7",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -16,9 +16,6 @@ importers:
       '@iconify-react/boxicons':
         specifier: ^1.0.2
         version: 1.0.2(react@19.2.7)
-      '@iconify/react':
-        specifier: ^6.0.2
-        version: 6.0.2(react@19.2.7)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -255,11 +252,6 @@ packages:
     resolution: {integrity: sha512-k33FKG4jGgd8odos+1HdSwCKZOQ5F1heQxwl/zDrA53tLg5IseDPMqsmQbcCEZ6E0Zgcrmfo4ceFSBmbuEvGtw==}
     peerDependencies:
       react: '>=18.0.0'
-
-  '@iconify/react@6.0.2':
-    resolution: {integrity: sha512-SMmC2sactfpJD427WJEDN6PMyznTFMhByK9yLW0gOTtnjzzbsi/Ke/XqsumsavFPwNiXs8jSiYeZTmLCLwO+Fg==}
-    peerDependencies:
-      react: '>=16'
 
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
@@ -2333,11 +2325,6 @@ snapshots:
       - react
 
   '@iconify/css-react@1.0.2(react@19.2.7)':
-    dependencies:
-      '@iconify/types': 2.0.0
-      react: 19.2.7
-
-  '@iconify/react@6.0.2(react@19.2.7)':
     dependencies:
       '@iconify/types': 2.0.0
       react: 19.2.7

--- a/frontend/src/components/chat/Chatroom.tsx
+++ b/frontend/src/components/chat/Chatroom.tsx
@@ -12,7 +12,12 @@ import { ChatBubble } from "@/components/ui/ChatBubble";
 import { useTranslation } from "@/hooks/useTranslation";
 import { Modal } from "@/components/ui/Modal";
 import { Input } from "@/components/ui/Input";
-import { Icon } from "@iconify/react";
+import SliderVerticalIcon from "@iconify-react/boxicons/slider-vertical";
+import SearchIcon from "@iconify-react/boxicons/search";
+import DotsHorizontalRoundedIcon from "@iconify-react/boxicons/dots-horizontal-rounded";
+import SidebarRightIcon from "@iconify-react/boxicons/sidebar-right";
+import XIcon from "@iconify-react/boxicons/x";
+import PaperclipIcon from "@iconify-react/boxicons/paperclip";
 
 interface ChatroomProps {
   roomId: string;
@@ -523,7 +528,7 @@ export default function Chatroom({ roomId, onOpenGroupSettings }: ChatroomProps)
               onClick={onOpenGroupSettings}
               className="py-1 px-3 text-xs flex items-center gap-1.5"
             >
-              <Icon icon="boxicons:slider-vertical" className="h-3.5 w-3.5" />
+              <SliderVerticalIcon aria-hidden="true" className="h-3.5 w-3.5" />
               <span className="hidden sm:inline">{t("chatroom.groupSettings")}</span>
             </Button>
           )}
@@ -537,7 +542,7 @@ export default function Chatroom({ roomId, onOpenGroupSettings }: ChatroomProps)
             }`}
             title={isSearchOpen ? t("chatroom.closeSearch") : t("chatroom.searchMessages")}
           >
-            <Icon icon="boxicons:search" className="h-4 w-4" />
+            <SearchIcon aria-hidden="true" className="h-4 w-4" />
           </button>
 
           <Dropdown
@@ -546,7 +551,7 @@ export default function Chatroom({ roomId, onOpenGroupSettings }: ChatroomProps)
                 className="p-1.5 border border-border-secondary hover:border-border-primary rounded-sm text-text-muted hover:text-foreground transition-colors cursor-pointer"
                 title={t("chatroom.chatOptions")}
               >
-                <Icon icon="bx:dots-horizontal-rounded" className="h-4 w-4" />
+                <DotsHorizontalRoundedIcon aria-hidden="true" className="h-4 w-4" />
               </button>
             }
             items={[
@@ -576,7 +581,7 @@ export default function Chatroom({ roomId, onOpenGroupSettings }: ChatroomProps)
             }`}
             title={showRightPanel ? t("chatroom.hideInfoPanel") : t("chatroom.showInfoPanel")}
           >
-            <Icon icon="boxicons:sidebar-right" className="h-4 w-4" />
+            <SidebarRightIcon aria-hidden="true" className="h-4 w-4" />
           </button>
         </div>
       </div>
@@ -584,7 +589,7 @@ export default function Chatroom({ roomId, onOpenGroupSettings }: ChatroomProps)
       {/* Search Bar */}
       {isSearchOpen && (
         <div className="border-b border-border-primary bg-surface-card px-3 md:px-6 py-2 flex items-center gap-2 shrink-0">
-          <Icon icon="boxicons:search" className="h-4 w-4 text-text-muted shrink-0" />
+          <SearchIcon aria-hidden="true" className="h-4 w-4 text-text-muted shrink-0" />
           <input
             ref={searchInputRef}
             type="text"
@@ -604,7 +609,7 @@ export default function Chatroom({ roomId, onOpenGroupSettings }: ChatroomProps)
             onClick={handleToggleSearch}
             className="p-0.5 text-text-muted hover:text-foreground transition-colors cursor-pointer shrink-0"
           >
-            <Icon icon="boxicons:x" className="h-4 w-4" />
+            <XIcon aria-hidden="true" className="h-4 w-4" />
           </button>
         </div>
       )}
@@ -786,7 +791,7 @@ export default function Chatroom({ roomId, onOpenGroupSettings }: ChatroomProps)
             onClick={() => setReplyTarget(null)}
             className="text-text-muted hover:text-foreground cursor-pointer p-0.5 border border-transparent hover:border-border-primary rounded-sm ml-4"
           >
-            <Icon icon="boxicons:x" className="h-3.5 w-3.5" />
+            <XIcon aria-hidden="true" className="h-3.5 w-3.5" />
           </button>
         </div>
       )}
@@ -861,7 +866,7 @@ export default function Chatroom({ roomId, onOpenGroupSettings }: ChatroomProps)
                 title={t("chatroom.uploadAttachment")}
                 className="p-2.5 border border-border-secondary hover:border-border-primary rounded-sm text-text-muted hover:text-foreground transition-colors cursor-pointer shrink-0 mb-0.5"
               >
-                <Icon icon="boxicons:paperclip" className="h-4 w-4" />
+                <PaperclipIcon aria-hidden="true" className="h-4 w-4" />
               </button>
               <div className="relative flex-1">
                 {editingMessage && (

--- a/frontend/src/components/layout/MobileNav.tsx
+++ b/frontend/src/components/layout/MobileNav.tsx
@@ -4,7 +4,11 @@ import React from "react";
 import { usePathname, useRouter } from "next/navigation";
 import { useChat } from "@/context/ChatContext";
 import { useTranslation } from "@/hooks/useTranslation";
-import { Icon } from "@iconify/react";
+import MessageDetailIcon from "@iconify-react/boxicons/message-detail";
+import GroupIcon from "@iconify-react/boxicons/group";
+import AlertTriangleIcon from "@iconify-react/boxicons/alert-triangle";
+import CogIcon from "@iconify-react/boxicons/cog";
+import LogoutIcon from "@iconify-react/boxicons/arrow-out-left-square-half-filled";
 
 type NavItem = {
   label: string;
@@ -33,7 +37,7 @@ export default function MobileNav() {
       label: t("rail.chats"),
       active: pathname === "/" || pathname.startsWith("/chat"),
       onClick: () => router.push("/"),
-      icon: <Icon icon="boxicons:message-detail" className="h-5 w-5 shrink-0" />,
+      icon: <MessageDetailIcon aria-hidden="true" className="h-5 w-5 shrink-0" />,
     },
     {
       label: t("rail.friends"),
@@ -43,25 +47,25 @@ export default function MobileNav() {
         router.push("/friends");
       },
       badge: pendingIncoming,
-      icon: <Icon icon="boxicons:group" className="h-5 w-5 shrink-0" />,
+      icon: <GroupIcon aria-hidden="true" className="h-5 w-5 shrink-0" />,
     },
     {
       label: t("rail.emergency"),
       active: pathname === "/emergency",
       onClick: () => router.push("/emergency"),
-      icon: <Icon icon="boxicons:alert-triangle" className="h-5 w-5 shrink-0" />,
+      icon: <AlertTriangleIcon aria-hidden="true" className="h-5 w-5 shrink-0" />,
     },
     {
       label: t("sidebar.settings"),
       active: pathname === "/settings",
       onClick: () => router.push("/settings"),
-      icon: <Icon icon="boxicons:cog" className="h-5 w-5 shrink-0" />,
+      icon: <CogIcon aria-hidden="true" className="h-5 w-5 shrink-0" />,
     },
     {
       label: t("sidebar.logout"),
       active: false,
       onClick: handleLogout,
-      icon: <Icon icon="boxicons:arrow-out-left-square-half-filled" className="h-5 w-5 shrink-0" />,
+      icon: <LogoutIcon aria-hidden="true" className="h-5 w-5 shrink-0" />,
     },
   ];
 

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -10,7 +10,17 @@ import { Modal } from "@/components/ui/Modal";
 import { useTranslation } from "@/hooks/useTranslation";
 import ChatList from "./ChatList";
 import FriendInfoPanel from "@/components/chat/FriendInfoPanel";
-import { Icon } from "@iconify/react";
+import MessageDetailIcon from "@iconify-react/boxicons/message-detail";
+import GroupIcon from "@iconify-react/boxicons/group";
+import AlertTriangleIcon from "@iconify-react/boxicons/alert-triangle";
+import CogIcon from "@iconify-react/boxicons/cog";
+import LogoutIcon from "@iconify-react/boxicons/arrow-out-left-square-half-filled";
+import SearchIcon from "@iconify-react/boxicons/search";
+import PlusIcon from "@iconify-react/boxicons/plus";
+import UserIcon from "@iconify-react/boxicons/user";
+import PlusSquareIcon from "@iconify-react/boxicons/plus-square";
+import JoinGroupIcon from "@iconify-react/boxicons/arrow-down-stroke-square";
+import FolderPlusIcon from "@iconify-react/boxicons/folder-plus";
 import { resolveAssetUrl } from "@/lib/assets";
 
 export default function Sidebar() {
@@ -104,7 +114,7 @@ export default function Sidebar() {
       label: t("rail.chats"),
       active: pathname === "/" || pathname.startsWith("/chat"),
       onClick: () => router.push(firstChatPath),
-      icon: <Icon icon="boxicons:message-detail" className="h-5 w-5 shrink-0" />,
+      icon: <MessageDetailIcon aria-hidden="true" className="h-5 w-5 shrink-0" />,
     },
     {
       label: t("rail.friends"),
@@ -114,25 +124,25 @@ export default function Sidebar() {
         router.push("/friends");
       },
       badge: pendingIncoming,
-      icon: <Icon icon="boxicons:group" className="h-5 w-5 shrink-0" />,
+      icon: <GroupIcon aria-hidden="true" className="h-5 w-5 shrink-0" />,
     },
     {
       label: t("rail.emergency"),
       active: pathname === "/emergency",
       onClick: () => router.push("/emergency"),
-      icon: <Icon icon="boxicons:alert-triangle" className="h-5 w-5 shrink-0" />,
+      icon: <AlertTriangleIcon aria-hidden="true" className="h-5 w-5 shrink-0" />,
     },
     {
       label: t("sidebar.settings"),
       active: isSettingsPage,
       onClick: () => router.push("/settings"),
-      icon: <Icon icon="boxicons:cog" className="h-5 w-5 shrink-0" />,
+      icon: <CogIcon aria-hidden="true" className="h-5 w-5 shrink-0" />,
     },
     {
       label: t("sidebar.logout"),
       active: false,
       onClick: handleLogout,
-      icon: <Icon icon="boxicons:arrow-out-left-square-half-filled" className="h-5 w-5 shrink-0" />,
+      icon: <LogoutIcon aria-hidden="true" className="h-5 w-5 shrink-0" />,
     },
   ];
 
@@ -152,7 +162,7 @@ export default function Sidebar() {
           {/* Search bar */}
           <div className="flex-1 relative">
             <span className="absolute inset-y-0 left-0 flex items-center pl-2 text-text-muted">
-              <Icon icon="boxicons:bx-search" className="h-3.5 w-3.5" />
+              <SearchIcon aria-hidden="true" className="h-3.5 w-3.5" />
             </span>
             <input
               type="text"
@@ -166,7 +176,7 @@ export default function Sidebar() {
           <div className="flex gap-1 shrink-0">
             <IconButton
               label={t("sidebar.actions")}
-              icon="boxicons:plus"
+              icon={<PlusIcon aria-hidden="true" className="h-4 w-4" />}
               onClick={() => {
                 setJoinInviteCode("");
                 setJoinError("");
@@ -202,7 +212,7 @@ export default function Sidebar() {
             />
           ) : (
             <div className="flex flex-col items-center justify-center h-full text-text-muted text-xs text-center p-4">
-              <Icon icon="boxicons:user" className="h-10 w-10 text-text-muted/30 mb-2" />
+              <UserIcon aria-hidden="true" className="h-10 w-10 text-text-muted/30 mb-2" />
               <p>{t("profileCard.selectPrompt")}</p>
             </div>
           )
@@ -277,7 +287,7 @@ export default function Sidebar() {
               }}
               className="flex items-center gap-4 p-4 border-b border-border-primary hover:bg-surface-muted transition-all cursor-pointer text-left w-full group select-none rounded-none"
             >
-              <Icon icon="boxicons:plus-square" className="h-6 w-6 text-text-muted group-hover:text-primary transition-colors shrink-0" />
+              <PlusSquareIcon aria-hidden="true" className="h-6 w-6 text-text-muted group-hover:text-primary transition-colors shrink-0" />
               <div className="flex-1 min-w-0">
                 <p className="text-sm font-bold text-foreground leading-snug">{t("sidebar.createGroup")}</p>
                 <p className="text-xs text-text-muted mt-1 leading-normal">{t("sidebar.createGroupDesc")}</p>
@@ -294,7 +304,7 @@ export default function Sidebar() {
               }}
               className="flex items-center gap-4 p-4 border-b border-border-primary hover:bg-surface-muted transition-all cursor-pointer text-left w-full group select-none rounded-none"
             >
-              <Icon icon="boxicons:arrow-down-stroke-square" className="h-6 w-6 text-text-muted group-hover:text-primary transition-colors shrink-0" />
+              <JoinGroupIcon aria-hidden="true" className="h-6 w-6 text-text-muted group-hover:text-primary transition-colors shrink-0" />
               <div className="flex-1 min-w-0">
                 <p className="text-sm font-bold text-foreground leading-snug">{t("sidebar.joinGroup")}</p>
                 <p className="text-xs text-text-muted mt-1 leading-normal">{t("sidebar.joinGroupDesc")}</p>
@@ -310,7 +320,7 @@ export default function Sidebar() {
               }}
               className="flex items-center gap-4 p-4 hover:bg-surface-muted transition-all cursor-pointer text-left w-full group select-none rounded-none"
             >
-              <Icon icon="boxicons:folder-plus" className="h-6 w-6 text-text-muted group-hover:text-primary transition-colors shrink-0" />
+              <FolderPlusIcon aria-hidden="true" className="h-6 w-6 text-text-muted group-hover:text-primary transition-colors shrink-0" />
               <div className="flex-1 min-w-0">
                 <p className="text-sm font-bold text-foreground leading-snug">{t("sidebar.createFolder")}</p>
                 <p className="text-xs text-text-muted mt-1 leading-normal">{t("sidebar.createFolderDesc")}</p>
@@ -406,7 +416,7 @@ function IconButton({
 }: {
   label: string;
   onClick: () => void;
-  icon: string;
+  icon: React.ReactNode;
 }) {
   return (
     <button
@@ -415,7 +425,7 @@ function IconButton({
       aria-label={label}
       className="p-1 text-text-muted hover:text-foreground border border-transparent hover:border-border-primary rounded-sm transition-colors cursor-pointer flex items-center justify-center shrink-0"
     >
-      <Icon icon={icon} className="h-4 w-4" />
+      {icon}
     </button>
   );
 }


### PR DESCRIPTION
## Summary
Refactored icon usage across the frontend to replace dynamic `@iconify/react` Icon components with static imported Boxicons components. This improves tree-shaking, reduces bundle size, and provides better type safety.

## Key Changes
- **Sidebar.tsx**: Replaced 13 dynamic `Icon` component calls with static imports from `@iconify-react/boxicons` (MessageDetailIcon, GroupIcon, AlertTriangleIcon, CogIcon, LogoutIcon, SearchIcon, PlusIcon, UserIcon, PlusSquareIcon, JoinGroupIcon, FolderPlusIcon)
- **Chatroom.tsx**: Replaced 6 dynamic `Icon` component calls with static imports (SliderVerticalIcon, SearchIcon, DotsHorizontalRoundedIcon, SidebarRightIcon, XIcon, PaperclipIcon)
- **MobileNav.tsx**: Replaced 5 dynamic `Icon` component calls with static imports (MessageDetailIcon, GroupIcon, AlertTriangleIcon, CogIcon, LogoutIcon)
- **IconButton component**: Updated prop type from `icon: string` to `icon: React.ReactNode` to accept JSX elements instead of icon name strings
- **Accessibility**: Added `aria-hidden="true"` to all icon components to properly indicate decorative icons
- **Dependencies**: Removed `@iconify/react` from package.json as it's no longer needed

## Implementation Details
- All icon components now use named imports from `@iconify-react/boxicons` package
- Icon sizing and styling (className props) remain consistent with previous implementation
- The IconButton component was refactored to render the icon node directly instead of wrapping it in an Icon component
- This change enables better static analysis and tree-shaking by the bundler

https://claude.ai/code/session_01N5d3aCkAXZiNRFnVWLmegS