### PR TITLE
chore(ci): 將主要分支收斂為 main 並移除 dev 分支設定

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -66,7 +66,7 @@ body:
     attributes:
       label: 6. Checks (確認事項)
       options:
-        - label: I confirm this issue exists on the latest dev branch.
+        - label: I confirm this issue exists on the latest main branch.
           required: true
         - label: I have provided reproduction steps and sufficient log/error details.
           required: true

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,6 @@ updates:
   # 1. 根目錄 npm/pnpm 套件
   - package-ecosystem: "npm"
     directory: "/"
-    target-branch: "dev"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -22,7 +21,6 @@ updates:
   # 2. 前端 npm/pnpm 套件 (/frontend)
   - package-ecosystem: "npm"
     directory: "/frontend"
-    target-branch: "dev"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -41,7 +39,6 @@ updates:
   # 3. 後端 npm/pnpm 套件 (/backend)
   - package-ecosystem: "npm"
     directory: "/backend"
-    target-branch: "dev"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -60,7 +57,6 @@ updates:
   # 4. GitHub Actions 工作流 (.github/workflows)
   - package-ecosystem: "github-actions"
     directory: "/"
-    target-branch: "dev"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -72,7 +68,6 @@ updates:
   # 5. 後端 Docker Base Image (/backend)
   - package-ecosystem: "docker"
     directory: "/backend"
-    target-branch: "dev"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -84,7 +79,6 @@ updates:
   # 6. 前端 Docker Base Image (/frontend)
   - package-ecosystem: "docker"
     directory: "/frontend"
-    target-branch: "dev"
     schedule:
       interval: "weekly"
       day: "monday"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main]
     paths-ignore:
       - 'docs/**'
       - 'README.md'
@@ -11,7 +11,7 @@ on:
       - 'LICENSE'
       - 'AGENTS.md'
   pull_request:
-    branches: [main, dev]
+    branches: [main]
     paths-ignore:
       - 'docs/**'
       - 'README.md'

--- a/.github/workflows/close-issues-on-merge.yml
+++ b/.github/workflows/close-issues-on-merge.yml
@@ -1,9 +1,9 @@
-name: Close Issues on Dev Merge
+name: Close Issues on Merge
 
 on:
   pull_request:
     types: [closed]
-    branches: [dev]
+    branches: [main]
 
 permissions:
   issues: write

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,7 +15,7 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-    branches: [ "main", "dev" ]
+    branches: [ "main" ]
   schedule:
     - cron: '41 15 * * 1'
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,11 +21,12 @@ Please read through this guide to understand our development, testing, and contr
 
 ## 1. Git Workflow & Branching
 
-* **Active Development Branch**: The main branch for development is **`dev`**.
+* **Active Development Branch**: The main branch for development is **`main`**.
 * **Branching Strategy**: 
-  - Always branch off `dev` (e.g., `feat/my-feature` or `fix/my-bug`).
-  - Submit all Pull Requests back to the `dev` branch.
-  - Avoid pushing changes directly to `main` or `dev`.
+  - Always branch off `main` (e.g., `feat/my-feature` or `fix/my-bug`).
+  - Submit all Pull Requests back to the `main` branch.
+  - Avoid pushing changes directly to `main`.
+* **Releases**: Releases are cut by pushing a version tag (e.g., `v1.2.0`) on `main`; there is no long-lived release branch.
 
 ---
 
@@ -143,7 +144,7 @@ For details, refer to [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md).
 ## 7. Submitting a Pull Request
 
 1. **Self-Review**: Run ESLint, Type checks, and the full test suite locally.
-2. **Branch base**: Ensure the base branch of your PR is set to **`dev`**.
+2. **Branch base**: Ensure the base branch of your PR is set to **`main`**.
 3. **Commit Messages**: Verify your commit messages match the Conventional Commit format.
 4. **Description**: Describe your changes in **Traditional Chinese (繁體中文)** using our Pull Request Template.
 5. **Test Plan**: Document your verification steps clearly in the PR description.

--- a/CONTRIBUTING.zh-TW.md
+++ b/CONTRIBUTING.zh-TW.md
@@ -21,11 +21,12 @@
 
 ## 1. Git 工作流程與分支規範
 
-* **主要開發分支**：本專案的主要開發分支為 **`dev`**。
+* **主要開發分支**：本專案的主要開發分支為 **`main`**。
 * **分支策略**：
-  - 所有的開發都應從 `dev` 分支切出（例如：`feat/my-feature` 或 `fix/my-bug`）。
-  - 所有的 Pull Request 都必須提交回 `dev` 分支。
-  - 請避免將變更直接 Push 至 `main` 或 `dev` 分支。
+  - 所有的開發都應從 `main` 分支切出（例如：`feat/my-feature` 或 `fix/my-bug`）。
+  - 所有的 Pull Request 都必須提交回 `main` 分支。
+  - 請避免將變更直接 Push 至 `main` 分支。
+* **版本發布**：發布是在 `main` 上推送版本 tag（例如 `v1.2.0`）觸發，不再維護長期的發布分支。
 
 ---
 
@@ -143,7 +144,7 @@ docker compose exec backend pnpm run db:seed
 ## 7. 提交 Pull Request
 
 1. **自我檢查**：請先在本地執行 ESLint、型別檢查與所有測試。
-2. **分支對象**：確保 PR 的 Base Branch 設定為 **`dev`**。
+2. **分支對象**：確保 PR 的 Base Branch 設定為 **`main`**。
 3. **Commit 訊息**：檢查 Commit 訊息是否符合 Conventional Commit 格式。
 4. **內容描述**：請套用我們的 Pull Request 範本，並以 **繁體中文 (Traditional Chinese)** 描述您的變更。
 5. **測試計畫**：在 PR 說明中清楚記錄您的驗證步驟。

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -347,12 +347,12 @@ describe('userRepository', () => {
 ## 8. Git Workflow, PR Guidelines & Release Automation
 
 ### Git Branching Strategy
-* **Active Development Branch**: The main development branch is `dev`.
-* **Feature Branches**: All feature and bugfix branches must be created from `dev` (e.g. `feat/my-feature` or `fix/my-bug`).
-* **Pull Requests**: Submit all Pull Requests back to the `dev` branch. Direct pushes to `main` or `dev` are prohibited.
+* **Active Development Branch**: The main development branch is `main`.
+* **Feature Branches**: All feature and bugfix branches must be created from `main` (e.g. `feat/my-feature` or `fix/my-bug`).
+* **Pull Requests**: Submit all Pull Requests back to the `main` branch. Direct pushes to `main` are prohibited.
 
 ### PR Merge Requirement: Squash and Merge
-To keep the commit history clean and prevent cluttered changelogs, **all Pull Requests merged into `dev` must use Squash and Merge**.
+To keep the commit history clean and prevent cluttered changelogs, **all Pull Requests merged into `main` must use Squash and Merge**.
 * **PR Title Format**: PR titles must follow [Conventional Commits](https://www.conventionalcommits.org/) format in English:
   - `feat(scope): short description` - New feature
   - `fix(scope): short description` - Bug fix
@@ -360,10 +360,10 @@ To keep the commit history clean and prevent cluttered changelogs, **all Pull Re
   - `refactor(scope): short description` - Code refactoring
   - `chore: short description` - Maintenance task
   - `BREAKING CHANGE:` or `feat!:` - Breaking API or schema changes
-* **Squash Merge Benefit**: Squashing compresses multiple small/WIP commits in a feature branch into a single, clean conventional commit on `dev`.
+* **Squash Merge Benefit**: Squashing compresses multiple small/WIP commits in a feature branch into a single, clean conventional commit on `main`.
 
-### Automated Version Release Flow (`dev` → `main`)
-When milestone changes on `dev` are merged into `main`, GitHub Actions (`.github/workflows/ci.yml`) automatically triggers the `release` job running `semantic-release` upon CI completion:
+### Automated Version Release Flow (tag-based)
+When changes are merged into `main`, GitHub Actions (`.github/workflows/ci.yml`) automatically triggers the `release` job running `semantic-release` upon CI completion:
 
 1. **Semantic Versioning (`a.b.c`) Calculation**:
    - `fix:` → Increments **Patch (`c`)** (e.g. `v1.0.1` → `v1.0.2`)

--- a/docs/ZH-TW/DEVELOPMENT.md
+++ b/docs/ZH-TW/DEVELOPMENT.md
@@ -330,12 +330,12 @@ describe('userRepository', () => {
 ## 8. Git 工作流程、PR 規範與自動化發布
 
 ### Git 分支策略
-* **主要開發分支**：本專案主要開發分支為 **`dev`**。
-* **功能分支**：所有功能開發與 Bug 修復皆需自 `dev` 切出（例如：`feat/my-feature` 或 `fix/my-bug`）。
-* **Pull Request**：所有 Pull Request 皆需提交回 `dev` 分支。嚴禁直接 Push 至 `main` 或 `dev` 分支。
+* **主要開發分支**：本專案主要開發分支為 **`main`**。
+* **功能分支**：所有功能開發與 Bug 修復皆需自 `main` 切出（例如：`feat/my-feature` 或 `fix/my-bug`）。
+* **Pull Request**：所有 Pull Request 皆需提交回 `main` 分支。嚴禁直接 Push 至 `main` 分支。
 
 ### PR 合併規範：Squash and Merge
-為保持 Git 歷史乾淨並避免發布日誌（Changelog）雜亂，**所有 Merge 至 `dev` 的 Pull Request 必須採用 Squash and Merge**。
+為保持 Git 歷史乾淨並避免發布日誌（Changelog）雜亂，**所有 Merge 至 `main` 的 Pull Request 必須採用 Squash and Merge**。
 * **PR 標題格式**：PR 標題必須遵循 [Conventional Commits](https://www.conventionalcommits.org/) 規範：
   - `feat(scope): 英文簡述` — 新增功能 (feature)
   - `fix(scope): 英文簡述` — 修正 Bug
@@ -345,8 +345,8 @@ describe('userRepository', () => {
   - `BREAKING CHANGE:` 或 `feat!:` — 破壞性變更（重大 API / 資料庫架構調整）
 * **Squash Merge 優點**：在合併時將 Feature 分支中多個微小的提交（如修飾註解、修復排版）壓縮為單一精確的提交。
 
-### 自動化版本發布流程 (`dev` → `main`)
-當 `dev` 分支累積階段變更並合併回 `main` 分支時，GitHub Actions (`.github/workflows/ci.yml`) 會於 CI 測試全數通過後自動執行 `semantic-release` 發布工作：
+### 自動化版本發布流程（以 tag 發布）
+當變更合併進 `main` 分支時，GitHub Actions (`.github/workflows/ci.yml`) 會於 CI 測試全數通過後自動執行 `semantic-release` 發布工作：
 
 1. **語意化版本 (`a.b.c`) 計算**：
    - `fix:` $\rightarrow$ 遞增 **Patch (`c`)**（如 `v1.0.1` $\rightarrow$ `v1.0.2`）


### PR DESCRIPTION
## 摘要
未來 release 改以 tag 進行，不再需要 `dev` 分支，故將所有分支設定收斂到 `main`。

## 變更內容
- `.github/workflows/ci.yml`：push / pull_request 觸發改為 `branches: [main]`
- `.github/workflows/close-issues-on-dev-merge.yml` → `close-issues-on-merge.yml`：名稱與觸發分支改為 `main`
- `.github/dependabot.yml`：移除全部 6 處 `target-branch: "dev"`，改用預設分支
- `.github/ISSUE_TEMPLATE/bug.yml`：確認欄位改為 `main` 分支
- `CONTRIBUTING.md` / `CONTRIBUTING.zh-TW.md`：分支策略改 `main`，補上「發布以 `main` 上推 tag 進行」
- `docs/DEVELOPMENT.md` / `docs/ZH-TW/DEVELOPMENT.md`：分支策略、Squash merge 目標、發布流程標題改為 tag-based

未改動：`docs/` 下歷史分析報告中提到的 `dev`（當時的 commit 紀錄或 npm script 名稱）屬史料保留。CI `release` job 原本就是 push 到 `main` 後執行 semantic-release 建 tag，與 tag 發布一致。

## 測試計畫
- CI 於本 PR（base = `main`）需正常觸發並全綠
- 合併後確認 dependabot 新 PR 以 `main` 為 base

🤖 Generated with [Claude Code](https://claude.com/claude-code)