### PR TITLE
fix: 修正 Semantic Release 設定衝突（[skip ci]、@semantic-release/github、fetch-depth） (#405)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,8 +344,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      issues: write
-      pull-requests: write
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -347,6 +347,12 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
+          # semantic-release 會自行嘗試 git fetch --unshallow --tags 修復
+          # shallow clone，因此這不是硬性阻斷點，而是加固：明確取得完整
+          # 歷史與 tag，不依賴該 fallback 成功，並與 release-stack.yml 的
+          # checkout 設定一致。fetch-tags 不需另外指定——fetch-depth 為 0
+          # 時 actions/checkout 已包含 +refs/tags/*:refs/tags/* refspec。
+          fetch-depth: 0
           persist-credentials: false
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v7

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -27,7 +27,6 @@
         ],
         "message": "chore(release): ${nextRelease.version} [skip release]\n\n${nextRelease.notes}"
       }
-    ],
-    "@semantic-release/github"
+    ]
   ]
 }

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -25,7 +25,7 @@
           "backend/package.json",
           "CHANGELOG.md"
         ],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+        "message": "chore(release): ${nextRelease.version} [skip release]\n\n${nextRelease.notes}"
       }
     ],
     "@semantic-release/github"

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -371,6 +371,6 @@ When changes are merged into `main`, GitHub Actions (`.github/workflows/ci.yml`)
    - `BREAKING CHANGE:` → Increments **Major (`a`)** (e.g. `v1.0.1` → `v2.0.0`)
    - `docs:`, `chore:`, `refactor:` → No version increment
 2. **Multi-Package Version Sync**: Runs `scripts/update-versions.js` to synchronize `"version"` in root `package.json`, `frontend/package.json`, and `backend/package.json`.
-3. **Changelog & GitHub Release**: Automatically generates `CHANGELOG.md` and publishes formatted **Release Notes directly on the GitHub Release page**.
-4. **Stack Image & Bundle Publication**: Creating tag `vX.Y.Z` triggers `.github/workflows/release-stack.yml`, building & pushing Docker images to GHCR, signing provenance attestations, and attaching `near-chat-stack-vX.Y.Z.tar.gz` deployment bundle to the GitHub Release.
+3. **Changelog**: Automatically generates and commits `CHANGELOG.md` into the repository. The GitHub Release page itself is created by `release-stack.yml`, not by `semantic-release`, so its notes list image references, digests and the bundle hash rather than the formatted changelog.
+4. **Stack Image & Bundle Publication**: `.github/workflows/release-stack.yml` builds & pushes Docker images to GHCR, signs provenance attestations, and attaches the `near-chat-stack-vX.Y.Z.tar.gz` deployment bundle to the GitHub Release. Note that the tag created by `semantic-release` does **not** yet hand over to this workflow automatically: `release-stack.yml` requires an annotated tag (see issue #406) and a trigger path from `ci.yml` (see issue #407). Until both land, run it manually with `gh workflow run release-stack.yml --ref vX.Y.Z`.
 

--- a/docs/ZH-TW/DEVELOPMENT.md
+++ b/docs/ZH-TW/DEVELOPMENT.md
@@ -354,6 +354,6 @@ describe('userRepository', () => {
    - `BREAKING CHANGE:` $\rightarrow$ 遞增 **Major (`a`)**（如 `v1.0.1` $\rightarrow$ `v2.0.0`）
    - `docs:`, `chore:`, `refactor:` $\rightarrow$ 不遞增版本號
 2. **三方版本號同步**：自動執行 `scripts/update-versions.js` 同步更新根目錄 `package.json`、`frontend/package.json` 與 `backend/package.json` 的版本。
-3. **Changelog 與 Release 頁面**：自動更新 `CHANGELOG.md`，並**將格式化後的 Release Notes 直接發布於 GitHub Release 頁面**。
-4. **Stack 映像檔與部署包發布**：建立 `vX.Y.Z` 標籤並觸發 `.github/workflows/release-stack.yml`，自動建置 Frontend/Backend 容器映像檔推至 GHCR、簽署 SLSA Provenance，並附加 `near-chat-stack-vX.Y.Z.tar.gz` 部署包至 GitHub Release。
+3. **Changelog**：自動更新 `CHANGELOG.md` 並提交回 repo。GitHub Release 頁面本身由 `release-stack.yml` 建立而非 `semantic-release`，因此其內容為 image 參照、digest 與部署包雜湊，而不是格式化後的 changelog。
+4. **Stack 映像檔與部署包發布**：`.github/workflows/release-stack.yml` 會建置 Frontend/Backend 容器映像檔推至 GHCR、簽署 SLSA Provenance，並附加 `near-chat-stack-vX.Y.Z.tar.gz` 部署包至 GitHub Release。注意 `semantic-release` 建立的標籤目前**尚未**自動交棒給此工作流程：`release-stack.yml` 要求 annotated tag（見 issue #406），且需要一條由 `ci.yml` 出發的觸發路徑（見 issue #407）。在兩者完成前，請以 `gh workflow run release-stack.yml --ref vX.Y.Z` 手動觸發。
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "@semantic-release/commit-analyzer": "^13.0.1",
     "@semantic-release/exec": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
-    "@semantic-release/github": "^11.0.1",
     "@semantic-release/release-notes-generator": "^14.0.0",
     "semantic-release": "^24.2.3"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,9 +27,6 @@ importers:
       '@semantic-release/git':
         specifier: ^10.0.1
         version: 10.0.1(semantic-release@24.2.9(supports-color@7.2.0)(typescript@6.0.3))(supports-color@7.2.0)
-      '@semantic-release/github':
-        specifier: ^11.0.1
-        version: 11.0.6(semantic-release@24.2.9(supports-color@7.2.0)(typescript@6.0.3))(supports-color@7.2.0)
       '@semantic-release/release-notes-generator':
         specifier: ^14.0.0
         version: 14.1.1(semantic-release@24.2.9(supports-color@7.2.0)(typescript@6.0.3))(supports-color@7.2.0)


### PR DESCRIPTION
## 變更描述 (Description)

修正 PR #397 引入 Semantic Release 時遺留的三項純設定層級缺陷。這三項各自都會使發布流程失效，且彼此獨立、可分別回退。

**本 issue 先前的 PR #410 已於 2026-07-28 被關閉且未合併（`merged: false`）**：它的 base 是 `dev`，而該分支已在 #427（`chore(ci): 將主要分支收斂為 main 並移除 dev 分支設定`）的收斂中移除，修正因此整批遺失。本 PR 以 `main` 為基準重做，並依現況重新驗證每一項。

### 緊急性已改變（本次實測，非沿用先前結論）

PR #410 當時的判斷是「`origin/main` 沒有 `release` job、也沒有 `.releaserc.json`，這條流程從未真正執行過」，因此修正是「可證明無害」的預防性變更。**這個前提現在已不成立。**

收斂後三者已同時存在於 `main`，且 `release` job **已經實際跑過**：CI run [30379730707](https://github.com/nearcsie/near-chat/actions/runs/30379730707)（commit `02b202b`）的 `release` job（id `90344592030`）於 2026-07-28T16:46:32Z 執行，`Run Semantic Release` 步驟成功結束。其 log 為：

```
[semantic-release] › ℹ  Found 5 commits since last release
[@semantic-release/commit-analyzer] › ℹ  Analysis of 5 commits complete: no release
[semantic-release] › ℹ  There are no relevant changes, so no new version is released.
```

之所以沒出事，只是因為那 5 個 commit 全是 `chore:` 與 `docs:`。**下一次帶 `feat:` 或 `fix:` 的合併進 `main` 就會以目前這份有缺陷的設定執行一次真正的發布。**

### 根因分析 (Root Cause)

三點皆於本次在 `02b202b` 的實際檔案上逐項確認：

1. **`[skip ci]` 與 `release-stack.yml` 的驗證條件互相矛盾。** `.releaserc.json:28` 的 commit message 為 `chore(release): ${nextRelease.version} [skip ci]`。`ci.yml:4-5` 的觸發為 `push: branches: [main]`，而 `release-stack.yml:78-95` 要求以 `head_sha` 查到一次已完成且成功的 `ci.yml` push run，此條件因而永遠無法成立。
2. **`release` job 的 checkout 是 shallow clone。** `ci.yml:350-352` 只設定 `persist-credentials: false`。
3. **`@semantic-release/github` 與 `release-stack.yml` 的冪等性防護互斥。** `.releaserc.json:31` 的該外掛會自行建立 GitHub Release；`release-stack.yml:200` 在「Release 已存在但四個 image 參照皆遺失」時直接中止，拒絕以新建置覆寫。一旦產生沒有對應 image 的 Release，該版本之後永遠無法正確發布。真正的 Release 建立者是 `release-stack.yml:491` 的 `gh release create`。

## 相關的 Issue (Related Issue)

Closes #405

## 變更類型 (Type of Change)

- [x] `fix`: 修復 Bug
- [x] `ci`: CI 設定變更
- [x] `docs`: 修改文件
- [x] `chore`: 建置流程或輔助工具變更

## 變更內容 (What Changed)

五個獨立 commit，可分別回退：

| Commit | 變更 | 原因 |
| --- | --- | --- |
| `0561a31` | `.releaserc.json`：`[skip ci]` → `[skip release]` | 見下方「對 issue 指示的一項刻意偏離」 |
| `8a33215` | `.releaserc.json` 移除 `@semantic-release/github`；`ci.yml` 移除 `issues: write`、`pull-requests: write` | 讓 `release-stack.yml` 維持唯一 Release 建立者。兩者必須同一個 commit：單獨回退外掛移除會復原一個 `verifyConditions` 需要這些權限的外掛，導致 job 失敗 |
| `03a8a66` | `ci.yml`：release job checkout 加 `fetch-depth: 0` | 加固（非 bug 修復，理由見下） |
| `6776ef0` | `docs/DEVELOPMENT.md`、`docs/ZH-TW/DEVELOPMENT.md` | 修正兩點已不成立的敘述 |
| `1620860` | `package.json`、`pnpm-lock.yaml` | 移除直接 devDependency，可單獨 drop |

`persist-credentials: false` 未更動，`contents: write` 保留，`semantic-release` 本身未移除。

### 對 issue 指示的一項刻意偏離（請優先審查此節）

Issue 的工作項目寫「將 `message` 移除 `[skip ci]`」。本 PR 改為**替換**為 semantic-release 原生的 `[skip release]`，而非整段刪除。驗收標準「commit message 不含 `[skip ci]`」仍然滿足。

理由是這份設定有一個字面照做會留下的漏洞：commit message 內嵌了 `${nextRelease.notes}`，而 `@semantic-release/commit-analyzer` 的 `default-release-rules.js:6` 第一條規則是 `{ breaking: true, release: "major" }`，**先於 type 判斷**。若某次 release notes 含有能被 conventional parser 解讀為 `BREAKING CHANGE` footer 的內容，版本號 commit 自身就會被分析為 major。

這不是推測，已用對照實驗實測（兩組除了 `[skip release]` 之外完全相同）：

**對照組（照 issue 字面：只刪掉 `[skip ci]`，無防護）**
```
[@semantic-release/commit-analyzer] › i  Analyzing commit: chore(release): 1.1.0
[@semantic-release/commit-analyzer] › i  The release type for the commit is major
[semantic-release] › i  The next release version is 2.0.0
```

**實驗組（本 PR 的 `[skip release]`），同樣的 commit 內容**
```
[@semantic-release/commit-analyzer] › i  Analysis of 0 commits complete: no release
[semantic-release] › i  There are no relevant changes, so no new version is released.
```

`[skip release]` 是工具原生機制：`semantic-release/lib/definitions/plugins.js:22` 的 `analyzeCommits.preprocess` 以 `/\[skip\s+release]|\[release\s+skip]/i` 將這些 commit 過濾掉（注意是 0 commits，代表是被過濾而非被分析後判定不發布），CI 則照常執行。它不需要任何新設定，且在 #407 改用 PAT／App token 之後仍然有效——那正是此迴圈會從潛在變成實際的時間點。

若審查者堅持字面一致，替代方案是從 commit message 移除 `${nextRelease.notes}`；但保留 notes 且加上 `[skip release]` 破壞性較低。

### 關於 lockfile 的精確說明

`@semantic-release/github@11.0.6` **本來就是 `semantic-release@24.2.9` 自己的直接相依**（`pnpm-lock.yaml:7475`）。因此它仍留在 lockfile 的 packages／snapshots 區段與 `node_modules` 中，**只有頂層 importer 條目被移除**（淨變更 -3 行）。正確說法是「不再是直接 devDependency」，而非「已從 lockfile 移除」。

lockfile 為手動移除 importer 條目，而非重跑 `pnpm install --lockfile-only`：後者會一併帶入無關的 `picomatch` 4.0.4 → 4.0.5 漂移。已以 `pnpm install --frozen-lockfile --lockfile-only` 驗證（結束碼 0，且未再變動檔案），確認手動編輯結果正是 pnpm 認定與 `package.json` 一致的狀態。

`1620860` 刻意置於最後：它是唯一動到 `package.json`／`pnpm-lock.yaml` 的 commit，與 #444、#445、#447、#448 及 draft #416 有衝突風險（#416 更會整個移除 `pnpm-lock.yaml`），且屬 issue 中「若已無用途則一併移除」的條件性項目。**審查者若希望等 dependabot PR 先落地，可單獨 drop 此 commit，不影響前四個 commit 的任何功能。**

## 驗證與測試計畫 (Verification & Test Plan)

### 本地測試 (Local Tests)

本 PR 不含任何 `backend/`、`frontend/`、`shared/` 程式碼或資料庫變更，PR 範本列出的 Docker 型別檢查與測試套件**不適用**，因此未執行：

- [ ] 後端型別檢查 — 不適用（未變更後端程式碼）
- [ ] 前端型別檢查 — 不適用（未變更前端程式碼）
- [ ] 前端 Linter 檢查 — 不適用（未變更前端程式碼）
- [ ] 單元測試 — 不適用
- [ ] 整合測試 — 不適用

### 手動驗證 (Manual Verification) — 已實際執行

在合成 repo 中執行（真實的 `.releaserc.json` 與 `scripts/update-versions.js`、本地 bare remote 以 `file://` URL 作為 origin、annotated tag `v1.0.0` 為基準、再加一個 `feat(backend):` commit）。**注意不能在本 checkout 直接跑 dry-run**：此環境的 `remote.origin.url` 是 `http://local_proxy@127.0.0.1:41729/...`，`get-config.js:73` → `git.js:173` 會解析到錯誤的 repository URL。

**1. 非 dry-run 實際執行 — 結束碼 0**

```
--- version commit message ---
chore(release): 1.1.0 [skip release]
--- '[skip ci]' occurrences ---
0
--- synced versions ---
root = 1.1.0 / frontend = 1.1.0 / backend = 1.1.0
--- GitHub Release attempts ---
0
```

**2. 載入的外掛（無 `@semantic-release/github`）— 對應驗收標準第三項**

```
Loaded plugin "analyzeCommits"   from "@semantic-release/commit-analyzer"
Loaded plugin "generateNotes"    from "@semantic-release/release-notes-generator"
Loaded plugin "prepare"          from "@semantic-release/changelog"
Loaded plugin "verifyConditions" from "@semantic-release/exec"
Loaded plugin "prepare"          from "@semantic-release/git"
```

無 plugin 解析錯誤，並正確由 1.0.0 算出下一版 1.1.0。移除 `@semantic-release/github` 後 semantic-release **沒有**因缺少 publish 外掛而報錯（`lib/definitions/plugins.js:68` 將 `publish` 標記為 `required: false`）。

**3. 迴圈防護對照實驗** — 見上方「刻意偏離」一節。

**4. Lockfile 一致性** — `pnpm install --frozen-lockfile --lockfile-only` 結束碼 0 且未改動檔案。

**5. 設定檔靜態檢查** — 解析後 `release` job 的 `permissions` 為 `{contents: write}`，checkout 的 `with` 為 `{fetch-depth: 0, persist-credentials: false}`。

### 未驗證事項（明確標示）

- 未在真實 GitHub Actions 上跑過端到端發布。上述皆為合成 repo 加本地 remote 的結果。
- 合成測試的 remote 是 `file://` 路徑，**未涵蓋** `GITHUB_TOKEN` 組出 https 認證 URL 的推送路徑；該路徑改由原始碼確認（`get-git-auth-url.js:64-101`，因該 step 僅有一個 token 環境變數而於第 99-102 行短路返回）。
- 「預設 `GITHUB_TOKEN` 產生的事件不觸發新 workflow run」為 GitHub 官方文件記載的行為；本次嘗試抓取 docs.github.com 被 403 擋下，**未能在本次執行中以一手來源驗證**，故標示為未確認。

## 重要：本 PR 不足以讓自動發布跑通

必須明講，避免合併後誤以為自動發布已可用。

- 依 GitHub 的防遞迴機制，以預設 `GITHUB_TOKEN` 推送的版本號 commit **即使移除 `[skip ci]` 仍不會產生屬於自己的 `ci.yml` run**；tag 推送同樣不會觸發 `release-stack.yml`（`release-stack.yml:3-5` 只監聽 `push: tags`）。因此 #407 敘述的前提「移除 `[skip ci]` 後版本號 commit 才有屬於自己的 CI run 可供 `workflow_run` 監聽」**並不成立**，建議在 #407 實作前先修正其設計前提。
- 本次實測**再次確認 #406 的前提為真**：semantic-release 建立的是 lightweight tag（合成 repo 中 `git cat-file -t v1.1.0` 回傳 `commit`，源頭是 `lib/git.js:223-225` 的 `execa("git", ["tag", tagName, ref])`，無 `-a`/`-m`），而 `release-stack.yml:59-62` 硬性要求 annotated tag。

**淨效果需要明講**：本 PR 單獨合併後，發布行為會從「由 `@semantic-release/github` 建立一個帶格式化 notes 的 Release」變成「只建立一個 lightweight tag，不產生任何 Release」。在 #406 與 #407 落地前，這是一個**可見的功能倒退**，換來的是不再有「產生無對應 image 的 Release 而永久卡死該版本」的風險。建議 #405 與 #406 一併排程。

### 一併接受的行為變更

- Release 頁面不再含格式化的 changelog，changelog 僅存在於 repo 內的 `CHANGELOG.md`（`release-stack.yml:472-489` 的 notes 只有 image 參照、digest、bundle 雜湊與文件連結）。若不符預期，建議由 #408 讓 `release-stack.yml` 將該版本的 `CHANGELOG.md` 區段併入 notes。
- 發布失敗時不再自動開「The automated release is failing」issue，只會呈現為紅色的 CI job。日後若要恢復失敗通報，需同時復原外掛與 `issues: write` 權限。
- `release-stack.yml:496` 帶有 `--latest=false`（既有行為）；與本 PR 合併後，repo 將不會有任何被標為 Latest 的 release。

## 顧問意見要點 (Advisor Notes)

已請 architect 子代理（opus）覆核，其意見改變了原始計畫三處，且推翻了我原本兩項假設：

1. **`[skip ci]` 整段移除是不夠的** — 顧問指出防遞迴機制讓「移除 `[skip ci]` 以換得 CI run」的理由本身不成立，且點出 `${nextRelease.notes}` + breaking-first 規則的 major 迴圈風險，建議改用 `[skip release]`。已採納並補上對照實驗佐證。
2. **`fetch-depth: 0` 是加固而非 bug 修復** — `lib/branches/index.js:21` → `lib/git.js:106-136` 會嘗試 `git fetch --unshallow --tags` 並在失敗時退回 `git fetch --tags`，兩條路徑都無條件帶 `--tags`，因此 tag 本來就取得到。仍保留此設定（成本低、行為確定、與 `release-stack.yml:31-33` 一致），但改以「加固」定位。**預期設定後 log 中會看到 `--unshallow` 嘗試失敗並退回，這是正常現象，不是錯誤。**
3. **`fetch-tags: true` 是多餘的** — `fetch-depth` 為 0 時 `actions/checkout` 已包含 `+refs/tags/*:refs/tags/*` refspec。已不加入。
4. **權限移除必須與外掛移除同一個 commit** — 已採納，理由見變更表。
5. **建議將 lockfile 變更獨立或延後** — 已獨立為最後一個可單獨 drop 的 commit，並在上文說明衝突風險。

顧問另確認：移除 `@semantic-release/github` **不會**破壞推送能力（`get-git-auth-url.js:64-101` 由 core 而非外掛組出認證 URL），且明確的 `plugins` 陣列會完全取代預設值（`get-config.js:75-83`），不會回退到 `@semantic-release/npm`。**另請勿在該 job 額外加入 `GH_TOKEN`**：`get-git-auth-url.js:96` 會蒐集所有 token 環境變數，多於一個就會離開短路路徑，改走逐一驗證並選用第一個通過者。

---
Generated with Claude Code (https://claude.com/claude-code)