### PR TITLE
chore(deps): 修正 Dependabot 設定以配合單一 root lockfile 的 workspace

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,33 +1,22 @@
 version: 2
 updates:
-  # 1. 根目錄 npm/pnpm 套件
+  # 1. npm/pnpm 套件 —— 整個 pnpm workspace
+  #
+  # 只需要這一個項目。本 repo 是單一 root lockfile 的 pnpm workspace，
+  # frontend/ 與 backend/ 底下已經沒有各自的 pnpm-lock.yaml，Dependabot 會
+  # 從根目錄一併解析所有 workspace 套件的 package.json 並更新根 lockfile。
+  #
+  # 先前另外宣告 /frontend 與 /backend 兩個 npm 項目，在 lockfile 收斂（#420）
+  # 之後會產生「只改 package.json、不更新 lockfile」的 PR，導致
+  # `pnpm install --frozen-lockfile` 失敗而永遠無法合併。
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-      - "root"
-    groups:
-      minor-and-patch:
-        patterns:
-          - "*"
-        update-types:
-          - "patch"
-          - "minor"
-
-  # 2. 前端 npm/pnpm 套件 (/frontend)
-  - package-ecosystem: "npm"
-    directory: "/frontend"
-    schedule:
-      interval: "weekly"
-      day: "monday"
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
-      - "frontend"
     groups:
       minor-and-patch:
         patterns:
@@ -36,25 +25,7 @@ updates:
           - "patch"
           - "minor"
 
-  # 3. 後端 npm/pnpm 套件 (/backend)
-  - package-ecosystem: "npm"
-    directory: "/backend"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    open-pull-requests-limit: 10
-    labels:
-      - "dependencies"
-      - "backend"
-    groups:
-      minor-and-patch:
-        patterns:
-          - "*"
-        update-types:
-          - "patch"
-          - "minor"
-
-  # 4. GitHub Actions 工作流 (.github/workflows)
+  # 2. GitHub Actions 工作流 (.github/workflows)
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -65,7 +36,8 @@ updates:
       - "ci/cd"
       - "dependencies"
 
-  # 5. 後端 Docker Base Image (/backend)
+  # 3. 後端 Docker Base Image (/backend)
+  #    Dockerfile 仍位於各套件目錄，因此 docker 項目維持分開宣告。
   - package-ecosystem: "docker"
     directory: "/backend"
     schedule:
@@ -76,7 +48,7 @@ updates:
       - "docker"
       - "backend"
 
-  # 6. 前端 Docker Base Image (/frontend)
+  # 4. 前端 Docker Base Image (/frontend)
   - package-ecosystem: "docker"
     directory: "/frontend"
     schedule:


### PR DESCRIPTION
## 問題

lockfile 收斂（#420 / #423）之後，`frontend/` 與 `backend/` 底下已不再有各自的 `pnpm-lock.yaml`，但 `.github/dependabot.yml` 仍宣告了 `/frontend` 與 `/backend` 兩個 npm 項目。

Dependabot 因此只能改動這兩個目錄的 `package.json`，卻無法更新根 lockfile —— 產生的 PR 一律會讓 `pnpm install --frozen-lockfile` 失敗，也就永遠無法合併。這是我在 #423 漏掉的一環。

**目前開啟的 20 個 Dependabot PR 中，有 9 個屬於這種情況且全部無法合併：**

| PR | 內容 |
| --- | --- |
| #434 | eslint in /backend |
| #435 | react + react-dom in /frontend |
| #436 | jsdom in /frontend |
| #437 | typescript in /backend |
| #438 | eslint in /frontend |
| #439 | @types/node in /backend |
| #440 | @types/node in /frontend |
| #441 | @babel/core in /frontend |
| #442 | typescript in /frontend |

## 變更

只保留根目錄一個 npm 項目。pnpm workspace 下 Dependabot 會從根目錄一併解析所有 workspace 套件的 `package.json` 並更新唯一的根 lockfile，因此原本三個項目的涵蓋範圍由這一個取代（上限相應由 5 提高為 10）。

`github-actions` 與兩個 `docker` 項目維持不變 —— Dockerfile 仍位於各套件目錄，那兩個項目依然有效。

## 後續

這個 PR 只修設定、不含任何套件升級。上述 9 個無法合併的 PR 會另行關閉，其內容併入一個經過實測的整合升級 PR（單一 lockfile 下，所有 npm PR 都會改到同一個檔案而彼此衝突，逐一合併並不可行）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FLcRR1excMoBSFSNSmLZwD