### PR TITLE
ci: 新增後端版本映像自動發布

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,18 @@ jobs:
               - 'frontend/**'
               - 'shared/**'
               - 'tsconfig.base.json'
+              - 'package.json'
+              - 'pnpm-workspace.yaml'
+              - '.dockerignore'
+              - '.github/workflows/**'
             backend:
               - 'backend/**'
               - 'shared/**'
               - 'tsconfig.base.json'
+              - 'package.json'
+              - 'pnpm-workspace.yaml'
+              - '.dockerignore'
+              - '.github/workflows/**'
 
   frontend-lint:
     needs: changes

--- a/.github/workflows/release-backend.yml
+++ b/.github/workflows/release-backend.yml
@@ -1,0 +1,314 @@
+name: 發布後端容器映像
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+concurrency:
+  group: release-backend-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: nearcsie/near-chat-backend
+
+jobs:
+  publish:
+    name: 驗證版本、發布映像與建立 Release
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: write
+      packages: write
+      attestations: write
+      id-token: write
+    steps:
+      - name: 取出完整版本歷史
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: 驗證版本標籤、main HEAD 與成功 CI
+        id: version
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "$GITHUB_REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "版本標籤必須完全符合 vX.Y.Z：$GITHUB_REF_NAME" >&2
+            exit 1
+          fi
+
+          version="${GITHUB_REF_NAME#v}"
+          package_version="$(jq -r '.version // empty' backend/package.json)"
+          if [[ "$package_version" != "$version" ]]; then
+            echo "Tag 版本必須等於 backend/package.json：tag=$version package=$package_version" >&2
+            exit 1
+          fi
+
+          tag_ref="refs/tags/${GITHUB_REF_NAME}"
+          git fetch --force origin "${tag_ref}:${tag_ref}"
+          object_type="$(git cat-file -t "$tag_ref")"
+          if [[ "$object_type" != "tag" ]]; then
+            echo "正式版本必須使用 annotated tag；實際 object type：$object_type" >&2
+            exit 1
+          fi
+
+          peeled_sha="$(git rev-parse "${tag_ref}^{}")"
+          if [[ "$(git cat-file -t "$peeled_sha")" != "commit" || "$peeled_sha" != "$GITHUB_SHA" ]]; then
+            echo "Tag peeled commit 必須等於 workflow commit：tag=$peeled_sha workflow=$GITHUB_SHA" >&2
+            exit 1
+          fi
+
+          git fetch --no-tags origin '+refs/heads/main:refs/remotes/origin/main'
+          main_sha="$(git rev-parse refs/remotes/origin/main)"
+          if [[ "$main_sha" != "$GITHUB_SHA" ]]; then
+            echo "版本 tag 必須指向目前 main HEAD：main=$main_sha tag=$GITHUB_SHA" >&2
+            exit 1
+          fi
+
+          runs="$(gh api --method GET \
+            -H 'Accept: application/vnd.github+json' \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "/repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs" \
+            -f head_sha="$GITHUB_SHA" \
+            -f branch=main \
+            -f event=push \
+            -f status=completed \
+            -f per_page=100)"
+          run_id="$(jq -r '
+            [.workflow_runs[] | select(.conclusion == "success")]
+            | first
+            | .id // empty
+          ' <<< "$runs")"
+          if [[ -z "$run_id" ]]; then
+            echo "找不到此 main commit 已完成且成功的 ci.yml push run：$GITHUB_SHA" >&2
+            exit 1
+          fi
+
+          jobs="$(gh api --method GET \
+            -H 'Accept: application/vnd.github+json' \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "/repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/jobs" \
+            -f per_page=100)"
+          required='["backend-build","unit-tests","integration-tests","e2e-tests","security-scan"]'
+          if ! jq -e --argjson required "$required" '
+            [.jobs[] | select(.conclusion == "success") | .name] as $successful
+            | ($required - $successful | length == 0)
+          ' <<< "$jobs" >/dev/null; then
+            echo "Main CI run 未包含全部成功的後端發布必要工作：run_id=$run_id" >&2
+            exit 1
+          fi
+
+          {
+            echo "number=$version"
+            echo "sha_tag=sha-${GITHUB_SHA:0:12}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: 檢查既有 GitHub Release
+        id: release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          release_json="$RUNNER_TEMP/existing-backend-release.json"
+          release_error="$RUNNER_TEMP/existing-backend-release.error"
+
+          if gh api "/repos/${GITHUB_REPOSITORY}/releases/tags/${GITHUB_REF_NAME}" \
+            > "$release_json" 2> "$release_error"; then
+            echo 'exists=true' >> "$GITHUB_OUTPUT"
+            echo "Release 已存在；後續只驗證，不會覆寫。"
+          elif grep -q 'HTTP 404' "$release_error"; then
+            echo 'exists=false' >> "$GITHUB_OUTPUT"
+            echo "Release 尚未建立。"
+          else
+            cat "$release_error" >&2
+            exit 1
+          fi
+
+      - name: 登入 GitHub Container Registry
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 設定 Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: 檢查不可變映像參照
+        id: registry
+        shell: bash
+        env:
+          VERSION_REF: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.number }}
+          SHA_REF: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.sha_tag }}
+          RELEASE_EXISTS: ${{ steps.release.outputs.exists }}
+        run: |
+          set -euo pipefail
+
+          inspect_digest() {
+            local ref="$1"
+            local output digest
+            local error_file="$RUNNER_TEMP/imagetools-inspect.error"
+
+            if output="$(docker buildx imagetools inspect "$ref" 2> "$error_file")"; then
+              digest="$(awk '$1 == "Digest:" { print $2; exit }' <<< "$output")"
+              if [[ ! "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+                echo "無法從映像參照解析 digest：$ref" >&2
+                exit 1
+              fi
+              printf '%s' "$digest"
+              return 0
+            fi
+
+            if grep -Eiq '(manifest unknown|name unknown|not found|no such manifest)' "$error_file"; then
+              echo "映像參照不存在：$ref" >&2
+              return 0
+            fi
+
+            cat "$error_file" >&2
+            return 1
+          }
+
+          version_digest="$(inspect_digest "$VERSION_REF")"
+          sha_digest="$(inspect_digest "$SHA_REF")"
+
+          if [[ -z "$version_digest" && -z "$sha_digest" ]]; then
+            if [[ "$RELEASE_EXISTS" == "true" ]]; then
+              echo "Release 已存在但兩個映像參照皆遺失；拒絕以新建置取代既有 digest。" >&2
+              exit 1
+            fi
+            echo 'build_required=true' >> "$GITHUB_OUTPUT"
+            echo 'resolved_digest=' >> "$GITHUB_OUTPUT"
+          elif [[ -n "$version_digest" && -n "$sha_digest" ]]; then
+            if [[ "$version_digest" != "$sha_digest" ]]; then
+              echo "版本與 commit 映像的 digest 不一致，拒絕覆寫。" >&2
+              exit 1
+            fi
+            if [[ "$RELEASE_EXISTS" != "true" ]]; then
+              echo "映像已存在但 Release 不存在；拒絕包裝或補簽既有 artifact。" >&2
+              exit 1
+            fi
+            echo 'build_required=false' >> "$GITHUB_OUTPUT"
+            echo "resolved_digest=$version_digest" >> "$GITHUB_OUTPUT"
+          else
+            echo "只存在一個映像參照，屬於不完整發布；拒絕自動修補。" >&2
+            exit 1
+          fi
+
+      - name: 首次建置並推送後端映像
+        if: steps.registry.outputs.build_required == 'true'
+        id: push
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          file: ./backend/Dockerfile.prod
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.number }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.sha_tag }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.version.outputs.number }}
+
+      - name: 解析最終映像 Digest
+        id: resolved
+        shell: bash
+        env:
+          BUILD_REQUIRED: ${{ steps.registry.outputs.build_required }}
+          EXISTING_DIGEST: ${{ steps.registry.outputs.resolved_digest }}
+          BUILT_DIGEST: ${{ steps.push.outputs.digest }}
+        run: |
+          set -euo pipefail
+          if [[ "$BUILD_REQUIRED" == "true" ]]; then
+            digest="$BUILT_DIGEST"
+          else
+            digest="$EXISTING_DIGEST"
+          fi
+
+          if [[ ! "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "最終映像 digest 無效：$digest" >&2
+            exit 1
+          fi
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+
+      - name: 驗證既有 Release 不可變內容
+        if: steps.release.outputs.exists == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          IMAGE_DIGEST: ${{ steps.resolved.outputs.digest }}
+        run: |
+          set -euo pipefail
+          body="$(gh release view "$GITHUB_REF_NAME" \
+            --repo "$GITHUB_REPOSITORY" \
+            --json body \
+            --jq .body)"
+          if [[ "$body" != *"$GITHUB_SHA"* || "$body" != *"$IMAGE_DIGEST"* ]]; then
+            echo "既有 Release 與預期 commit／digest 不一致，拒絕修改。" >&2
+            exit 1
+          fi
+
+      - name: 建立映像來源證明
+        if: steps.release.outputs.exists == 'false' && steps.registry.outputs.build_required == 'true'
+        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.resolved.outputs.digest }}
+          push-to-registry: true
+          create-storage-record: false
+
+      - name: 驗證映像來源證明
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          IMAGE_DIGEST: ${{ steps.resolved.outputs.digest }}
+        run: |
+          set -euo pipefail
+          gh attestation verify \
+            "oci://${REGISTRY}/${IMAGE_NAME}@${IMAGE_DIGEST}" \
+            --repo "$GITHUB_REPOSITORY" \
+            --signer-workflow "$GITHUB_REPOSITORY/.github/workflows/release-backend.yml" \
+            --source-digest "$GITHUB_SHA" \
+            --bundle-from-oci
+
+      - name: 建立 GitHub Release
+        if: steps.release.outputs.exists == 'false' && steps.registry.outputs.build_required == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION_NUMBER: ${{ steps.version.outputs.number }}
+          IMAGE_SHA_TAG: ${{ steps.version.outputs.sha_tag }}
+          IMAGE_DIGEST: ${{ steps.resolved.outputs.digest }}
+        run: |
+          set -euo pipefail
+          notes_file="$RUNNER_TEMP/backend-release-notes.md"
+          image="${REGISTRY}/${IMAGE_NAME}"
+
+          {
+            echo '# Near Chat 後端正式版本'
+            echo
+            printf -- '- 版本：`%s`\n' "$GITHUB_REF_NAME"
+            printf -- '- 程式 Commit：`%s`\n' "$GITHUB_SHA"
+            printf -- '- 容器映像：`%s:%s`\n' "$image" "$VERSION_NUMBER"
+            printf -- '- Commit 映像標籤：`%s:%s`\n' "$image" "$IMAGE_SHA_TAG"
+            printf -- '- 映像 Digest：`%s@%s`\n' "$image" "$IMAGE_DIGEST"
+            echo
+            echo '此映像由 main 的成功 CI commit 建置。部署與回滾應固定使用 Release 記錄的 digest。'
+            echo
+            printf -- '發布說明：[繁體中文](https://github.com/%s/blob/%s/docs/ZH-TW/backend-release.md)／[English](https://github.com/%s/blob/%s/docs/backend-release.md)\n' \
+              "$GITHUB_REPOSITORY" "$GITHUB_REF_NAME" "$GITHUB_REPOSITORY" "$GITHUB_REF_NAME"
+          } > "$notes_file"
+
+          gh release create "$GITHUB_REF_NAME" \
+            --repo "$GITHUB_REPOSITORY" \
+            --verify-tag \
+            --title "Near Chat 後端 $GITHUB_REF_NAME" \
+            --notes-file "$notes_file" \
+            --latest=false

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A real-time group chat application built as an NTNU Database Theories course pro
 - [Getting Started](#getting-started)
 - [Production Deployment](#production-deployment)
 - [Testing](#testing)
+- [Backend Releases](#backend-releases)
 
 ---
 
@@ -139,3 +140,6 @@ docker compose -f docker-compose.prod.yml down
 
 For detailed instructions on running unit, integration, and E2E tests, please refer directly to the [Developer & Testing Guide](docs/DEVELOPMENT.md#5-testing-guide).
 
+## Backend Releases
+
+Annotated `vX.Y.Z` tags automatically publish immutable GHCR backend images and a digest-recorded GitHub Release. See the [Backend Version Release Guide](docs/backend-release.md).

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -15,6 +15,7 @@
 - [快速開始](#快速開始)
 - [生產環境部署](#生產環境部署)
 - [測試指令](#測試指令)
+- [後端版本發布](#後端版本發布)
 
 ---
 
@@ -138,3 +139,6 @@ docker compose -f docker-compose.prod.yml down
 
 關於如何執行單元測試、整合測試與 E2E 測試的詳細說明，請直接參閱 [開發者與測試指南](docs/ZH-TW/DEVELOPMENT.md#5-測試指南)。
 
+## 後端版本發布
+
+推送 annotated `vX.Y.Z` tag 後，系統會自動發布不可變的 GHCR 後端映像，以及記錄 digest 的 GitHub Release。詳見[後端版本發布指南](docs/ZH-TW/backend-release.md)。

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -1,9 +1,9 @@
 # Stage 1: Build the backend application
-FROM node:lts-slim AS builder
+FROM node:24-slim@sha256:6f7b03f7c2c8e2e784dcf9295400527b9b1270fd37b7e9a7285cf83b6951452d AS builder
 ENV CI=true
 
 RUN apt-get update -y && apt-get install -y openssl
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN corepack enable && corepack prepare pnpm@11.15.0 --activate
 
 WORKDIR /workspace
 
@@ -15,7 +15,7 @@ COPY shared/ ./shared/
 COPY backend/package.json backend/pnpm-lock.yaml backend/tsconfig.json ./backend/
 
 WORKDIR /workspace/backend
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store,uid=1000,gid=1000 \
+RUN --mount=type=cache,id=pnpm-v11-builder,target=/pnpm/store,uid=1000,gid=1000 \
     pnpm install --store-dir /pnpm/store --no-frozen-lockfile --ignore-scripts
 
 # Copy backend source code and compile
@@ -23,11 +23,11 @@ COPY backend/src ./src
 RUN pnpm build
 
 # Stage 2: Create a production runner image
-FROM node:lts-slim AS runner
+FROM node:24-slim@sha256:6f7b03f7c2c8e2e784dcf9295400527b9b1270fd37b7e9a7285cf83b6951452d AS runner
 ENV CI=true
 
 RUN apt-get update -y && apt-get install -y openssl && rm -rf /var/lib/apt/lists/*
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN corepack enable && corepack prepare pnpm@11.15.0 --activate
 
 WORKDIR /app
 
@@ -41,7 +41,7 @@ USER node
 
 # Copy production dependency declarations
 COPY --chown=node:node backend/package.json backend/pnpm-lock.yaml ./
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store,uid=1000,gid=1000 \
+RUN --mount=type=cache,id=pnpm-v11-runner,target=/pnpm/store,uid=1000,gid=1000 \
     pnpm install --store-dir /pnpm/store --prod --no-frozen-lockfile --ignore-scripts
 
 # Copy compiled files and migrations

--- a/docs/ZH-TW/backend-release.md
+++ b/docs/ZH-TW/backend-release.md
@@ -1,0 +1,36 @@
+# 後端版本發布
+
+[English](../backend-release.md) | 繁體中文
+
+`main` 上的 Express／Node 後端採用 Semantic Versioning。PR #392 合併的應用程式基線是 `5455d6a524c39eeafd4bfb860afb3a7c6fb8b27a`，套件版本為 `1.0.0`。第一個 Release tag 會指向稍後加入本發布自動化、但不改變後端行為的 `main` commit。
+
+## 發布版本
+
+只有推送完全符合 `vX.Y.Z` 的 annotated tag 才會啟動發布。數字版本必須等於 `backend/package.json`，tag 必須指向目前 `main` HEAD，而且同一個 commit 必須已有成功的 main CI run，包含 backend build、unit、integration、E2E 與 security jobs。
+
+```bash
+git switch main
+git pull --ff-only origin main
+git tag -a v1.0.0 -m "Near Chat backend v1.0.0"
+git push origin v1.0.0
+```
+
+Workflow 會發布：
+
+- `ghcr.io/nearcsie/near-chat-backend:1.0.0`
+- `ghcr.io/nearcsie/near-chat-backend:sha-<12-character-commit>`
+- provenance attestation，以及記錄完整 commit 與映像 digest 的繁體中文 GitHub Release
+
+不發布可變的 `latest` tag。部署與回滾應固定使用 digest：
+
+```bash
+docker pull ghcr.io/nearcsie/near-chat-backend@sha256:<digest-from-release>
+```
+
+## 不可變與失敗處理
+
+版本與 commit 映像參照都視為不可變。乾淨的首次發布要求 GitHub Release 與兩個映像參照都不存在。重新執行時，只驗證兩個參照解析為相同 digest、且 Release 已記錄該 commit 與 digest 的完整既有發布。
+
+若發生 partial publication、digest 不一致、只有 Release 沒有映像，或只有映像沒有 Release，workflow 會停止。它不會自動覆寫或重建既有版本；必須先人工調查 registry 與 Release 再決定後續處理。
+
+Production image 使用 Node.js 24 與 pnpm 11。發布成果不得包含 `.env`、credential、包含真實資料的 database volume／dump，或使用者 uploads。

--- a/docs/backend-release.md
+++ b/docs/backend-release.md
@@ -1,0 +1,36 @@
+# Backend Version Release
+
+[繁體中文](ZH-TW/backend-release.md) | English
+
+The Express / Node backend on `main` uses Semantic Versioning. The application baseline merged by PR #392 is `5455d6a524c39eeafd4bfb860afb3a7c6fb8b27a` and has package version `1.0.0`. The first release tag points to the later `main` commit that adds this release automation without changing backend behavior.
+
+## Publish a version
+
+Publishing starts only when an annotated tag exactly matching `vX.Y.Z` is pushed. The numeric part must equal `backend/package.json`, the tag must point to the current `main` HEAD, and the same commit must have a successful main CI run containing backend build, unit, integration, E2E, and security jobs.
+
+```bash
+git switch main
+git pull --ff-only origin main
+git tag -a v1.0.0 -m "Near Chat backend v1.0.0"
+git push origin v1.0.0
+```
+
+The workflow publishes:
+
+- `ghcr.io/nearcsie/near-chat-backend:1.0.0`
+- `ghcr.io/nearcsie/near-chat-backend:sha-<12-character-commit>`
+- a provenance attestation and Traditional Chinese GitHub Release containing the exact commit and image digest
+
+No mutable `latest` tag is published. Deploy and roll back by digest:
+
+```bash
+docker pull ghcr.io/nearcsie/near-chat-backend@sha256:<digest-from-release>
+```
+
+## Immutability and failure handling
+
+Version and commit image references are treated as immutable. A clean first publication requires the GitHub Release and both image references to be absent. A rerun only verifies a complete existing publication whose two references resolve to the same digest and whose Release records that commit and digest.
+
+The workflow stops for partial publications, mismatched digests, a Release without images, or images without a Release. It never overwrites or reconstructs an existing version automatically. Investigate the registry and Release manually before retrying.
+
+The production image uses Node.js 24 and pnpm 11. Release artifacts must never contain `.env` files, credentials, database volumes or dumps containing real data, or uploaded user files.


### PR DESCRIPTION
## 摘要

- 新增由 annotated `vX.Y.Z` tag 觸發的後端 GHCR 發布流程
- 發布 `ghcr.io/nearcsie/near-chat-backend:X.Y.Z` 與 `sha-<12位commit>`，不建立可變的 `latest`
- 要求 tag 版本符合 `backend/package.json`、指向目前 `main` HEAD，且該 commit 的 backend CI 全部成功
- 建立並驗證 OCI provenance attestation，將映像 digest 寫入繁中 GitHub Release
- 固定 production image 的 Node 24 digest 與 pnpm 11.15.0，並補上中英文發布文件

## 不可變與重跑策略

- 版本映像、commit 映像與 GitHub Release 必須同時不存在，才允許首次建置
- 三者已存在時只驗證 digest、Release 與 attestation，不重新建置或覆寫
- 部分發布或 digest 不一致時直接失敗，留待人工調查

## 驗證

- `docker build -f backend/Dockerfile.prod -t near-chat-backend:version-release-verify .`
- image runtime：Node `v24.18.0`、pnpm `11.15.0`
- 所有 GitHub Actions YAML 可解析，所有內嵌 Bash 通過 `bash -n`
- `git diff --check`
- 獨立 code review：APPROVE，無阻擋問題

合併後再於新的 `main` HEAD 建立 annotated `v1.0.0` tag，讓 tag 所指 commit 本身包含此發布 workflow。