### PR TITLE
chore: set effort level to xhigh in Claude settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,5 @@
 {
+  "effortLevel": "xhigh",
   "hooks": {
     "SessionStart": [
       {


### PR DESCRIPTION
## 變更描述 (Description)
Updated `.claude/settings.json` to set `effortLevel` to `"xhigh"`. This configuration change increases the effort level for Claude's processing, likely to enable more thorough analysis and higher quality outputs.

## 相關的 Issue (Related Issue)
Closes #

## 變更類型 (Type of Change)
- [x] `chore`: 建置流程或輔助工具變更

## 驗證與測試計畫 (Verification & Test Plan)
N/A - This is a configuration change with no code logic or functionality to test.

## 資料庫變更 (Database Changes)
* 此變更是否包含資料庫 Schema 修改？ **否**

## API 與 WebSocket 協定一致性 (API & WebSocket Contract Check)
* 此變更是否涉及 API 路由或 WebSocket 事件的資料結構變更？ **否**

https://claude.ai/code/session_01KNbBQZhCsEkoqn5Fzc4tXm