### PR TITLE
feat: 群組邀請連結與接受邀請頁面 (#271)

### DIFF
--- a/backend/scripts/run-tests.ts
+++ b/backend/scripts/run-tests.ts
@@ -1,0 +1,52 @@
+import { Glob } from "bun";
+import { spawnSync } from "child_process";
+import path from "path";
+
+const args = Bun.argv.slice(2);
+const folder = args[0] || "tests";
+
+// Instantiate the Glob pattern
+const glob = new Glob("**/*.test.ts");
+
+// Scan the target directory synchronously
+const files = Array.from(glob.scanSync({
+  cwd: path.resolve(process.cwd(), folder),
+  absolute: true,
+})).sort();
+
+console.log(`Found ${files.length} test files under ${folder}`);
+
+let passed = 0;
+let failed = 0;
+const failedFiles: string[] = [];
+
+for (const file of files) {
+  const relativePath = path.relative(process.cwd(), file);
+  console.log(`\n============================================`);
+  console.log(`Running: ${relativePath}`);
+  console.log(`============================================\n`);
+  
+  const result = spawnSync("bun", ["test", file], { stdio: "inherit" });
+  
+  if (result.status === 0) {
+    passed++;
+  } else {
+    failed++;
+    failedFiles.push(relativePath);
+  }
+}
+
+console.log(`\n============================================`);
+console.log(`Test Execution Summary:`);
+console.log(`  Passed: ${passed}`);
+console.log(`  Failed: ${failed}`);
+if (failed > 0) {
+  console.log(`\nFailed Files:`);
+  for (const f of failedFiles) {
+    console.log(`  - ${f}`);
+  }
+  process.exit(1);
+} else {
+  console.log(`\nAll tests passed successfully! 🎉`);
+  process.exit(0);
+}

--- a/backend/src/routes/roomRoutes.ts
+++ b/backend/src/routes/roomRoutes.ts
@@ -20,6 +20,7 @@ export interface RoomService {
   createPrivate(userId: string, targetUserId: string, bypassFriendCheck?: boolean): Promise<{ room: Room | RoomSummary | unknown; isExisting?: boolean; created?: boolean }>;
   update(roomId: string, callerId: string, data: unknown): Promise<unknown>;
   joinByCode(userId: string, inviteCode: string): Promise<unknown>;
+  previewByCode(userId: string, inviteCode: string): Promise<unknown>;
   leave(userId: string, roomId: string): Promise<void>;
   deleteGroup(roomId: string, callerId: string): Promise<void>;
   uploadAvatar(roomId: string, callerId: string, file: UploadedFile): Promise<unknown>;
@@ -61,6 +62,14 @@ export const makeRoomRoutes = (service: RoomService) => {
     const body = c.req.valid('json') as { inviteCode: string };
     const room = await service.joinByCode(userId, body.inviteCode);
     return c.json(room, 200);
+  });
+
+  // Read-only lookup backing the accept-invite page. Registered ahead of the
+  // `/:id` routes so the literal `invite` segment is never taken for a room id.
+  app.get('/invite/:code', async (c) => {
+    const userId = c.get('user').userId;
+    const preview = await service.previewByCode(userId, c.req.param('code'));
+    return c.json(preview, 200);
   });
 
   app.get('/:id/members', async (c) => {

--- a/backend/src/services/roomService.ts
+++ b/backend/src/services/roomService.ts
@@ -1,5 +1,5 @@
 import type { UploadedFile } from '../utils/fileUpload';
-import type { Room, RoomSummary } from '@shared/types';
+import type { Room, RoomInvitePreview, RoomSummary } from '@shared/types';
 import { randomBytes } from 'crypto';
 import { isUserOnline } from '../realtime/presence';
 import { removeManagedAvatar, saveAvatarUpload } from '../utils/avatarUpload';
@@ -169,13 +169,37 @@ export const makeRoomService = (
       return updated;
     },
 
+    async previewByCode(userId: string, inviteCode: string): Promise<RoomInvitePreview> {
+      const room = await repo.findByInviteCode(inviteCode);
+      if (!room || room.type !== 'group') throw new NotFoundError('room', inviteCode);
+      const existing = await roomMemberRepo.findMember(room.roomId, userId);
+      return {
+        roomId: room.roomId,
+        name: room.name,
+        avatarUrl: room.avatarUrl,
+        requireApproval: room.requireApproval,
+        isMember: !!existing,
+        isPending: existing?.role === 'pending',
+      };
+    },
+
     async joinByCode(userId: string, inviteCode: string): Promise<Room> {
       const room = await repo.findByInviteCode(inviteCode);
       if (!room) throw new NotFoundError('room', inviteCode);
       const existing = await roomMemberRepo.findMember(room.roomId, userId);
       if (existing) throw new ConflictError('User is already a member of this room');
       const role = room.requireApproval ? 'pending' : 'member';
-      await roomMemberRepo.add({ roomId: room.roomId, userId, role });
+      try {
+        await roomMemberRepo.add({ roomId: room.roomId, userId, role });
+      } catch (err) {
+        // Two simultaneous joins can both pass the findMember check above; the
+        // losing insert then violates the (room_id, user_id) primary key. Report
+        // it as the same conflict the pre-check would have raised rather than a 500.
+        if ((err as { code?: string }).code === '23505') {
+          throw new ConflictError('User is already a member of this room');
+        }
+        throw err;
+      }
 
       if (role === 'member') {
         // Notify existing room members that someone new joined.

--- a/backend/tests/e2e/routes/room.e2e.test.ts
+++ b/backend/tests/e2e/routes/room.e2e.test.ts
@@ -140,6 +140,81 @@ describe('Room E2E', () => {
     expect(joinRes.body.roomId).toBe(createRes.body.roomId);
   });
 
+  it('should preview a room by invite code without joining, then reflect membership after joining', async () => {
+    const createRes = await request(app)
+      .post('/api/v1/rooms')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        type: 'group',
+        name: 'Preview Room',
+        avatarUrl: 'https://example.com/group.png',
+      });
+    const inviteCode = createRes.body.inviteCode;
+
+    const previewRes = await request(app)
+      .get(`/api/v1/rooms/invite/${inviteCode}`)
+      .set('Authorization', `Bearer ${otherToken}`);
+
+    expect(previewRes.status).toBe(200);
+    expect(previewRes.body).toEqual({
+      roomId: createRes.body.roomId,
+      name: 'Preview Room',
+      avatarUrl: 'https://example.com/group.png',
+      requireApproval: false,
+      isMember: false,
+      isPending: false,
+    });
+
+    await request(app)
+      .post(`/api/v1/rooms/${createRes.body.roomId}/members`)
+      .set('Authorization', `Bearer ${otherToken}`)
+      .send({ inviteCode });
+
+    const previewAfterJoinRes = await request(app)
+      .get(`/api/v1/rooms/invite/${inviteCode}`)
+      .set('Authorization', `Bearer ${otherToken}`);
+
+    expect(previewAfterJoinRes.status).toBe(200);
+    expect(previewAfterJoinRes.body.isMember).toBe(true);
+  });
+
+  it('should report isPending when previewing an approval-required group already requested', async () => {
+    const createRes = await request(app)
+      .post('/api/v1/rooms')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        type: 'group',
+        name: 'Approval Room',
+        requireApproval: true,
+      });
+    const inviteCode = createRes.body.inviteCode;
+
+    await request(app)
+      .post(`/api/v1/rooms/${createRes.body.roomId}/members`)
+      .set('Authorization', `Bearer ${otherToken}`)
+      .send({ inviteCode });
+
+    const previewRes = await request(app)
+      .get(`/api/v1/rooms/invite/${inviteCode}`)
+      .set('Authorization', `Bearer ${otherToken}`);
+
+    expect(previewRes.status).toBe(200);
+    expect(previewRes.body.requireApproval).toBe(true);
+    expect(previewRes.body.isMember).toBe(true);
+    expect(previewRes.body.isPending).toBe(true);
+    // This group was created without an avatar, so the optional field is omitted
+    // from the payload rather than serialized as null (see api-documentation.md).
+    expect(previewRes.body).not.toHaveProperty('avatarUrl');
+  });
+
+  it('should 404 when previewing an unknown invite code', async () => {
+    const res = await request(app)
+      .get('/api/v1/rooms/invite/DOESNOTEXIST')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(404);
+  });
+
   it('should create an idempotent private room for accepted friends', async () => {
     await makeFriends();
 

--- a/backend/tests/unit/routes/roomRoutes.test.ts
+++ b/backend/tests/unit/routes/roomRoutes.test.ts
@@ -4,6 +4,7 @@ import { makeRoomRoutes } from '../../../src/routes/roomRoutes';
 import { authMiddleware } from '../../../src/middlewares/authMiddleware';
 import { errorHandler } from '../../../src/middlewares/errorHandler';
 import { signToken } from '../../../src/utils/jwt';
+import { NotFoundError } from '../../../src/utils/AppError';
 
 // authMiddleware looks the caller up through the shared SQL client; a non-empty
 // row is all it needs to accept the signed token.
@@ -156,5 +157,74 @@ describe('PATCH /rooms/:id/members/:targetUserId', () => {
     expect(res.status).toBe(200);
     expect(service.transferOwnership).not.toHaveBeenCalled();
     expect(service.updateMember).toHaveBeenCalledWith(ROOM_ID, CALLER_ID, NEW_OWNER_ID, { role: 'admin' });
+  });
+});
+
+describe('GET /rooms/invite/:code', () => {
+  let service: any;
+  let token: string;
+
+  const makeApp = () => {
+    const app = new Hono();
+    app.onError(errorHandler);
+    app.use('/rooms/*', authMiddleware);
+    app.route('/rooms', makeRoomRoutes(service));
+    return app;
+  };
+
+  const previewInvite = (code: string) =>
+    makeApp().request(`/rooms/invite/${code}`, {
+      method: 'GET',
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+  beforeEach(async () => {
+    token = await signToken({ userId: CALLER_ID, email: 'caller@test.com' } as any);
+    service = {
+      previewByCode: mock().mockResolvedValue({
+        roomId: ROOM_ID,
+        name: 'Study Room',
+        requireApproval: false,
+        isMember: false,
+        isPending: false,
+      }),
+      joinByCode: mock(),
+    };
+  });
+
+  afterAll(() => {
+    mock.restore();
+  });
+
+  it('returns the preview for the caller without joining', async () => {
+    const res = await previewInvite('ABC123');
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      roomId: ROOM_ID,
+      name: 'Study Room',
+      requireApproval: false,
+      isMember: false,
+      isPending: false,
+    });
+    expect(service.previewByCode).toHaveBeenCalledWith(CALLER_ID, 'ABC123');
+    expect(service.joinByCode).not.toHaveBeenCalled();
+  });
+
+  it('does not shadow the room-by-id route', async () => {
+    // `invite` is a literal segment, so `/rooms/:id` must not swallow it.
+    await previewInvite('ABC123');
+
+    expect(service.previewByCode).toHaveBeenCalled();
+  });
+
+  it('surfaces an unknown invite code as 404 through the error handler', async () => {
+    service.previewByCode = mock(async () => {
+      throw new NotFoundError('room', 'BOGUS');
+    });
+
+    const res = await previewInvite('BOGUS');
+
+    expect(res.status).toBe(404);
   });
 });

--- a/backend/tests/unit/services/roomService.test.ts
+++ b/backend/tests/unit/services/roomService.test.ts
@@ -219,6 +219,55 @@ describe('roomService', () => {
 
     expect(mockRepo.update).not.toHaveBeenCalled();
   });
+  describe('previewByCode', () => {
+    it('returns a preview without joining', async () => {
+      mockRepo.findByInviteCode.mockResolvedValue(room);
+      mockMemberRepo.findMember.mockResolvedValue(null);
+
+      const preview = await roomService.previewByCode('user-2', 'ABCDEF');
+
+      expect(preview).toEqual({
+        roomId: 'room-1',
+        name: 'Study Room',
+        avatarUrl: undefined,
+        requireApproval: false,
+        isMember: false,
+        isPending: false,
+      });
+      expect(mockMemberRepo.add).not.toHaveBeenCalled();
+    });
+
+    it('flags isMember when the caller already belongs to the room', async () => {
+      mockRepo.findByInviteCode.mockResolvedValue(room);
+      mockMemberRepo.findMember.mockResolvedValue(ownerMember);
+
+      const preview = await roomService.previewByCode('user-1', 'ABCDEF');
+
+      expect(preview.isMember).toBe(true);
+      expect(preview.isPending).toBe(false);
+    });
+
+    it('flags isPending when the caller is still awaiting approval', async () => {
+      mockRepo.findByInviteCode.mockResolvedValue({ ...room, requireApproval: true });
+      mockMemberRepo.findMember.mockResolvedValue({ ...ownerMember, userId: 'user-2', role: 'pending' });
+
+      const preview = await roomService.previewByCode('user-2', 'ABCDEF');
+
+      expect(preview.isMember).toBe(true);
+      expect(preview.isPending).toBe(true);
+    });
+
+    it('throws NotFoundError for an unknown invite code', async () => {
+      mockRepo.findByInviteCode.mockResolvedValue(null);
+      await expect(roomService.previewByCode('user-2', 'BOGUS')).rejects.toThrow(NotFoundError);
+    });
+
+    it('throws NotFoundError if the invite code somehow resolves to a non-group room', async () => {
+      mockRepo.findByInviteCode.mockResolvedValue({ ...room, type: 'private' });
+      await expect(roomService.previewByCode('user-2', 'ABCDEF')).rejects.toThrow(NotFoundError);
+    });
+  });
+
   describe('joinByCode', () => {
     it('joins room using invite code', async () => {
       mockRepo.findByInviteCode.mockResolvedValue(room);
@@ -230,6 +279,22 @@ describe('roomService', () => {
       mockRepo.findByInviteCode.mockResolvedValue(room);
       mockMemberRepo.findMember.mockResolvedValue({} as RoomMember);
       await expect(roomService.joinByCode('user-2', 'ABCDEF')).rejects.toThrow(ConflictError);
+    });
+
+    it('converts a concurrent-insert unique violation into ConflictError', async () => {
+      mockRepo.findByInviteCode.mockResolvedValue(room);
+      mockMemberRepo.findMember.mockResolvedValue(null);
+      mockMemberRepo.add.mockRejectedValue(Object.assign(new Error('duplicate key'), { code: '23505' }));
+
+      await expect(roomService.joinByCode('user-2', 'ABCDEF')).rejects.toThrow(ConflictError);
+    });
+
+    it('rethrows non-unique-violation database errors', async () => {
+      mockRepo.findByInviteCode.mockResolvedValue(room);
+      mockMemberRepo.findMember.mockResolvedValue(null);
+      mockMemberRepo.add.mockRejectedValue(Object.assign(new Error('connection lost'), { code: '08006' }));
+
+      await expect(roomService.joinByCode('user-2', 'ABCDEF')).rejects.toThrow('connection lost');
     });
   });
 

--- a/docs/ZH-TW/api-documentation.md
+++ b/docs/ZH-TW/api-documentation.md
@@ -284,6 +284,39 @@ NEXT_PUBLIC_API_URL=http://localhost:4005
   }
   ```
 
+#### RoomInvitePreview
+- **說明**: 以邀請碼解析出的群組唯讀預覽，用於使用者確認加入前顯示群組資訊。由 `GET /rooms/invite/:code` 回傳。
+- **欄位說明**:
+  | 欄位 | 型別 | 說明 |
+  | :--- | :--- | :--- |
+  | `roomId` | UUID | 聊天室唯一識別碼 |
+  | `name` | 字串（選填） | 群組名稱。未設定時不會出現在回應中 |
+  | `avatarUrl` | 字串（選填） | 群組頭像網址。群組沒有頭像時不會出現在回應中 |
+  | `requireApproval` | 布林值 | 加入是否需要 owner/admin 審核 |
+  | `isMember` | 布林值 | 呼叫者是否已有成員資料列（含尚待審核者） |
+  | `isPending` | 布林值 | 呼叫者是否已送出加入申請、尚待審核 |
+- **範例**:
+  ```json
+  {
+    "roomId": "8f8b8c8d-8e8f-8a8b-8c8d-8e8f8a8b8c8d",
+    "name": "Project Discussion Group",
+    "avatarUrl": "https://example.com/room-avatar.png",
+    "requireApproval": false,
+    "isMember": false,
+    "isPending": false
+  }
+  ```
+- **範例（沒有頭像的群組）**：選填欄位會直接省略，而不是回傳 `null`。
+  ```json
+  {
+    "roomId": "8f8b8c8d-8e8f-8a8b-8c8d-8e8f8a8b8c8d",
+    "name": "Project Discussion Group",
+    "requireApproval": false,
+    "isMember": false,
+    "isPending": false
+  }
+  ```
+
 #### RoomMember
 - **欄位說明**:
   | 欄位 | 型別 | 說明 |
@@ -1005,6 +1038,29 @@ NEXT_PUBLIC_API_URL=http://localhost:4005
     "viewHistory": true,
     "isArchived": false,
     "createdAt": "2026-06-14T22:18:13Z"
+  }
+  ```
+
+---
+
+#### `GET /rooms/invite/:code`
+- **說明**: 預覽邀請連結所指向的群組，但不會加入該群組。供接受邀請頁面在使用者確認前顯示群組名稱與頭像。
+- **驗證與權限**: 需驗證。任何已登入使用者皆可預覽有效的邀請碼，不需為該房間成員。
+- **路徑參數**:
+  | 參數 | 型別 | 說明 |
+  | :--- | :--- | :--- |
+  | `code` | 字串 | 取自邀請連結的邀請碼 |
+- **回應**:
+  - `200 OK`: 回傳 [`RoomInvitePreview`](#roominvitepreview)。此為唯讀操作，不會將呼叫者加入該房間。
+  - `404 Not Found`: 找不到符合此邀請碼的群組。
+- **回應範例**（此群組沒有頭像，因此不含 `avatarUrl` 欄位）:
+  ```json
+  {
+    "roomId": "8f8b8c8d-8e8f-8a8b-8c8d-8e8f8a8b8c8d",
+    "name": "New Project Chat",
+    "requireApproval": true,
+    "isMember": false,
+    "isPending": false
   }
   ```
 

--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -284,6 +284,39 @@ All errors return the following JSON structure:
   }
   ```
 
+#### RoomInvitePreview
+- **Description**: Read-only preview of a group room resolved from an invite code, shown before the caller confirms joining. Returned by `GET /rooms/invite/:code`.
+- **Field Details**:
+  | Field | Type | Description |
+  | :--- | :--- | :--- |
+  | `roomId` | UUID | Unique chat room identifier |
+  | `name` | String (optional) | Group name. Omitted from the response when unset |
+  | `avatarUrl` | String (optional) | Group avatar URL. Omitted from the response when the group has no avatar |
+  | `requireApproval` | Boolean | Whether joining requires owner/admin approval |
+  | `isMember` | Boolean | Whether the caller already has a membership row, including a pending one |
+  | `isPending` | Boolean | Whether the caller has already requested to join and is awaiting approval |
+- **Example**:
+  ```json
+  {
+    "roomId": "8f8b8c8d-8e8f-8a8b-8c8d-8e8f8a8b8c8d",
+    "name": "Project Discussion Group",
+    "avatarUrl": "https://example.com/room-avatar.png",
+    "requireApproval": false,
+    "isMember": false,
+    "isPending": false
+  }
+  ```
+- **Example (group without an avatar)**: optional fields are absent rather than `null`.
+  ```json
+  {
+    "roomId": "8f8b8c8d-8e8f-8a8b-8c8d-8e8f8a8b8c8d",
+    "name": "Project Discussion Group",
+    "requireApproval": false,
+    "isMember": false,
+    "isPending": false
+  }
+  ```
+
 #### RoomMember
 - **Field Details**:
   | Field | Type | Description |
@@ -1005,6 +1038,29 @@ All errors return the following JSON structure:
     "viewHistory": true,
     "isArchived": false,
     "createdAt": "2026-06-14T22:18:13Z"
+  }
+  ```
+
+---
+
+#### `GET /rooms/invite/:code`
+- **Description**: Preview the group a share-able invite link points at, without joining it. Used by the accept-invite page to show the group name and avatar before the user confirms.
+- **Authentication & Authorization**: Authentication required. Any authenticated user may preview a valid invite code; no membership is required.
+- **Path Parameters**:
+  | Parameter | Type | Description |
+  | :--- | :--- | :--- |
+  | `code` | String | Invite code taken from the invite link |
+- **Response**:
+  - `200 OK`: Returns a [`RoomInvitePreview`](#roominvitepreview). This call is read-only and never adds the caller to the room.
+  - `404 Not Found`: No group matches this invite code.
+- **Response Example** (this group has no avatar, so `avatarUrl` is absent):
+  ```json
+  {
+    "roomId": "8f8b8c8d-8e8f-8a8b-8c8d-8e8f8a8b8c8d",
+    "name": "New Project Chat",
+    "requireApproval": true,
+    "isMember": false,
+    "isPending": false
   }
   ```
 

--- a/frontend/src/app/invite/[code]/page.tsx
+++ b/frontend/src/app/invite/[code]/page.tsx
@@ -1,0 +1,7 @@
+import InviteAcceptPageContent from "@/components/pages/InviteAcceptPageContent";
+
+export const dynamic = "force-dynamic";
+
+export default function InvitePage() {
+  return <InviteAcceptPageContent />;
+}

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,12 +1,18 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useSyncExternalStore } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import Image from "next/image";
 import { Input } from "@/components/ui/Input";
 import { Button } from "@/components/ui/Button";
 import { login } from "@/lib/api";
+import {
+  getServerRedirect,
+  readRedirectParam,
+  subscribeToRedirect,
+  withRedirectParam,
+} from "@/lib/redirect";
 
 const getFriendlyLoginError = (error: unknown) => {
   const message = error instanceof Error ? error.message : "";
@@ -24,6 +30,11 @@ export default function LoginPage() {
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const redirectTo = useSyncExternalStore(
+    subscribeToRedirect,
+    readRedirectParam,
+    getServerRedirect,
+  );
 
   useEffect(() => {
     document.title = "Near | Sign In";
@@ -53,7 +64,7 @@ export default function LoginPage() {
           avatar: result.user.avatarUrl ?? "",
         }),
       );
-      router.push("/");
+      router.push(redirectTo);
     } catch (err) {
       setError(getFriendlyLoginError(err));
     } finally {
@@ -126,7 +137,7 @@ export default function LoginPage() {
           <p className="text-xs text-text-muted font-sans select-none">
             No account yet?{" "}
             <Link
-              href="/register"
+              href={withRedirectParam("/register", redirectTo)}
               className="text-primary font-semibold hover:underline"
             >
               Create one

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -1,12 +1,18 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useSyncExternalStore } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import Image from "next/image";
 import { Input } from "@/components/ui/Input";
 import { Button } from "@/components/ui/Button";
 import { register } from "@/lib/api";
+import {
+  getServerRedirect,
+  readRedirectParam,
+  subscribeToRedirect,
+  withRedirectParam,
+} from "@/lib/redirect";
 
 const getFriendlyRegisterError = (error: unknown) => {
   const message = error instanceof Error ? error.message : "";
@@ -26,6 +32,11 @@ export default function RegisterPage() {
   const [confirmPassword, setConfirmPassword] = useState("");
   const [error, setError] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const redirectTo = useSyncExternalStore(
+    subscribeToRedirect,
+    readRedirectParam,
+    getServerRedirect,
+  );
 
   useEffect(() => {
     document.title = "Near | Register";
@@ -60,7 +71,7 @@ export default function RegisterPage() {
         }),
       );
       localStorage.setItem("just_registered", "true");
-      router.push("/");
+      router.push(redirectTo);
     } catch (err) {
       setError(getFriendlyRegisterError(err));
     } finally {
@@ -157,7 +168,7 @@ export default function RegisterPage() {
           <p className="text-xs text-text-muted font-sans select-none">
             Already have an account?{" "}
             <Link
-              href="/login"
+              href={withRedirectParam("/login", redirectTo)}
               className="text-primary font-semibold hover:underline"
             >
               Sign in

--- a/frontend/src/components/pages/InviteAcceptPageContent.tsx
+++ b/frontend/src/components/pages/InviteAcceptPageContent.tsx
@@ -1,0 +1,225 @@
+"use client";
+
+import React, { useCallback, useEffect, useState, useSyncExternalStore } from "react";
+import { useParams, useRouter } from "next/navigation";
+import Image from "next/image";
+import { Avatar } from "@/components/ui/Avatar";
+import { Button } from "@/components/ui/Button";
+import {
+  getActiveAccessToken,
+  getMySettings,
+  getRoomInvitePreview,
+  joinRoomByCode,
+  refreshTokensExclusive,
+} from "@/lib/api";
+import {
+  getServerLocale,
+  getStoredLocale,
+  isLocale,
+  setStoredLocale,
+  subscribeToLocale,
+  translate,
+} from "@/lib/i18n";
+import type { RoomInvitePreview } from "@shared/types";
+
+// This page renders outside the `(main)` route group (like `login`/`register`) so a
+// signed-out visitor can reach it and be redirected to `/login?redirect=...` without
+// mounting the full chat app shell. `useTranslation` is unavailable here because it
+// depends on `ChatProvider`, so the persisted locale is read directly instead.
+type Status = "checking" | "loading" | "ready" | "joining" | "pending" | "error";
+
+export default function InviteAcceptPageContent() {
+  const params = useParams<{ code: string }>();
+  const router = useRouter();
+  const code = Array.isArray(params.code) ? params.code[0] : params.code;
+
+  const [status, setStatus] = useState<Status>("checking");
+  const [preview, setPreview] = useState<RoomInvitePreview | null>(null);
+  const [errorMessage, setErrorMessage] = useState("");
+  const [token, setToken] = useState<string | null>(null);
+  // The server has no access to the visitor's stored language, so it renders the
+  // default locale and React re-renders with the real one right after hydration.
+  // Reading localStorage directly in a `useState` initializer would instead make
+  // the server and client markup disagree.
+  const locale = useSyncExternalStore(subscribeToLocale, getStoredLocale, getServerLocale);
+  const t = useCallback(
+    (key: string, replacements?: Record<string, string | number>) =>
+      translate(locale, `inviteAccept.${key}`, replacements),
+    [locale],
+  );
+
+  useEffect(() => {
+    document.title = t("pageTitle");
+  }, [t]);
+
+  useEffect(() => {
+    if (!code) return;
+    let cancelled = false;
+
+    void (async () => {
+      let activeToken = getActiveAccessToken();
+      if (!activeToken) {
+        try {
+          // Must hold the cross-tab lock: two invite tabs bootstrapping at once
+          // would otherwise present the same pre-rotation cookie and trip the
+          // server's reuse detection, revoking every session.
+          activeToken = (await refreshTokensExclusive()).token;
+        } catch {
+          if (!cancelled) {
+            window.location.replace(`/login?redirect=${encodeURIComponent(`/invite/${code}`)}`);
+          }
+          return;
+        }
+      }
+      if (cancelled) return;
+      setToken(activeToken);
+      setStatus("loading");
+
+      // On a browser that has never run the main app there is no stored language,
+      // and this page never mounts the ChatProvider that would load it, so pull
+      // the account preference directly. Failure here only affects wording.
+      void getMySettings(activeToken)
+        .then((settings) => {
+          if (!cancelled && isLocale(settings?.language)) setStoredLocale(settings.language);
+        })
+        .catch(() => {});
+
+      try {
+        const result = await getRoomInvitePreview(activeToken, code);
+        if (cancelled) return;
+        setPreview(result);
+        // A pending member has a membership row but cannot use the room yet, so
+        // show the awaiting-approval state rather than sending them into it.
+        setStatus(result.isPending ? "pending" : "ready");
+      } catch (err) {
+        if (cancelled) return;
+        // The API layer surfaces the backend's English text, so show a localized
+        // message and keep the original for debugging only.
+        console.error("Failed to load invite preview:", err);
+        setErrorMessage(t("invalidInvite"));
+        setStatus("error");
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [code, t]);
+
+  const handleAccept = useCallback(async () => {
+    if (!token || !code || !preview) return;
+    setStatus("joining");
+    try {
+      const room = await joinRoomByCode(token, code);
+      // Branch on the join response, not the preview: an admin may have toggled
+      // requireApproval since the preview was fetched, and the response carries
+      // the setting that actually decided our role.
+      if (room.requireApproval) {
+        setStatus("pending");
+      } else {
+        router.push(`/chat/${room.roomId}`);
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "";
+      // Preview and accept aren't atomic (e.g. joined from another tab in between) —
+      // treat "already a member" as success rather than surfacing a hard error.
+      if (message.toLowerCase().includes("already a member")) {
+        // Re-read the server state rather than trusting the preview: the winning
+        // request decides whether we ended up pending, and requireApproval may
+        // have been toggled since this page loaded.
+        try {
+          const fresh = await getRoomInvitePreview(token, code);
+          setPreview(fresh);
+          if (fresh.isPending) {
+            setStatus("pending");
+          } else {
+            router.push(`/chat/${fresh.roomId}`);
+          }
+        } catch (refreshErr) {
+          console.error("Failed to re-check membership after a concurrent join:", refreshErr);
+          setErrorMessage(t("joinFailed"));
+          setStatus("ready");
+        }
+        return;
+      }
+      console.error("Failed to join room from invite:", err);
+      setErrorMessage(t("joinFailed"));
+      setStatus("ready");
+    }
+  }, [token, code, preview, router, t]);
+
+  return (
+    <div className="flex min-h-dvh flex-col items-center justify-center p-4 bg-background transition-colors overflow-y-auto">
+      <div className="w-full max-w-sm border border-border-primary rounded-sm bg-surface-card p-8 flex flex-col items-center">
+        <div className="size-16 bg-surface-muted rounded-sm flex items-center justify-center mb-6 overflow-hidden">
+          <Image src="/near.png" alt="Near logo" width={128} height={128} className="object-contain size-full" />
+        </div>
+
+        {(status === "checking" || status === "loading") && (
+          <p className="text-sm text-text-muted font-sans">{t("loading")}</p>
+        )}
+
+        {status === "error" && (
+          <>
+            <p className="text-sm text-red-600 font-sans text-center mb-6">{errorMessage}</p>
+            <Button variant="secondary" className="w-full" onClick={() => router.push("/")}>
+              {t("backToNear")}
+            </Button>
+          </>
+        )}
+
+        {status === "pending" && (
+          <>
+            <p className="text-sm text-foreground font-sans text-center mb-6">
+              {t("pendingApproval", { name: preview?.name ?? t("group") })}
+            </p>
+            <Button variant="secondary" className="w-full" onClick={() => router.push("/")}>
+              {t("backToNear")}
+            </Button>
+          </>
+        )}
+
+        {(status === "ready" || status === "joining") && preview && (
+          <>
+            <Avatar name={preview.name ?? t("group")} src={preview.avatarUrl} size="lg" className="mb-4" />
+            <h1 className="text-lg font-bold text-foreground mb-1 text-center font-sans">
+              {preview.name ?? t("group")}
+            </h1>
+            <p className="text-xs text-text-muted select-none font-sans mb-8 text-center">
+              {preview.isMember ? t("alreadyMember") : t("invited")}
+            </p>
+
+            {errorMessage && (
+              <p className="text-xs text-red-600 font-sans text-center mb-4">{errorMessage}</p>
+            )}
+
+            {preview.isMember ? (
+              <Button variant="primary" className="w-full" onClick={() => router.push(`/chat/${preview.roomId}`)}>
+                {t("openChat")}
+              </Button>
+            ) : (
+              <div className="w-full flex gap-3">
+                <Button
+                  variant="secondary"
+                  className="flex-1"
+                  disabled={status === "joining"}
+                  onClick={() => router.push("/")}
+                >
+                  {t("cancel")}
+                </Button>
+                <Button
+                  variant="primary"
+                  className="flex-1"
+                  disabled={status === "joining"}
+                  onClick={handleAccept}
+                >
+                  {status === "joining" ? t("joining") : t("accept")}
+                </Button>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/settings/GroupSettings.tsx
+++ b/frontend/src/components/settings/GroupSettings.tsx
@@ -411,6 +411,19 @@ export default function GroupSettings({ roomId, onClose }: GroupSettingsProps) {
     }
   };
 
+  const handleCopyInviteLink = async () => {
+    const code = activeRoom?.inviteCode;
+    if (!code) return;
+    const link = `${window.location.origin}/invite/${code}`;
+
+    try {
+      await navigator.clipboard.writeText(link);
+      setFeedback(t("groupSettings.inviteLinkCopied"));
+    } catch {
+      window.prompt(t("groupSettings.inviteLinkManualCopy"), link);
+    }
+  };
+
   const handleSearchQueryChange = (value: string) => {
     setSearchQuery(value);
 
@@ -570,14 +583,24 @@ export default function GroupSettings({ roomId, onClose }: GroupSettingsProps) {
             </code>
           </div>
           {activeRoom.inviteCode && (
-            <Button
-              type="button"
-              variant="secondary"
-              className="text-xs py-1 px-3 shrink-0"
-              onClick={() => void handleCopyInviteCode()}
-            >
-              {t("groupSettings.copyInviteCode")}
-            </Button>
+            <div className="flex flex-col gap-1 shrink-0">
+              <Button
+                type="button"
+                variant="secondary"
+                className="text-xs py-1 px-3"
+                onClick={() => void handleCopyInviteCode()}
+              >
+                {t("groupSettings.copyInviteCode")}
+              </Button>
+              <Button
+                type="button"
+                variant="secondary"
+                className="text-xs py-1 px-3"
+                onClick={() => void handleCopyInviteLink()}
+              >
+                {t("groupSettings.copyInviteLink")}
+              </Button>
+            </div>
           )}
         </div>
 

--- a/frontend/src/hooks/useTranslation.ts
+++ b/frontend/src/hooks/useTranslation.ts
@@ -2,61 +2,18 @@
 
 import { useCallback } from "react";
 import { useUiLanguage } from "@/context/ChatContext";
-import zhTW from "@/locales/zh-TW.json";
-import en from "@/locales/en.json";
-
-const translations = {
-  "zh-TW": zhTW,
-  en: en,
-} as const;
+import { translate } from "@/lib/i18n";
 
 export function useTranslation() {
   // Subscribes to the language-only context: translation consumers must not
   // re-render whenever unrelated chat state (messages, typing, …) changes.
   const uiLanguage = useUiLanguage();
 
-  const t = useCallback((key: string, replacements?: Record<string, string | number>): string => {
-    const keys = key.split(".");
-    const localesToTry = [uiLanguage, "en", "zh-TW"] as const;
-
-    let current: unknown = null;
-    for (const locale of localesToTry) {
-      let candidate: unknown = translations[locale] || translations["zh-TW"];
-      let found = true;
-
-      for (const k of keys) {
-        if (candidate && typeof candidate === "object" && k in candidate) {
-          candidate = (candidate as Record<string, unknown>)[k];
-        } else {
-          found = false;
-          break;
-        }
-      }
-
-      if (found) {
-        current = candidate;
-        break;
-      }
-    }
-
-    if (current === null) {
-      console.warn(`Translation key not found: ${key} for locale: ${uiLanguage}`);
-      return key;
-    }
-
-    if (typeof current !== "string") {
-      return key;
-    }
-
-    let text = current;
-    if (replacements) {
-      Object.entries(replacements).forEach(([k, v]) => {
-        text = text.replace(new RegExp(`{${k}}`, "g"), String(v));
-      });
-    }
-
-    return text;
-  }, [uiLanguage]);
+  const t = useCallback(
+    (key: string, replacements?: Record<string, string | number>): string =>
+      translate(uiLanguage, key, replacements),
+    [uiLanguage],
+  );
 
   return { t, locale: uiLanguage };
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -10,6 +10,7 @@ import type {
   MyProfile,
   RegisterRequest,
   Room,
+  RoomInvitePreview,
   RoomMember,
   RoomSummary,
   SearchUserResult,
@@ -146,6 +147,15 @@ const runExclusiveRefresh = <T,>(task: () => Promise<T>): Promise<T> => {
   }
   return task();
 };
+
+/**
+ * Refresh the session while holding the cross-tab lock. Callers outside the
+ * automatic 401 retry (e.g. a page bootstrapping its own token) must use this
+ * rather than `refreshTokens`, or two tabs can present the same pre-rotation
+ * cookie and trip the server's reuse detection, revoking every session.
+ */
+export const refreshTokensExclusive = (): Promise<AuthResponse> =>
+  runExclusiveRefresh(() => refreshTokens());
 
 let isRefreshing = false;
 let refreshSubscribers: { resolve: (token: string) => void; reject: (err: unknown) => void }[] = [];
@@ -410,6 +420,9 @@ export const joinRoomByCode = (token: string, inviteCode: string): Promise<Room>
     },
     { token },
   );
+
+export const getRoomInvitePreview = (token: string, inviteCode: string): Promise<RoomInvitePreview> =>
+  requestJson<RoomInvitePreview>(`/rooms/invite/${encodeURIComponent(inviteCode)}`, {}, { token });
 
 export const updateRoom = (
   token: string,

--- a/frontend/src/lib/i18n.ts
+++ b/frontend/src/lib/i18n.ts
@@ -1,0 +1,114 @@
+import zhTW from "@/locales/zh-TW.json";
+import en from "@/locales/en.json";
+
+const translations = {
+  "zh-TW": zhTW,
+  en: en,
+} as const;
+
+export type Locale = keyof typeof translations;
+
+export const isLocale = (value: unknown): value is Locale => value === "zh-TW" || value === "en";
+
+/**
+ * Resolve a dot-separated translation key against a locale, falling back to
+ * English and then Traditional Chinese. Pure lookup with no React dependency so
+ * pre-auth pages (which render outside `ChatProvider`) can localize too.
+ */
+export const translate = (
+  locale: string,
+  key: string,
+  replacements?: Record<string, string | number>,
+): string => {
+  const keys = key.split(".");
+  const localesToTry: Locale[] = [isLocale(locale) ? locale : "zh-TW", "en", "zh-TW"];
+
+  let current: unknown = null;
+  for (const candidateLocale of localesToTry) {
+    let candidate: unknown = translations[candidateLocale];
+    let found = true;
+
+    for (const k of keys) {
+      if (candidate && typeof candidate === "object" && k in candidate) {
+        candidate = (candidate as Record<string, unknown>)[k];
+      } else {
+        found = false;
+        break;
+      }
+    }
+
+    if (found) {
+      current = candidate;
+      break;
+    }
+  }
+
+  if (current === null) {
+    console.warn(`Translation key not found: ${key} for locale: ${locale}`);
+    return key;
+  }
+
+  if (typeof current !== "string") {
+    return key;
+  }
+
+  let text = current;
+  if (replacements) {
+    Object.entries(replacements).forEach(([k, v]) => {
+      text = text.replace(new RegExp(`{${k}}`, "g"), String(v));
+    });
+  }
+
+  return text;
+};
+
+/** Locale assumed during server rendering, matching ChatContext's initial state. */
+export const DEFAULT_LOCALE: Locale = "zh-TW";
+
+/**
+ * Read the persisted UI language without React context. Mirrors the
+ * `localStorage` key written by `setUiLanguage` in ChatContext.
+ */
+export const getStoredLocale = (): Locale => {
+  if (typeof window === "undefined") return DEFAULT_LOCALE;
+  try {
+    const saved = localStorage.getItem("language");
+    return isLocale(saved) ? saved : DEFAULT_LOCALE;
+  } catch {
+    return DEFAULT_LOCALE;
+  }
+};
+
+/** Server snapshot for `useSyncExternalStore`; always the SSR-stable default. */
+export const getServerLocale = (): Locale => DEFAULT_LOCALE;
+
+const localeListeners = new Set<() => void>();
+
+/**
+ * Persist the UI language and notify subscribers. The `storage` event only fires
+ * in *other* tabs, so same-tab writes have to notify explicitly.
+ */
+export const setStoredLocale = (locale: Locale): void => {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem("language", locale);
+  } catch {
+    // Ignore quota/privacy-mode failures; the in-memory notification still runs.
+  }
+  localeListeners.forEach((listener) => listener());
+};
+
+/**
+ * Subscribe to language changes. Paired with `getStoredLocale` in
+ * `useSyncExternalStore` so server and client agree during hydration and React
+ * re-renders once the stored preference is readable.
+ */
+export const subscribeToLocale = (onStoreChange: () => void): (() => void) => {
+  if (typeof window === "undefined") return () => {};
+  localeListeners.add(onStoreChange);
+  window.addEventListener("storage", onStoreChange);
+  return () => {
+    localeListeners.delete(onStoreChange);
+    window.removeEventListener("storage", onStoreChange);
+  };
+};

--- a/frontend/src/lib/redirect.ts
+++ b/frontend/src/lib/redirect.ts
@@ -1,0 +1,62 @@
+/** Pages that must never be a post-auth destination, or the user loops back to them. */
+const AUTH_PATHNAMES = new Set(["/login", "/register"]);
+
+// Reserved TLD (RFC 2606), so it can never collide with a real deployment origin.
+const RESOLVE_BASE = "http://redirect.invalid";
+
+/**
+ * Only ever redirect to a same-origin relative path.
+ *
+ * Pattern-matching the raw string is not sufficient: the URL parser strips tab
+ * and newline characters before resolving, so a payload like "/\t/evil.example"
+ * (delivered percent-encoded as `%09`, which `URLSearchParams` decodes) looks
+ * like a rooted path to a regex yet resolves to "//evil.example". Everything is
+ * therefore resolved against a sentinel origin first, and only inputs that stay
+ * on that origin are accepted. The parser's normalized output is returned rather
+ * than the caller's string so no smuggled control characters survive.
+ */
+export const sanitizeRedirect = (raw: string | null): string => {
+  if (!raw || !raw.startsWith("/")) return "/";
+
+  let url: URL;
+  try {
+    url = new URL(raw, RESOLVE_BASE);
+  } catch {
+    return "/";
+  }
+  if (url.origin !== RESOLVE_BASE) return "/";
+
+  const pathname = url.pathname.replace(/\/+$/, "") || "/";
+  if (AUTH_PATHNAMES.has(pathname)) return "/";
+
+  // Matching the parsed origin is not on its own enough: naming the sentinel host
+  // in a protocol-relative input ("//redirect.invalid//evil.example") keeps the
+  // origin intact while leaving a protocol-relative *pathname* behind. Validate
+  // the string actually handed to the router, which is what gets navigated to.
+  const target = `${url.pathname}${url.search}${url.hash}`;
+  return /^\/(?![/\\])/.test(target) ? target : "/";
+};
+
+/** Read and sanitize the `redirect` query parameter of the current URL. */
+export const readRedirectParam = (): string => {
+  if (typeof window === "undefined") return "/";
+  return sanitizeRedirect(new URLSearchParams(window.location.search).get("redirect"));
+};
+
+/**
+ * Server snapshot for `useSyncExternalStore`. The server cannot see the query
+ * string during pre-render, so it must report the same value every time and let
+ * React re-render with the real target after hydration; reading
+ * `window.location` in a `useState` initializer would instead bake a mismatched
+ * value into attributes such as `<Link href>`, which React does not repair.
+ */
+export const getServerRedirect = (): string => "/";
+
+/** The URL cannot change without a navigation, so there is nothing to observe. */
+export const subscribeToRedirect = (): (() => void) => () => {};
+
+/** Build a link to `path` that carries the pending redirect target along. */
+export const withRedirectParam = (path: string, redirectTo: string): string =>
+  redirectTo && redirectTo !== "/"
+    ? `${path}?redirect=${encodeURIComponent(redirectTo)}`
+    : path;

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -258,6 +258,9 @@
     "copyInviteCode": "Copy Invite Code",
     "inviteCodeCopied": "Invite code copied to clipboard!",
     "inviteCodeManualCopy": "Please copy the invite code manually:",
+    "copyInviteLink": "Copy Invite Link",
+    "inviteLinkCopied": "Invite link copied to clipboard!",
+    "inviteLinkManualCopy": "Please copy the invite link manually:",
     "saving": "Saving...",
     "saveSettings": "Save Settings",
     "settingsSaved": "Group settings saved.",
@@ -333,6 +336,21 @@
     "renameFailed": "Failed to rename folder",
     "deleteFailed": "Failed to delete folder",
     "confirmAction": "Confirm"
+  },
+  "inviteAccept": {
+    "pageTitle": "Near | Group Invite",
+    "loading": "Loading invite...",
+    "invalidInvite": "This invite link is invalid or has expired.",
+    "backToNear": "Back to Near",
+    "group": "Group",
+    "invited": "You've been invited to join this group.",
+    "alreadyMember": "You're already a member of this group.",
+    "openChat": "Open Chat",
+    "cancel": "Cancel",
+    "accept": "Accept",
+    "joining": "Joining...",
+    "joinFailed": "Failed to join this group.",
+    "pendingApproval": "Your request to join {name} has been sent. You'll be able to open it once an admin approves it."
   },
   "chatFilter": {
     "filterAll": "All",

--- a/frontend/src/locales/zh-TW.json
+++ b/frontend/src/locales/zh-TW.json
@@ -250,6 +250,9 @@
     "copyInviteCode": "複製邀請碼",
     "inviteCodeCopied": "邀請碼已複製到剪貼簿！",
     "inviteCodeManualCopy": "請手動複製以下邀請碼：",
+    "copyInviteLink": "複製邀請連結",
+    "inviteLinkCopied": "邀請連結已複製到剪貼簿！",
+    "inviteLinkManualCopy": "請手動複製以下邀請連結：",
     "saving": "儲存中...",
     "saveSettings": "儲存設定",
     "settingsSaved": "群組設定已儲存。",
@@ -333,6 +336,21 @@
     "renameFailed": "修改資料夾名稱失敗",
     "deleteFailed": "刪除資料夾失敗",
     "confirmAction": "確定"
+  },
+  "inviteAccept": {
+    "pageTitle": "Near | 群組邀請",
+    "loading": "正在載入邀請…",
+    "invalidInvite": "此邀請連結無效或已失效。",
+    "backToNear": "返回 Near",
+    "group": "群組",
+    "invited": "你被邀請加入這個群組。",
+    "alreadyMember": "你已經是這個群組的成員了。",
+    "openChat": "前往聊天室",
+    "cancel": "取消",
+    "accept": "同意加入",
+    "joining": "加入中…",
+    "joinFailed": "加入此群組失敗。",
+    "pendingApproval": "已送出加入 {name} 的申請，待管理員審核通過後即可開啟。"
   },
   "chatFilter": {
     "filterAll": "全部",

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -100,6 +100,18 @@ export interface RoomSummary extends Room {
   role?: RoomMemberRole;
 }
 
+/** Read-only preview of a group room resolved from an invite code, shown before the caller confirms joining. */
+export interface RoomInvitePreview {
+  roomId: string;
+  name?: string;
+  avatarUrl?: string;
+  requireApproval: boolean;
+  /** True if the caller already has a membership row for this room, including a pending one. */
+  isMember: boolean;
+  /** True if the caller has already requested to join and is still awaiting approval. */
+  isPending: boolean;
+}
+
 // ---------------------------------------------------------------------------
 // Messages
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## 變更描述 (Description)

Issue #271 提出兩項訴求：(1) 群組加入邀請連結 + 接受邀請頁面（顯示取消/同意與頭像）、(2) 好友列表底部的邀請連結 + QR Code；兩者都要求「登入後重導向」。

本 PR **僅實作 (1)**，並在下方「範圍排除說明」記錄 (2) 為何不在本次範圍內。因此本 PR **不會關閉 #271**（未使用 `Closes`），issue 保持開啟以追蹤好友邀請部分，後續規劃已留言於 issue。

> ### 給審閱者的重點提醒
>
> 1. **本 PR 範圍已顯著超出原始構想**，原因是六輪自動審查的回饋累積。除了邀請功能本身，現在還包含 `lib/i18n.ts`（翻譯查表抽離）、`lib/redirect.ts`（重導向檢查）、`login`／`register` 兩頁的修改，以及一次 `dev` 的 Bun & Hono 重構合併。每一項單獨看都有對應的審查意見支撐，但整體審查面積確實變大。**若希望縮小範圍，最合理的切分點是把 `login`／`register` 的 redirect 相關改動獨立成另一個 PR。**
> 2. **`sanitizeRedirect` 修掉了一個實際可利用的開放重導向漏洞**（詳見下方「安全性修正」），但本專案前端目前**沒有任何測試框架**（無 vitest／jest／test script／設定檔），因此這個安全性修正**沒有自動化迴歸測試保護**。我以 39 組案例在本機驗證過，但那是臨時腳本、未進版控。建議後續補上前端測試框架並為此函式加上迴歸測試——這個函式在連續兩輪審查中各出現過一次安全性缺陷，缺乏迴歸保護的風險是具體的。
> 3. **前端行為只有型別檢查與 lint 把關**。本次多數修正集中在 hydration、`<Link href>`、分頁競態等瀏覽器層行為，這些在此環境無法實測。後端則有 CI e2e 對真實 PostgreSQL 驗證，覆蓋良好。

### 根因分析 (Root Cause)

群組邀請原本只有 8 碼「邀請碼」機制（`roomService.joinByCode`），前端僅有一個手動貼上邀請碼的輸入框。沒有可分享的連結 URL、沒有顯示群組資訊與同意/取消的頁面，也完全沒有「未登入導向登入、登入後導回原頁」的機制（全專案 grep 確認不存在 `?redirect=`／`next=`）。`joinByCode` 本身是「查詢＋直接加入」的原子操作，沒有可先預覽再決定的唯讀端點。

## 相關的 Issue (Related Issue)
Relates to #271（僅實作群組邀請連結部分）

## 變更類型 (Type of Change)
- [x] `feat`: 新增功能
- [x] `fix`: 修復 Bug（含一項安全性修正）
- [x] `test`: 新增或修正測試案例
- [x] `docs`: 修改文件

## 變更內容 (What Changed)

### 後端
- **新增 `GET /api/v1/rooms/invite/:code`**：唯讀預覽端點，回傳 `{ roomId, name, avatarUrl, requireApproval, isMember, isPending }`，不會讓使用者加入群組。沿用整個 rooms router 既有的 `authMiddleware`。
- `isPending` 區分「已送出申請、尚待審核」與正式成員——待審核者若被當成正式成員導入聊天室，實際上讀不到任何訊息。
- **`joinByCode` 併發修正**：`roomMemberRepo.add` 是不含 `ON CONFLICT` 的純 INSERT，兩個同時的加入請求可能都通過前置的 `findMember` 檢查，落敗的一筆會以 500 收場。已將 `23505` 轉譯為既有的 `ConflictError`（比照 `friendController` 的既有慣例）。
- 防禦性檢查 `room.type === 'group'`，比照 `roomService` 中其他方法的既有慣例。
- `shared/types.ts` 新增 `RoomInvitePreview`。

### 前端
- **新增 `/invite/[code]` 接受邀請頁**：顯示群組頭像、名稱與同意/取消。刻意置於 `(main)` route group 之外（不掛載 `ChatProvider`），讓未登入訪客也能開啟並被導向登入。
  - 正式成員 → 顯示「已是成員／前往聊天室」；待審核者（`isPending`）→ 顯示等待審核。
  - 加入後依 `room.requireApproval`（加入回應，而非可能過期的 preview）決定導向或顯示等待審核。
  - 409「已是成員」的競態備援會**重新取得預覽**確認實際 membership，而非沿用舊的 preview。
  - 未登入時導向 `/login?redirect=/invite/{code}`。
  - 使用 `refreshTokensExclusive`（新增）取得 token，沿用 `api.ts` 既有的 Web Locks 跨分頁鎖；直接呼叫 `refreshTokens` 會讓兩個分頁送出同一個輪替前 cookie，觸發後端 reuse 偵測並撤銷所有 session。
  - 語系經 `useSyncExternalStore` 取得（SSR 穩定值 + hydration 後更新），並在取得 token 後讀取帳號語言偏好寫入 `localStorage`，解決全新瀏覽器一律顯示 zh-TW 的問題。
  - 錯誤訊息一律使用 `inviteAccept` 翻譯鍵，原始英文錯誤僅寫入 `console.error`。
- **`GroupSettings.tsx`** 新增「複製邀請連結」按鈕——這是讓新頁面在 UI 上真正可被觸及的入口。
- **`login`／`register`** 支援 `?redirect=`：登入頁的「Create one」與註冊頁的「Sign in」都會帶著目標路徑，註冊成功後同樣導回原邀請頁（沒有帳號的收件者是邀請流程最常見的情境）。兩頁的 redirect 值皆以 `useSyncExternalStore` 取得，避免 `<Link href>` 在 SSR 與 hydration 間不一致。
- **新增 `lib/i18n.ts`**：把翻譯查表抽成不依賴 React context 的純函式，讓 `(main)` 之外的頁面也能在地化。`useTranslation` 改為薄封裝，回退鏈（`uiLanguage` → `en` → `zh-TW`）完全不變。
- **新增 `lib/redirect.ts`**：共用的重導向檢查（見下方安全性修正）。

### 安全性修正 (Security)

`sanitizeRedirect` 原先以正則檢查「第一個斜線後是否緊接 `/` 或 `\`」。這不足夠：`URLSearchParams` 會把 `%09` 解碼成 tab，而 WHATWG URL 解析在解析前會先移除 tab／換行，因此 `/login?redirect=/%09/evil.example` 會通過檢查，最終 `router.push` 導向 `https://evil.example/`。已實測確認此攻擊鏈成立。

修正方式：先以 RFC 2606 保留網域 `redirect.invalid` 作為哨兵 base 用 URL parser 解析，只接受解析後 origin 未改變的輸入，並回傳 **parser 正規化後**的 `pathname + search + hash`（而非呼叫端原字串，否則夾帶的控制字元仍會流出）。同時以 pathname 比對排除 `/login`／`/register` 的所有變體（query、fragment、尾斜線）。

### 文件
- `docs/api-documentation.md` 與 `docs/ZH-TW/api-documentation.md` 新增端點與 `RoomInvitePreview` 型別。`name`／`avatarUrl` 標示為選填並註明未設定時會從回應中省略（repository 將 NULL 映射為 `undefined`，序列化時直接省略而非 `null`）。

### 合併 dev 的 Bun & Hono 重構
`dev` 於本 PR 進行中合入 PR #403（Express → Hono、Node → Bun、vitest → `bun:test`、目錄扁平化），本分支已合併並移植：`roomController.ts` 隨重構刪除，`previewByCode` 改以 Hono handler 實作於 `roomRoutes.ts`；單元測試自 `tests/unit/controllers/` 移至 `tests/unit/routes/roomRoutes.test.ts` 並改用 `bun:test` 與 `app.request()`。前端與 `shared/types.ts` 不受該重構影響。

### 範圍排除說明 (Explicitly Out of Scope)

**好友邀請連結 + QR Code 未包含在本次變更中**：位於完全不同的子系統；專案目前沒有安裝任何 QR Code 函式庫；且有一個會直接影響資料模型、issue 原文未回答的決策——連結識別碼要用原始 `userId`（不需後端變更，但等於公開曝光 user id 且無法撤銷），還是新的可撤銷／可過期 opaque token（需要新資料表與 migration）。已於 issue #271 留言請 repo owner 確認後再另開 PR。

## 驗證與測試計畫 (Verification & Test Plan)

### 自動化測試（CI 全綠）
- [x] `unit-tests`：通過（本機 `bun scripts/run-tests.ts tests/unit` 32 個檔案全數通過，含新增的 `previewByCode` 5 案例、`roomRoutes` 預覽路由 3 案例、`joinByCode` 的 23505 轉譯 2 案例）
- [x] `integration-tests`：通過
- [x] `e2e-tests`：通過（`room.e2e.test.ts` 新增 4 案例：未加入時 `isMember: false`、加入後 `isMember: true`、需審核群組送出申請後 `isPending: true`、未知邀請碼 404，並斷言無頭像時 `avatarUrl` 欄位被省略）
- [x] `frontend-typecheck`、`frontend-lint`：通過（本機 0 errors / 0 warnings）
- [x] 前端 production build：成功

> `backend-build`／`frontend-build`／`security-scan` 為 CI path-filter 判定跳過，非失敗。

### 未被自動化覆蓋的部分（需人工驗證）
前端無測試框架，以下必須人工確認：
- 於群組設定頁複製邀請連結，在無痕視窗開啟 → 應導向 `/login?redirect=...`，登入後自動回到邀請頁並顯示頭像、名稱與同意/取消。
- 未註冊使用者點「Create one」→ 註冊頁應保留 redirect，註冊成功後導回邀請頁。
- 需審核群組：同意後顯示「等待審核」；**重新開啟同一連結仍應顯示等待審核**，不應顯示「已是成員」。
- 已是正式成員開啟連結 → 顯示「前往聊天室」。
- 不存在的邀請碼 → 顯示在地化錯誤訊息（非後端英文原文）與返回按鈕。
- 切換帳號語言後開啟邀請連結 → 頁面文案與頁籤標題應隨之切換；全新瀏覽器（無 `localStorage.language`）亦應顯示帳號偏好語言。
- 一般登入流程（無 `redirect` 參數）不受影響，仍導向 `/`。
- **開放重導向**：`/login?redirect=//evil.com`、`/login?redirect=/\evil.com`、`/login?redirect=/%09/evil.example` 皆應 fallback 至 `/`，不得導向外部網域。

## 資料庫變更 (Database Changes)
* 是否包含 Schema 修改？ **否**

## API 與 WebSocket 協定一致性
* 是否涉及 API 或 WebSocket 資料結構變更？ **是**
* 純新增 `GET /api/v1/rooms/invite/:code`（回傳 `RoomInvitePreview`），未修改任何既有路由或 WebSocket 事件。已同步更新中英文 API 文件。

## 審查歷程 (Review History)

實作前經一位 `opus` architect 顧問審視根因與方案，主要採納：預覽端點回傳 `isMember` 而非以錯誤訊息字串比對（`api.ts` 的 `request()` 會丟棄 HTTP 狀態碼與 error code，只保留訊息文字，字串比對極脆弱）；不為了 i18n 把 `ChatProvider` 掛到此頁（其 init effect 會硬導向 `/login` 而與本頁的重導向邏輯衝突）；`requireApproval` 需獨立處理。

後續六輪自動審查共修正 12 項，其中多數是前一輪修正本身的缺陷，值得審閱者留意的有：待審核成員被導入無法使用的聊天室、併發加入的 500、繞過跨分頁 refresh 鎖、在地化翻譯鍵因三元判斷而永遠不會顯示、以及上述的開放重導向漏洞。各項的完整說明與取捨理由記錄在對應的 review thread 中。

Generated with [Claude Code](https://claude.com/claude-code)