### PR TITLE
chore: 新增 Dependabot 自動升級與安全維護設定

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,94 @@
+version: 2
+updates:
+  # 1. 根目錄 npm/pnpm 套件
+  - package-ecosystem: "npm"
+    directory: "/"
+    target-branch: "dev"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "root"
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+          - "minor"
+
+  # 2. 前端 npm/pnpm 套件 (/frontend)
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    target-branch: "dev"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "frontend"
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+          - "minor"
+
+  # 3. 後端 npm/pnpm 套件 (/backend)
+  - package-ecosystem: "npm"
+    directory: "/backend"
+    target-branch: "dev"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "backend"
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+          - "minor"
+
+  # 4. GitHub Actions 工作流 (.github/workflows)
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "dev"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "ci/cd"
+      - "dependencies"
+
+  # 5. 後端 Docker Base Image (/backend)
+  - package-ecosystem: "docker"
+    directory: "/backend"
+    target-branch: "dev"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "docker"
+      - "backend"
+
+  # 6. 前端 Docker Base Image (/frontend)
+  - package-ecosystem: "docker"
+    directory: "/frontend"
+    target-branch: "dev"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "docker"
+      - "frontend"


### PR DESCRIPTION
## 變更摘要
新增 `.github/dependabot.yml` 設定檔，為 `near-chat` 專案配置 Dependabot 自動套件與容器映像檔更新機器人。

## 設定細節
1. **npm / pnpm 套件**：
   - 定時檢查根目錄 (`/`)、前端 (`/frontend`) 與後端 (`/backend`) 的套件版本。
   - PR 目標分支設定為 `dev`。
   - 啟用 `minor-and-patch` 自動分組功能，將 minor 與 patch 升級自動合併成單一 PR。
2. **GitHub Actions**：
   - 監控 `.github/workflows` 中的工作流 Action 版本。
3. **Docker Base Image**：
   - 監控 `/frontend` 與 `/backend` 的 Dockerfile Base Image 升級。

## 驗證項目
- [x] 已通過 YAML 解析驗證，6 項更新任務語法解析無誤。