### PR TITLE
docs: Socket.IO 訊息傳送 API 文件同步 (week of 2026-07-19)

### DIFF
--- a/docs/ZH-TW/api-documentation.md
+++ b/docs/ZH-TW/api-documentation.md
@@ -1348,7 +1348,7 @@ NEXT_PUBLIC_API_URL=http://localhost:4005
 | :--- | :--- | :--- |
 | `join_room` | `{ roomId: string }` | 訂閱特定聊天室的訊息推播（需為成員） |
 | `leave_room` | `{ roomId: string }` | 取消訂閱 |
-| `send_message` | `{ roomId: string, content: string, replyTo?: string, attachmentIds?: string[] }` | 發送訊息；`replyTo` 為引用的訊息 ID；`attachmentIds` 為待綁定附件 ID 陣列 |
+| `send_message` | `{ roomId: string, content: string, replyTo?: string, attachmentIds?: string[] }` | 發送訊息；`replyTo` 為引用的訊息 ID；`attachmentIds` 為待綁定附件 ID 陣列。備註：`content` 僅在至少提供一個附件 ID 時可為空字串；否則 `content` 不可為空。 |
 | `recall_message` | `{ messageId: string }` | 收回訊息（僅限原發送者） |
 | `typing` | `{ roomId: string, isTyping: boolean }` | 廣播輸入中狀態 |
 | `read_receipt` | `{ roomId: string, messageId: string }` | 更新已讀游標至指定訊息 |

--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -1348,7 +1348,7 @@ All errors return the following JSON structure:
 | :--- | :--- | :--- |
 | `join_room` | `{ roomId: string }` | Subscribe to message broadcasts of a chat room (must be a member) |
 | `leave_room` | `{ roomId: string }` | Unsubscribe |
-| `send_message` | `{ roomId: string, content: string, replyTo?: string, attachmentIds?: string[] }` | Send message; `replyTo` is the referenced message ID; `attachmentIds` is the array of attachment IDs |
+| `send_message` | `{ roomId: string, content: string, replyTo?: string, attachmentIds?: string[] }` | Send message; `replyTo` is the referenced message ID; `attachmentIds` is the array of attachment IDs. Note: `content` can be empty only if at least one attachment ID is provided; otherwise `content` must not be empty. |
 | `recall_message` | `{ messageId: string }` | Recall message (Sender only) |
 | `typing` | `{ roomId: string, isTyping: boolean }` | Broadcast typing state |
 | `read_receipt` | `{ roomId: string, messageId: string }` | Update read receipt cursor to specified message |


### PR DESCRIPTION
## 掃描涵蓋的合併 PR

| PR 編號 | 標題 | 合併時間 | 連結 |
| :--- | :--- | :--- | :--- |
| #393 | ci: 新增後端版本映像自動發布 | 2026-07-19 | https://github.com/nearcsie/near-chat/pull/393 |
| #392 | Legacy/backend express node | 2026-07-19 | https://github.com/nearcsie/near-chat/pull/392 |
| #389 | docs: record re-evaluation of Turbopack chunking decision | 2026-07-19 | https://github.com/nearcsie/near-chat/pull/389 |
| #388 | chore: 統一開發環境使用 Turbopack | 2026-07-19 | https://github.com/nearcsie/near-chat/pull/388 |
| #386 | refactor(frontend): 以 next/dynamic 懶載入 GroupSettings | 2026-07-19 | https://github.com/nearcsie/near-chat/pull/386 |
| #378 | Potential fix for code scanning alert no. 9: DOM text reinterpreted as HTML | 2026-07-19 | https://github.com/nearcsie/near-chat/pull/378 |
| #372 | feat: 完成 PWA、通知與下載橋接基礎 | 2026-07-19 | https://github.com/nearcsie/near-chat/pull/372 |
| #384 | feat: 新增可重現的前端 bundle 分析基準 (#379) | 2026-07-19 | https://github.com/nearcsie/near-chat/pull/384 |
| #376 | Add PWA screenshots and disable font preloading | 2026-07-19 | https://github.com/nearcsie/near-chat/pull/376 |
| #375 | Update dependencies and Node.js version to latest LTS | 2026-07-17 | https://github.com/nearcsie/near-chat/pull/375 |
| #326 | fix: 整合觸控長按訊息選單修正並對齊操作顯示規則 | 2026-07-13 | https://github.com/nearcsie/near-chat/pull/326 |
| #323 | fix: 上傳可預覽附件時不再產生自動說明文字 (#301) | 2026-07-13 | https://github.com/nearcsie/near-chat/pull/323 |
| #299 | docs: 建立貢獻指南與 PR 範本 | 2026-07-13 | https://github.com/nearcsie/near-chat/pull/299 |
| #325 | docs: API 文件與合併變更同步 (週期: 2026-07-06) | 2026-07-13 | https://github.com/nearcsie/near-chat/pull/325 |

## 文件變更清單

| 檔案 | 變更說明 | 觸發 PR | 變更類型 |
| :--- | :--- | :--- | :--- |
| docs/api-documentation.md | 更新 `send_message` 事件文件，說明 content 欄位規則 | #323 | 文件說明更新 |
| docs/ZH-TW/api-documentation.md | 更新 `send_message` 事件文件，說明 content 欄位規則 | #323 | 文件說明更新 |

## 變更詳情

### PR #323: 上傳可預覽附件時不再產生自動說明文字

此 PR 修改了訊息傳送 API 的驗證架構：

**API 變更:**
- `content` 欄位現可為空字串，但僅限在至少提供一個 `attachmentIds` 時
- 若無附件，則 `content` 必須非空

**文件更新:**
- 更新 `send_message` Socket.IO 事件文件中 `content` 的驗證規則說明

Generated with Claude Code (https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019gc11KxfmqCd5aNWBxE6qf)_