### PR TITLE
fix: 修正 Semantic Release 設定衝突（移除 [skip ci] 與 @semantic-release/github、補 fetch-depth） (#405)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,11 +313,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      issues: write
-      pull-requests: write
     steps:
       - uses: actions/checkout@v7
         with:
+          fetch-depth: 0
           persist-credentials: false
       - uses: pnpm/action-setup@v6
         with:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -25,9 +25,8 @@
           "backend/package.json",
           "CHANGELOG.md"
         ],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+        "message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}"
       }
-    ],
-    "@semantic-release/github"
+    ]
   ]
 }

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -284,6 +284,6 @@ When milestone changes on `dev` are merged into `main`, GitHub Actions (`.github
    - `BREAKING CHANGE:` → Increments **Major (`a`)** (e.g. `v1.0.1` → `v2.0.0`)
    - `docs:`, `chore:`, `refactor:` → No version increment
 2. **Multi-Package Version Sync**: Runs `scripts/update-versions.js` to synchronize `"version"` in root `package.json`, `frontend/package.json`, and `backend/package.json`.
-3. **Changelog & GitHub Release**: Automatically generates `CHANGELOG.md` and publishes formatted **Release Notes directly on the GitHub Release page**.
+3. **Changelog Generation**: Automatically generates `CHANGELOG.md` and the formatted release notes content. The GitHub Release page itself is **not** created at this step - `.github/workflows/release-stack.yml` is the single owner of Release creation (see step 4).
 4. **Stack Image & Bundle Publication**: Creating tag `vX.Y.Z` triggers `.github/workflows/release-stack.yml`, building & pushing Docker images to GHCR, signing provenance attestations, and attaching `near-chat-stack-vX.Y.Z.tar.gz` deployment bundle to the GitHub Release.
 

--- a/docs/ZH-TW/DEVELOPMENT.md
+++ b/docs/ZH-TW/DEVELOPMENT.md
@@ -284,6 +284,6 @@ describe('userRepository', () => {
    - `BREAKING CHANGE:` $\rightarrow$ 遞增 **Major (`a`)**（如 `v1.0.1` $\rightarrow$ `v2.0.0`）
    - `docs:`, `chore:`, `refactor:` $\rightarrow$ 不遞增版本號
 2. **三方版本號同步**：自動執行 `scripts/update-versions.js` 同步更新根目錄 `package.json`、`frontend/package.json` 與 `backend/package.json` 的版本。
-3. **Changelog 與 Release 頁面**：自動更新 `CHANGELOG.md`，並**將格式化後的 Release Notes 直接發布於 GitHub Release 頁面**。
+3. **Changelog 產生**：自動更新 `CHANGELOG.md` 並產生格式化的 Release Notes 內容。此步驟**不會**建立 GitHub Release 頁面——`.github/workflows/release-stack.yml` 是唯一的 Release 建立者（見步驟 4）。
 4. **Stack 映像檔與部署包發布**：建立 `vX.Y.Z` 標籤並觸發 `.github/workflows/release-stack.yml`，自動建置 Frontend/Backend 容器映像檔推至 GHCR、簽署 SLSA Provenance，並附加 `near-chat-stack-vX.Y.Z.tar.gz` 部署包至 GitHub Release。
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "@semantic-release/commit-analyzer": "^13.0.1",
     "@semantic-release/exec": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
-    "@semantic-release/github": "^11.0.1",
     "@semantic-release/release-notes-generator": "^14.0.0",
     "semantic-release": "^24.2.3"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       '@semantic-release/git':
         specifier: ^10.0.1
         version: 10.0.1(semantic-release@24.2.9(typescript@6.0.3))
-      '@semantic-release/github':
-        specifier: ^11.0.1
-        version: 11.0.6(semantic-release@24.2.9(typescript@6.0.3))
       '@semantic-release/release-notes-generator':
         specifier: ^14.0.0
         version: 14.1.1(semantic-release@24.2.9(typescript@6.0.3))


### PR DESCRIPTION
## 變更描述 (Description)

修正 PR #397 引入 Semantic Release 時遺留的三項純設定層級缺陷。這三項各自都會讓發布流程失效，且彼此獨立、可分別回退。

### 根因分析 (Root Cause)

本次在 `origin/dev` 上逐項重新驗證（不沿用先前留言的結論），三項問題全部成立：

1. **`[skip ci]` 與 CI 驗證條件互相矛盾**
   `.releaserc.json` 第 28 行的 commit message 為 `chore(release): ${nextRelease.version} [skip ci]`。GitHub Actions 原生辨識 `[skip ci]` 並跳過該次 push 的所有 workflow run，因此版本號 commit 永遠不會有屬於自己的 `ci.yml` 執行紀錄；而 `release-stack.yml` 要求 tag 指向的 commit 必須有一次已完成且成功的 `ci.yml` push run。

2. **`release` job 的 checkout 是 shallow clone**
   `ci.yml` 第 280-282 行只設定 `persist-credentials: false`，未設 `fetch-depth: 0`。

3. **`@semantic-release/github` 與 `release-stack.yml` 的冪等性防護互斥**
   `.releaserc.json` 第 31 行的 `@semantic-release/github` 會自行建立 GitHub Release。`release-stack.yml` 設計上 fail-closed：第 200 行在「Release 已存在但四個 image 參照皆遺失」時直接中止，拒絕以新建置覆寫；而真正的 Release 建立者是它自己的第 491 行 `gh release create`。若 Semantic Release 先建立了沒有對應 image 的 Release，該版本之後永遠無法正確發布。

### 對 issue 描述的一項事實更正

Issue #405 敘述這三點「均在 `origin/dev` 上實地確認」。實際上 **`release-stack.yml` 只存在於 `origin/main`，不在 `origin/dev`**（`git ls-tree -r --name-only origin/dev -- .github/workflows/` 只有 `ci.yml` 與 `close-issues-on-dev-merge.yml`）。`docs/RELEASE.md` 與 `docs/ZH-TW/RELEASE.md` 同樣只在 `main`（這一點影響 #408 的前提）。

衝突本身仍然成立，因為兩邊都在 `main` 上執行：`.releaserc.json` 的 `branches` 為 `["main"]`，`ci.yml` 的 `release` job 條件為 `github.ref == 'refs/heads/main'`。此外 `origin/main` 目前**沒有** `release` job、也沒有 `.releaserc.json`，代表這條流程**從未真正執行過**，現在（提升到 `main` 之前）修正正是時機。

## 相關的 Issue (Related Issue)

Closes #405

## 變更類型 (Type of Change)

- [x] `fix`: 修復 Bug
- [x] `ci`: CI 設定變更
- [x] `docs`: 修改文件

## 變更內容 (What Changed)

四個獨立 commit，可分別回退：

| Commit | 變更 | 原因 |
| --- | --- | --- |
| `ff0ec9e` | `.releaserc.json`：commit message 移除 `[skip ci]` | 解除與 `release-stack.yml` CI 驗證條件的矛盾 |
| `ef8dd86` | `ci.yml`：`release` job checkout 加 `fetch-depth: 0`；移除 `issues: write` 與 `pull-requests: write` | 提供完整歷史；這兩個權限原本只為 `@semantic-release/github` 而設，該 job 其餘步驟（checkout、pnpm、node、install、`npx semantic-release`）皆未使用。與外掛移除放在相鄰 commit，使回退時權限與外掛一併復原 |
| `0f52b62` | `package.json` 與 `pnpm-lock.yaml`：移除 `@semantic-release/github` | 讓 `release-stack.yml` 成為唯一 Release 建立者 |
| `b5857c8` | `docs/DEVELOPMENT.md`、`docs/ZH-TW/DEVELOPMENT.md` 第 292 行 | 見下方「範圍說明」 |

`persist-credentials: false` 未更動。`semantic-release` 本身未移除。

### 關於 lockfile 的精確說明

`@semantic-release/github@11.0.6` **本來就是 `semantic-release@24.2.9` 自己的直接相依**（`pnpm-lock.yaml` 第 8000 行）。因此它仍會留在 lockfile 的 packages 區段與 `node_modules` 中，**只有頂層 importer 條目被移除**（lockfile 淨變更為 -3 行）。正確說法是「不再是直接 devDependency」，而非「已從 lockfile 移除」。

### 範圍說明（超出 issue 列舉檔案的部分）

Issue 的驗收標準將變更範圍限於 `.releaserc.json`、`ci.yml`、`package.json`／lockfile。本 PR 額外改了兩行文件：`docs/DEVELOPMENT.md` 與 `docs/ZH-TW/DEVELOPMENT.md` 第 292 行原本寫「semantic-release 將格式化後的 Release Notes 直接發布於 GitHub Release 頁面」，這句話**正是被本 PR 的第 3 項變更弄成錯誤的**，留著會誤導。已獨立為 commit `b5857c8`，若審查者希望嚴格遵守 issue 範圍，可單獨 drop 該 commit 而不影響其餘三項。

同兩份文件的步驟 4 寫「建立 `vX.Y.Z` 標籤並觸發 `release-stack.yml`」，這句話依下述原因其實也不正確，但它**不是本 PR 造成的**（屬既有錯誤），故未在此修改，留給 #407／#408 一併處理。

## 驗證與測試計畫 (Verification and Test Plan)

### 本地測試 (Local Tests)

本 PR 不含任何 `backend/`、`frontend/`、`shared/` 程式碼或資料庫變更，PR 範本列出的 Docker 型別檢查與測試套件**不適用**，因此未執行：

- [ ] 後端型別檢查 - 不適用（未變更後端程式碼）
- [ ] 前端型別檢查 - 不適用（未變更前端程式碼）
- [ ] 前端 Linter 檢查 - 不適用（未變更前端程式碼）
- [ ] 單元測試 - 不適用
- [ ] 整合測試 - 不適用

### 手動驗證 (Manual Verification) - 已實際執行

在本次 sandbox 中建立一個獨立的合成 repo（真實的 `.releaserc.json` 與 `scripts/update-versions.js`、本地 bare remote 作為 origin、annotated tag `v1.0.0` 為基準、再加一個 `feat(backend): ...` commit），實際執行 semantic-release：

**1. `npx semantic-release --dry-run --no-ci` - 結束碼 0**

```
Loaded plugin "verifyConditions" from "@semantic-release/changelog"
Loaded plugin "verifyConditions" from "@semantic-release/exec"
Loaded plugin "verifyConditions" from "@semantic-release/git"
Loaded plugin "analyzeCommits" from "@semantic-release/commit-analyzer"
Loaded plugin "generateNotes" from "@semantic-release/release-notes-generator"
Allowed to push to the Git repository
Found git tag v1.0.0 associated with version 1.0.0 on branch main
The release type for the commit is minor
The next release version is 1.1.0
```

五個外掛全部載入成功、無 plugin 解析錯誤，並正確算出下一版號 `1.1.0` - 對應驗收標準第三項。移除 `@semantic-release/github` 後 semantic-release **沒有**因缺少 publish 外掛而報錯（core 將 `publish` 標記為非必要）。

**2. 非 dry-run 的實際執行（對本地 bare remote）**

```
--- commit message of version commit ---
chore(release): 1.1.0
--- does it contain [skip ci]? ---
0 occurrences of 'skip ci' -> GOOD
--- tag object type ---
commit
--- synced versions ---
root = 1.1.0 / frontend = 1.1.0 / backend = 1.1.0
```

確認 commit message 已不含 `[skip ci]`、三個 `package.json` 版本同步、且**沒有建立任何 GitHub Release**。

**3. Lockfile 一致性**

`pnpm install --frozen-lockfile --lockfile-only` 結束碼 0 且未改動 `pnpm-lock.yaml`，證明手動編輯的 lockfile 正是 pnpm 認定與 `package.json` 一致的結果。

**4. 合併安全性**

`git merge-tree --write-tree origin/main fix/issue-405` 產生的樹仍包含 `release-stack.yml` 與 `codeql.yml`，確認未來 `dev` 提升到 `main` 不會刪除只存在於 `main` 的這兩個 workflow。

### 未驗證事項（明確標示）

- 未在真實 GitHub Actions 上跑過端到端流程。上述皆為合成 repo 加本地 remote 的執行結果。
- 合成測試的 remote 是本地路徑，**未涵蓋** `GITHUB_TOKEN` 組出 https 認證 URL 的推送路徑。該路徑改為由原始碼確認（見下方顧問意見最後一段）。
- 版本號 commit 觸發的那次 CI 是否會全綠，未經實測。
- 「預設 `GITHUB_TOKEN` 產生的事件不觸發新 workflow run」為 GitHub 官方文件記載的行為，非本 repo 實測。

## 重要：本 PR 不足以讓發布流程跑通

必須明講，避免合併後誤以為自動發布已可用。移除 `[skip ci]` 是**必要但不充分**的：

- 版本號 commit 是用預設 `GITHUB_TOKEN` 推送的，依 GitHub 的防遞迴機制，**即使移除 `[skip ci]` 它仍然不會產生屬於自己的 `ci.yml` run**。
- 同樣地，**tag 推送也不會觸發 `release-stack.yml`**（該 workflow 只監聽 `push: tags`）。

因此 #407 敘述的前提「移除 `[skip ci]` 後版本號 commit 才有屬於自己的 CI run 可供 `workflow_run` 監聽」並不成立 - 監聽 `ci.yml` 的橋接沒有東西可觸發，且就算橋接成功，tag push 本身也不會啟動 `release-stack.yml`。建議在 #407 實作前先修正其設計前提。

另外，本次實測已**確認 #406 的前提為真**：semantic-release 建立的是 lightweight tag（上方 `git cat-file -t` 回傳 `commit` 而非 `tag`），而 `release-stack.yml` 第 59-61 行硬性要求 annotated tag。

以現況而言，這三項修正在合併後是「可證明無害」的：目前不論改或不改，都不會產生任何 workflow run。風險只在未來導入 PAT 或 App token 後才浮現。

## 顧問意見要點 (Advisor Notes)

已請 architect 子代理（opus）覆核，其意見改變了原始計畫三處：

1. **`fetch-tags: true` 是多餘的** - 我原本一併加上。`actions/checkout` 在 `fetch-depth` 小於等於 0 時走 `getRefSpecForAllHistory()`，該 refspec 已包含 `+refs/tags/*:refs/tags/*`。已移除，只保留 `fetch-depth: 0`。
2. **`fetch-depth: 0` 應定位為「加固」而非「修 bug」** - semantic-release 自己會呼叫 `git fetch --unshallow --tags` 自我修復 shallow clone。此項降低不確定性，但並非硬性阻斷點。
3. **移除 `issues: write` 與 `pull-requests: write`** - 顧問逐步檢查 `release` job 後確認無其他步驟使用，且應與外掛移除相鄰以保持回退的原子性。已採納。

顧問另確認：移除 `@semantic-release/github` **不會**破壞推送能力。semantic-release core 在載入任何外掛前就於 `index.js:67` 呼叫 `getGitAuthUrl()`，由 `GITHUB_TOKEN` 組出形如 `https://x-access-token:TOKEN@github.com/...` 的認證 URL；因目前 `ci.yml` 只設定 `GITHUB_TOKEN` 一個 token 變數，會走 `envVars.length === 1` 的快速路徑。**因此請勿在該 job 額外加入 `GH_TOKEN`**，否則會離開此路徑。

---
Generated with Claude Code (https://claude.com/claude-code)