### PR TITLE
fix(security): 修正 next/brace-expansion 漏洞並改用 CVE ratcheting 閘門

### DIFF
--- a/.cve-lite/baseline.json
+++ b/.cve-lite/baseline.json
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "createdAt": "2026-07-28T15:52:33.532Z",
+  "findings": [
+    {
+      "name": "brace-expansion",
+      "version": "1.1.15",
+      "advisoryIds": [
+        "GHSA-3jxr-9vmj-r5cp",
+        "GHSA-mh99-v99m-4gvg"
+      ]
+    },
+    {
+      "name": "sharp",
+      "version": "0.34.5",
+      "advisoryIds": [
+        "GHSA-f88m-g3jw-g9cj"
+      ]
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,19 +245,68 @@ jobs:
       # pnpm-lock.yaml covering every importer — so the previous per-package
       # scans would have found nothing to read and could have passed silently,
       # losing CVE coverage without ever turning the build red.
-      - name: Scan workspace dependencies for vulnerabilities
-        uses: OWASP/cve-lite-cli@v1
+      # Invoked directly rather than via OWASP/cve-lite-cli@v1: the action
+      # exposes no `ratchet` input, and `--ratchet` is what keeps the two
+      # unfixable findings in .cve-lite/baseline.json from blocking `release`
+      # without disarming `--fail-on high` for everything else. The baseline
+      # pins name+version, so a bump to either package re-reports it.
+      #
+      # Rejected alternative: the action's `only-used: true`. It suppresses any
+      # package the source never imports, which would permanently hide
+      # runtime-only transitive deps — sharp among them — instead of the two
+      # findings we actually accepted.
+      - uses: actions/setup-node@v7
         with:
-          path: "."
-          all: "true"
-          verbose: "true"
-          fail-on: high
-          sarif: "true"
+          node-version: 24
+      # `--ratchet` with no baseline present exits 0 and writes one, even with
+      # findings at or above --fail-on. A runner always starts from a clean
+      # checkout, so if .cve-lite/baseline.json ever stops being tracked, every
+      # run would silently self-baseline and the gate would pass forever with
+      # nothing to show it had been disarmed. Fail loudly instead.
+      - name: Verify CVE baseline is tracked
+        run: |
+          if [ ! -f .cve-lite/baseline.json ]; then
+            echo "::error::.cve-lite/baseline.json is missing. --ratchet would" \
+                 "self-baseline and silently disable the security gate." \
+                 "Commit the baseline instead of letting CI regenerate it."
+            exit 1
+          fi
+      - name: Scan workspace dependencies for vulnerabilities
+        run: |
+          npm install --no-save --prefix "$RUNNER_TEMP/cve-lite" cve-lite-cli@1
+          "$RUNNER_TEMP/cve-lite/node_modules/.bin/cve-lite" . \
+            --all --verbose --fail-on high --ratchet --sarif --no-open
+      # `--ratchet` writes no SARIF at all when nothing exceeds the baseline —
+      # the common case on a green build. Falling through with no file would
+      # fail the `if: always()` upload below, and worse, leave the `workspace`
+      # category with no analysis on main until GitHub flags the configuration
+      # as erroring. So synthesise an empty-but-valid run: same tool driver
+      # name, zero results, which clears stale alerts and keeps the tool
+      # reporting.
       - name: Rename workspace SARIF file
         if: always()
         run: |
           if ls cve-lite-scan-*.sarif 1> /dev/null 2>&1; then
             mv cve-lite-scan-*.sarif workspace.sarif
+          else
+            cat > workspace.sarif <<'SARIF'
+          {
+            "$schema": "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json",
+            "version": "2.1.0",
+            "runs": [
+              {
+                "tool": {
+                  "driver": {
+                    "name": "CVE Lite CLI",
+                    "informationUri": "https://owasp.org/cve-lite-cli/",
+                    "rules": []
+                  }
+                },
+                "results": []
+              }
+            ]
+          }
+          SARIF
           fi
       - name: Upload workspace scan to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@v4

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@iconify-react/boxicons": "^1.0.2",
     "clsx": "^2.1.1",
-    "next": "16.2.10",
+    "next": "16.2.12",
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "socket.io-client": "^4.8.3",
@@ -30,7 +30,7 @@
     "@types/react-dom": "^19.2.3",
     "babel-plugin-react-compiler": "^1.0.0",
     "eslint": "^9.39.5",
-    "eslint-config-next": "16.2.10",
+    "eslint-config-next": "16.2.12",
     "eslint-plugin-react-compiler": "19.1.0-rc.2",
     "jsdom": "^29.1.1",
     "tailwindcss": "^4.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   ws: ^8.21.0
   '@babel/core': ^7.29.7
   form-data: ^4.0.6
+  brace-expansion@>=5: 5.0.8
 
 importers:
 
@@ -112,8 +113,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       next:
-        specifier: 16.2.10
-        version: 16.2.10(@babel/core@7.29.7(supports-color@7.2.0))(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: 16.2.12
+        version: 16.2.12(@babel/core@7.29.7(supports-color@7.2.0))(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react:
         specifier: 19.2.7
         version: 19.2.7
@@ -158,8 +159,8 @@ importers:
         specifier: ^9.39.5
         version: 9.39.5(jiti@2.7.0)(supports-color@7.2.0)
       eslint-config-next:
-        specifier: 16.2.10
-        version: 16.2.10(@typescript-eslint/parser@8.62.0(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3))(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+        specifier: 16.2.12
+        version: 16.2.12(@typescript-eslint/parser@8.62.0(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3))(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
       eslint-plugin-react-compiler:
         specifier: 19.1.0-rc.2
         version: 19.1.0-rc.2(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)
@@ -634,60 +635,60 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@next/env@16.2.10':
-    resolution: {integrity: sha512-zLPxg9M0MEHmygpj5OuxjQ+vHMiy/K7cSp74G8ecYolmgUWw0RwN02tF56npup/+qaI8JB97hQgS/r2Hb6QwVA==}
+  '@next/env@16.2.12':
+    resolution: {integrity: sha512-d0Z5Bc13Fa4nR8pFAKx2jay2yhJM16vlfHbTzYnUQAxlNb6B6lmn4hjt69lYNt4kRtyYP6gEM49lPRHNbIyneg==}
 
-  '@next/eslint-plugin-next@16.2.10':
-    resolution: {integrity: sha512-Gs8D2m21VnJeFo9qvYIIqJH94frWerWYu41BprU1pLtRVF7PCQNLiFZZ3fG+iPuj3K83Cwv/rt+msLOy8Qgu3Q==}
+  '@next/eslint-plugin-next@16.2.12':
+    resolution: {integrity: sha512-uF2z/qAK2q7B5/6CpnFcBRX6jOq5iCO+Uqh1UkJhXljX1JwLarLYhhoJadO6dPb6moTprOKewMXheBcbIoSbug==}
 
-  '@next/swc-darwin-arm64@16.2.10':
-    resolution: {integrity: sha512-v9IdJCa0H0mbo+8z5zwUpOk1Vj7RjkcI5uNYf5Ws1y6szf/p3Mzl9hLaST8SCt6L9h8NGnruZcd2+o0NTNwDhA==}
+  '@next/swc-darwin-arm64@16.2.12':
+    resolution: {integrity: sha512-0W1R0teHWJrqKX0FH20IzzIWAOuGtBxPGuObrxy1lE8hQvCFj49KE8a3WUg0D7sq6rn6zkM4c7YGUnhudBS6oA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@16.2.10':
-    resolution: {integrity: sha512-17IS0jJRViROGmA9uGdNR8VPJpfbnaVG7E9qhso5jDLkmyd0lSDORWxbcKINzcFqzZqGwGtMSnrFRxBpuUYjLQ==}
+  '@next/swc-darwin-x64@16.2.12':
+    resolution: {integrity: sha512-Hy5Ls099+aFUmOLmIgPfLqNi6iCwhL3uQCssz5rWk+5Nkc6TUKCE83DY5BbNylfm3+mfwcSFnLRfrZDJhVxdtw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@16.2.10':
-    resolution: {integrity: sha512-GRQRsRtuciNJvB54AvvuQTiq0oZtFwa1owQqtZD8wwnGpM2L39MV22kpI72YSXLKIyY40LC66EiLFv4PiicXxg==}
+  '@next/swc-linux-arm64-gnu@16.2.12':
+    resolution: {integrity: sha512-+YqU2h1cQkHsGfvjAsrSmst8UIFBibBGm5x3Xgel8NLMiDQtNOM4sM2GOEMvG5YiOBNeN/Ykk8cQC2S0Xrqljg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-arm64-musl@16.2.10':
-    resolution: {integrity: sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A==}
+  '@next/swc-linux-arm64-musl@16.2.12':
+    resolution: {integrity: sha512-0qjhiYBaKAqF63LA1ZWAAnKTzFUguAaZiRa5etMLGGPj/B6uEVjtIZldIzFEp3wHlB0koK6aTzqPtSdplTCjoA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-linux-x64-gnu@16.2.10':
-    resolution: {integrity: sha512-iCVJnwvrPYECvA6WM/7+oo+OiTvedIKLxtCLAZP4xZR3nXa1zmzZyLPbYCmWvpd4CvMYF1EMTafd0ii3DygLvA==}
+  '@next/swc-linux-x64-gnu@16.2.12':
+    resolution: {integrity: sha512-7A3q26W+h7gnA15uqBToNuDqBEFZZcqh0mW2mn4AJh/G5pdg2RVE3n4slzLEliASZFG3NmsbEzng/x2Sh09mBg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-x64-musl@16.2.10':
-    resolution: {integrity: sha512-ov2g4H0dHY9bPoOU83m91hWT7Iq5qy13bUnyyshLU3HGR1Ownn0X9QpmDPc5iIUaahTp7f7LeGAhV4DSFtackw==}
+  '@next/swc-linux-x64-musl@16.2.12':
+    resolution: {integrity: sha512-qSjL/uppm+cbh21s72Ss8gkiOhQ4dExWHNGOWy6eZV7STj5WsKehgxT61beSsOj+YYQuTplL376lOCdMQU5T8w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-win32-arm64-msvc@16.2.10':
-    resolution: {integrity: sha512-DwAnhLX76HQiFFQNgWlcK+JzlnD1rZ+UK/WY0ZMI/deXpvgnesjNYrqcfo1JzBuz4Kf7o3brIBL0glI1junatA==}
+  '@next/swc-win32-arm64-msvc@16.2.12':
+    resolution: {integrity: sha512-X6hzsOUJac/e7AWSbn9gQ9nzHld1xWP5iyjHpYWvud8pufB679O1xg4JDyKr8Xd69Jvd+kM2Der6uftiZCmjYA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@16.2.10':
-    resolution: {integrity: sha512-0JXq3b85Jk9Jg4ntLUbXSPvoDw3gpZou7twuKdoFG2jOw635v7+IiXfTaa0TxVMyx78pUjnrVYwLgjKfX4e6/A==}
+  '@next/swc-win32-x64-msvc@16.2.12':
+    resolution: {integrity: sha512-F6fakeHuFTLOPt0bslQJdf+xtT+WIP9DVn/m4y1w1mRnVPyh3D/cNvzlRkxM444xfm+IvvYNSOrKiA2CDJ0Uxw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -1576,9 +1577,9 @@ packages:
   brace-expansion@1.1.15:
     resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -1973,8 +1974,8 @@ packages:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
 
-  eslint-config-next@16.2.10:
-    resolution: {integrity: sha512-HSybLOY0QKf39i4FWUqPN0xWiNDi6A6UqJmZtgDkS3zMqjXTqULvj/sueXx3cdCG0mVG+qH6k5/qdegklH1d1w==}
+  eslint-config-next@16.2.12:
+    resolution: {integrity: sha512-iaaf4vvKo5h2LBdGt0JuRv7t0Ysqr9FMCiFxbptDg8LqOE//mIKR80DdpOnSVM7qjLH3jT8P0aFiwXxBEGZRXw==}
     peerDependencies:
       eslint: '>=9.0.0'
       typescript: '>=3.3.1'
@@ -2918,8 +2919,8 @@ packages:
   nerf-dart@1.0.0:
     resolution: {integrity: sha512-EZSPZB70jiVsivaBLYDCyntd5eH8NTSMOn3rB+HxwdmKThGELLdYv8qVIMWvZEFy9w8ZZpW9h9OB32l1rGtj7g==}
 
-  next@16.2.10:
-    resolution: {integrity: sha512-2som5AVXb3kE6Yjine3/mNbBayYF58eguBWIVVUdr1y/L426xyVEgYxgBG+1QC34P2x5E+tcDup6XkuOAX3dCA==}
+  next@16.2.12:
+    resolution: {integrity: sha512-iD59eYQWmbFcEbX7v/acG5DRym9iw1DdaPoD0WTA920naWsE25wShzJW4+UvAs8MK9EC2kBfIH6vtto1H1PHGw==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -4572,34 +4573,34 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@next/env@16.2.10': {}
+  '@next/env@16.2.12': {}
 
-  '@next/eslint-plugin-next@16.2.10':
+  '@next/eslint-plugin-next@16.2.12':
     dependencies:
       fast-glob: 3.3.1
 
-  '@next/swc-darwin-arm64@16.2.10':
+  '@next/swc-darwin-arm64@16.2.12':
     optional: true
 
-  '@next/swc-darwin-x64@16.2.10':
+  '@next/swc-darwin-x64@16.2.12':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@16.2.10':
+  '@next/swc-linux-arm64-gnu@16.2.12':
     optional: true
 
-  '@next/swc-linux-arm64-musl@16.2.10':
+  '@next/swc-linux-arm64-musl@16.2.12':
     optional: true
 
-  '@next/swc-linux-x64-gnu@16.2.10':
+  '@next/swc-linux-x64-gnu@16.2.12':
     optional: true
 
-  '@next/swc-linux-x64-musl@16.2.10':
+  '@next/swc-linux-x64-musl@16.2.12':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@16.2.10':
+  '@next/swc-win32-arm64-msvc@16.2.12':
     optional: true
 
-  '@next/swc-win32-x64-msvc@16.2.10':
+  '@next/swc-win32-x64-msvc@16.2.12':
     optional: true
 
   '@noble/hashes@1.8.0': {}
@@ -5113,8 +5114,8 @@ snapshots:
 
   '@typescript-eslint/project-service@8.62.0(supports-color@7.2.0)(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.62.0(typescript@6.0.3)
-      '@typescript-eslint/types': 8.62.0
+      '@typescript-eslint/tsconfig-utils': 8.65.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.65.0
       debug: 4.4.3(supports-color@7.2.0)
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -5522,7 +5523,7 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -6001,9 +6002,9 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-config-next@16.2.10(@typescript-eslint/parser@8.62.0(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3))(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3):
+  eslint-config-next@16.2.12(@typescript-eslint/parser@8.62.0(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3))(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3):
     dependencies:
-      '@next/eslint-plugin-next': 16.2.10
+      '@next/eslint-plugin-next': 16.2.12
       eslint: 9.39.5(jiti@2.7.0)(supports-color@7.2.0)
       eslint-import-resolver-node: 0.3.10(supports-color@7.2.0)
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)
@@ -6967,7 +6968,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.8
 
   minimatch@3.1.5:
     dependencies:
@@ -6997,9 +6998,9 @@ snapshots:
 
   nerf-dart@1.0.0: {}
 
-  next@16.2.10(@babel/core@7.29.7(supports-color@7.2.0))(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  next@16.2.12(@babel/core@7.29.7(supports-color@7.2.0))(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
-      '@next/env': 16.2.10
+      '@next/env': 16.2.12
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.40
       caniuse-lite: 1.0.30001799
@@ -7008,14 +7009,14 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
       styled-jsx: 5.1.6(@babel/core@7.29.7(supports-color@7.2.0))(react@19.2.7)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.2.10
-      '@next/swc-darwin-x64': 16.2.10
-      '@next/swc-linux-arm64-gnu': 16.2.10
-      '@next/swc-linux-arm64-musl': 16.2.10
-      '@next/swc-linux-x64-gnu': 16.2.10
-      '@next/swc-linux-x64-musl': 16.2.10
-      '@next/swc-win32-arm64-msvc': 16.2.10
-      '@next/swc-win32-x64-msvc': 16.2.10
+      '@next/swc-darwin-arm64': 16.2.12
+      '@next/swc-darwin-x64': 16.2.12
+      '@next/swc-linux-arm64-gnu': 16.2.12
+      '@next/swc-linux-arm64-musl': 16.2.12
+      '@next/swc-linux-x64-gnu': 16.2.12
+      '@next/swc-linux-x64-musl': 16.2.12
+      '@next/swc-win32-arm64-msvc': 16.2.12
+      '@next/swc-win32-x64-msvc': 16.2.12
       babel-plugin-react-compiler: 1.0.0
       sharp: 0.34.5
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,3 +21,9 @@ overrides:
   "@babel/core": "^7.29.7"  # was ^7.29.6 in frontend/, weaker than the ^7.29.7
                             # already declared in frontend/package.json
   form-data: "^4.0.6"       # was backend/
+  # GHSA-3jxr-9vmj-r5cp / GHSA-mh99-v99m-4gvg. Scoped to the 5.x line via the
+  # `pkg@range` selector: `minimatch@10` (node-pg-migrate -> glob) pulls 5.0.6,
+  # while eslint 9 -> minimatch@3 still pulls 1.1.15, whose v1-line fix is
+  # 1.1.16 — an unscoped pin would force that consumer onto an incompatible
+  # major. The 1.1.15 path stays open on purpose; see the eslint 10 note below.
+  "brace-expansion@>=5": "5.0.8"


### PR DESCRIPTION
起因是 GitHub 回報 CVE Lite CLI 的 code scanning configuration error。根因是 SARIF category 改名：aced0fb 把掃描收斂為單一 `workspace` category，但 main 上仍掛著舊的 `backend` / `frontend` configuration，其中 `frontend` 自 2026-07-20 起就沒有再回報。**孤兒 configuration 已直接透過 code-scanning API 刪除**，本 PR 處理的是後續的漏洞與閘門設計。

## 修掉的漏洞

工作區掃描由 **4 high 降為 2 high**：

- `next` 16.2.10 → **16.2.12**，清掉 9 個 CVE。
- `brace-expansion@>=5` override 至 **5.0.8**（`GHSA-3jxr-9vmj-r5cp`、`GHSA-mh99-v99m-4gvg`）。

override 刻意使用 `pkg@range` 選擇器限定 5.x 線：`eslint@9 -> minimatch@3` 仍使用 1.1.15，無範圍的 pin 會把該 consumer 強推到不相容的 major。

## 剩餘 2 筆改以 ratchet 抑制

兩筆都無法在此 PR 解決，解除條件記錄於 #424：

| 套件 | 為什麼卡住 |
|---|---|
| `brace-expansion@1.1.15` | advisory 顯示 1.x 線修復版是 1.1.16，但 CVE Lite CLI 不分 major line，對 1.1.15 一律標 `Fixed 5.0.8` — pin 到 1.1.16 不會變綠。需 eslint 10 才能移除 `minimatch@3.x` 整條路徑。 |
| `sharp@0.34.5` | `next@16.2.12` 的 optionalDependencies 仍寫死 `^0.34.5`，升 next 不會帶動 sharp。工具自身標記 `⊘ Advisory hint only`。 |

採 `--ratchet` baseline 抑制，而非放寬 `--fail-on high`。baseline 綁定 name+version，套件一升版就重新報，抑制不會擴散到未來版本。

## security-scan 改為直接呼叫 CLI

`OWASP/cve-lite-cli@v1` 未暴露 `ratchet` input，故改為直接安裝執行，`--sarif` 與 Code Scanning 上傳皆保留。

曾評估該 action 的 `only-used: true`（實測可讓 CI 直接變綠）但**未採用**：它會濾掉原始碼未 import 的套件，等於永久遮蔽 sharp 這類執行期才使用的 transitive 相依 — 比預期的抑制範圍大得多。

## 一併修掉兩個會使閘門靜默失效的路徑

兩者皆為實測發現，非推導：

1. **`--ratchet` 在 baseline 缺席時 exit 0 並自動建立**，即使存在達到 `--fail-on` 門檻的 findings。runner 每次都是全新 checkout，若 `.cve-lite/` 脫離版控，閘門會永遠綠燈且不留任何痕跡。新增前置檢查改為明確失敗。

2. **`--ratchet` 無新發現時完全不產生 SARIF**（綠燈時的常態）。原本的 `if ls ...` 保護會讓 `workspace.sarif` 不存在 → `if: always()` 的上傳步驟失敗，且該 category 會斷更至再次被 GitHub 標為 configuration error — 正好重演本 PR 起因。改為產生 driver 名稱相同、`results: []` 的合法空 SARIF。

## 驗證

- 前端 lint、`tsc --noEmit`、build（6 條路由）、vitest **30 passed** 全過。
- workflow YAML 以 parser 取出實際 shell 腳本，空 SARIF 分支與 baseline guard 雙向行為皆實跑驗證。

## 注意

`security-scan` 的 `if` 條件為 `github.ref == 'refs/heads/main' || github.base_ref == 'main'`，**本 PR 的 base 是 dev，因此該 job 會 skipped** — 新設定要等 dev → main 時才會實際執行。`if` 條件未調整是刻意的，因為專案規劃收斂為單一 main 主分支（#409）。

Refs #424

🤖 Generated with [Claude Code](https://claude.com/claude-code)
