### PR TITLE
docs: 同步文件與 Bun/Hono 後端重構後的實際狀態 (week of 2026-07-29)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,13 +3,13 @@
 <!-- Generated: 2026-06-14 | Updated: 2026-06-14 -->
 
 ## Purpose
-This is a real-time group chat application built as a database course project. It is structured as a monorepo containing a Next.js/React frontend, a Node.js/Express backend API utilizing raw PostgreSQL queries, and a PostgreSQL 18 database, orchestrated locally via Docker Compose.
+This is a real-time group chat application built as a database course project. It is structured as a monorepo containing a Next.js/React frontend, a Bun/Hono backend API utilizing raw PostgreSQL queries, and a PostgreSQL 18 database, orchestrated locally via Docker Compose.
 
 ## Key Files for Project Orientation
 
 | File | Description |
 |------|-------------|
-| [docker-compose.yml](docker-compose.yml) | Defines the local three-service development stack: `db` (PostgreSQL 18), `backend` (Express), and `frontend` (Next.js) |
+| [docker-compose.yml](docker-compose.yml) | Defines the local three-service development stack: `db` (PostgreSQL 18), `backend` (Bun + Hono), and `frontend` (Next.js) |
 | [docker-compose.prod.yml](docker-compose.prod.yml) | Defines the local three-service production stack with optimized builds and Cloudflare Tunnel |
 | [.env.example](.env.example) | Template for environment variables. Must be copied to `.env` in the root folder before local runs |
 | [issues.json](issues.json) | **CRITICAL TASK LIST**: Contains the active catalog of outstanding issues, bugs, refactorings, and features to implement with detailed tasks and acceptance criteria |
@@ -28,7 +28,7 @@ To get details on database schemas, REST APIs, or local setups, refer to the fol
 
 | Directory | Purpose | Detail Orientation |
 |-----------|---------|--------------------|
-| [backend/](backend/) | Express + Socket.IO API server | See [backend/CLAUDE.md](backend/CLAUDE.md) |
+| [backend/](backend/) | Hono + Socket.IO API server | See [backend/CLAUDE.md](backend/CLAUDE.md) |
 | [frontend/](frontend/) | Next.js 16 + React 19 Client Web App | See [frontend/CLAUDE.md](frontend/CLAUDE.md) |
 | [shared/](shared/) | Shared TypeScript models and interfaces | Mounts read-only into both services |
 | [docs/](docs/) | Design specifications and guidelines | See [docs/CLAUDE.md](docs/CLAUDE.md) |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 English | [繁體中文](CONTRIBUTING.zh-TW.md)
 
-First off, thank you for taking the time to contribute to Near Chat! This project is a database course project, structured as a monorepo containing a React/Next.js frontend, a Node.js/Express backend API, and a PostgreSQL 18 database, orchestrated locally via Docker Compose.
+First off, thank you for taking the time to contribute to Near Chat! This project is a database course project, structured as a monorepo containing a React/Next.js frontend, a Bun/Hono backend API, and a PostgreSQL 18 database, orchestrated locally via Docker Compose.
 
 Please read through this guide to understand our development, testing, and contribution workflows.
 
@@ -113,7 +113,7 @@ docker compose exec backend pnpm run db:seed
    ```bash
    docker compose exec frontend pnpm run lint
    ```
-3. **Running Vitest Tests**:
+3. **Running Bun Tests**:
    - **Unit Tests**:
      ```bash
      docker compose exec backend pnpm run test:unit
@@ -136,7 +136,7 @@ For details, refer to [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md).
 
 ## 6. API & WebSocket Contract Verification
 
-* Any changes to Express controllers, backend routes, or Socket.IO events must strictly align with the payloads and models defined in [docs/api-documentation.md](docs/api-documentation.md).
+* Any changes to Hono routes, backend services, or Socket.IO events must strictly align with the payloads and models defined in [docs/api-documentation.md](docs/api-documentation.md).
 * Breaking contracts will cause frontend-backend integration failures and fail CI builds.
 
 ---

--- a/CONTRIBUTING.zh-TW.md
+++ b/CONTRIBUTING.zh-TW.md
@@ -2,7 +2,7 @@
 
 [English](CONTRIBUTING.md) | 繁體中文
 
-首先，非常感謝您願意花時間為 Near Chat 做出貢獻！本專案是一門資料庫課程的專案，結構為 Monorepo，包含 React/Next.js 前端、Node.js/Express 後端 API，以及 PostgreSQL 18 資料庫，並在本地透過 Docker Compose 進行容器編排與整合。
+首先，非常感謝您願意花時間為 Near Chat 做出貢獻！本專案是一門資料庫課程的專案，結構為 Monorepo，包含 React/Next.js 前端、Bun/Hono 後端 API，以及 PostgreSQL 18 資料庫，並在本地透過 Docker Compose 進行容器編排與整合。
 
 請仔細閱讀本指南，以瞭解我們的開發、測試與貢獻工作流程。
 
@@ -113,7 +113,7 @@ docker compose exec backend pnpm run db:seed
    ```bash
    docker compose exec frontend pnpm run lint
    ```
-3. **執行 Vitest 測試**：
+3. **執行 Bun 測試**：
    - **單元測試**：
      ```bash
      docker compose exec backend pnpm run test:unit
@@ -136,7 +136,7 @@ docker compose exec backend pnpm run db:seed
 
 ## 6. API 與 WebSocket 協定驗證
 
-* 任何對 Express 控制器 (Controllers)、後端路由 (Routes) 或 Socket.IO 事件處理常式的修改，都必須精確對齊 [docs/api-documentation.md](docs/api-documentation.md) 中所定義的 Payload 與資料模型。
+* 任何對 Hono 路由 (Routes)、後端服務 (Services) 或 Socket.IO 事件處理常式的修改，都必須精確對齊 [docs/api-documentation.md](docs/api-documentation.md) 中所定義的 Payload 與資料模型。
 * 破壞協定契約將會導致前後端串接失敗，並使 CI 流程出錯。
 
 ---

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 English | [繁體中文](README.zh-TW.md)
 
-A real-time group chat application built as an NTNU Database Theories course project. This monorepo features a Next.js frontend, a Node.js/Express backend API using raw SQL query pools, and a PostgreSQL database orchestrating custom permissions, chat folders, message lifecycle triggers, and emergency contact alerts.
+A real-time group chat application built as an NTNU Database Theories course project. This monorepo features a Next.js frontend, a Bun/Hono backend API using raw SQL query pools, and a PostgreSQL database orchestrating custom permissions, chat folders, message lifecycle triggers, and emergency contact alerts.
 
 ---
 
@@ -35,7 +35,7 @@ A real-time group chat application built as an NTNU Database Theories course pro
 ## Tech Stack
 
 - **Frontend**: Next.js 16.2 (App Router), React 19, Tailwind CSS v4, Socket.IO Client.
-- **Backend**: Node.js, Express v5, Socket.IO, `pg` (PostgreSQL raw client).
+- **Backend**: Bun, Hono v4, Socket.IO, `pg` (PostgreSQL raw client).
 - **Database**: PostgreSQL 18.
 - **Orchestration**: Docker & Docker Compose.
 - **Package Manager**: pnpm.
@@ -44,8 +44,8 @@ A real-time group chat application built as an NTNU Database Theories course pro
 
 ```text
 .
-├── backend/                # Express API backend
-│   ├── src/                # Backend TypeScript source code (routes, controllers, services, repositories)
+├── backend/                # Hono API backend
+│   ├── src/                # Backend TypeScript source code (routes, services, models, middlewares, realtime, utils)
 │   ├── migrations/         # PostgreSQL node-pg-migrate schema migrations
 │   └── Dockerfile          # Backend container configurations
 ├── frontend/               # Next.js frontend web app
@@ -75,6 +75,7 @@ Here are the key environment parameters you can configure in `.env`:
 | `DATABASE_URL` | PostgreSQL connection URL | `postgresql://chatuser:chatpassword@db:5432/chatdb` |
 | `JWT_SECRET` | Secret key for signing JWT tokens | `dev_secret_key` |
 | `RATE_LIMIT_DISABLED` | Disables request rate limiting for testing | `true` (Set `false` or omit in production) |
+| `TRUST_PROXY` | Take the client IP for rate limiting from the first `X-Forwarded-For` entry. Only enable when the backend really sits behind a trusted reverse proxy | `false` |
 | `NEXT_PUBLIC_API_URL` | Browser-facing backend API URL | `http://localhost:4005` |
 | `ALLOWED_DEV_ORIGINS` | Allowed remote origins for dev (e.g., Tailscale IPs) | *(Empty)* |
 | `UPLOADS_MOUNT_SOURCE` | Storage path or Docker volume name for attachments | `app_uploads` |
@@ -104,7 +105,7 @@ docker compose exec backend pnpm run db:seed
 | Service | Address | Description |
 | :--- | :--- | :--- |
 | **Frontend App** | [http://localhost:3005](http://localhost:3005) | Main Next.js web application |
-| **Backend API** | [http://localhost:4005](http://localhost:4005) | Express API & Socket.IO server |
+| **Backend API** | [http://localhost:4005](http://localhost:4005) | Bun + Hono API & Socket.IO server |
 | **PostgreSQL Database** | `localhost:5435` | PostgreSQL 18 instance (Mapped from internal port `5432`) |
 
 ---

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -2,7 +2,7 @@
 
 [English](README.md) | 繁體中文
 
-國立臺灣師範大學資料庫系統概論期末專案——即時文字通訊與群組聊天系統。本專案採 Monorepo 架構，結合 Next.js 前端、Node.js/Express 後端，以 Raw SQL 直接操作 PostgreSQL 進行高效查詢，並實現自訂群組權限、聊天分類資料夾、訊息生命週期，以及離線警報（遺言模式）等具體資料庫應用。
+國立臺灣師範大學資料庫系統概論期末專案——即時文字通訊與群組聊天系統。本專案採 Monorepo 架構，結合 Next.js 前端、Bun/Hono 後端，以 Raw SQL 直接操作 PostgreSQL 進行高效查詢，並實現自訂群組權限、聊天分類資料夾、訊息生命週期，以及離線警報（遺言模式）等具體資料庫應用。
 
 ---
 
@@ -35,7 +35,7 @@
 ## 技術棧
 
 - **前端**: Next.js 16.2 (App Router), React 19, Tailwind CSS v4, Socket.IO Client。
-- **後端**: Node.js, Express v5, Socket.IO, `pg` (PostgreSQL 原始驅動)。
+- **後端**: Bun, Hono v4, Socket.IO, `pg` (PostgreSQL 原始驅動)。
 - **資料庫**: PostgreSQL 18。
 - **環境編排**: Docker 與 Docker Compose。
 - **套件管理**: pnpm。
@@ -44,8 +44,8 @@
 
 ```text
 .
-├── backend/                # Express API 後端服務
-│   ├── src/                # 後端 TypeScript 源碼 (routes, controllers, services, repositories)
+├── backend/                # Hono API 後端服務
+│   ├── src/                # 後端 TypeScript 源碼 (routes, services, models, middlewares, realtime, utils)
 │   ├── migrations/         # PostgreSQL node-pg-migrate 遷移腳本
 │   └── Dockerfile          # 後端映像檔配置
 ├── frontend/               # Next.js 前端網頁應用
@@ -75,6 +75,7 @@ cp .env.example .env
 | `DATABASE_URL` | PostgreSQL 連線 URL | `postgresql://chatuser:chatpassword@db:5432/chatdb` |
 | `JWT_SECRET` | 用於簽署 JWT 的密鑰鍵值 | `dev_secret_key` |
 | `RATE_LIMIT_DISABLED` | 關閉 API 請求速率限制（供測試使用） | `true`（生產環境請設為 `false` 或移除） |
+| `TRUST_PROXY` | 速率限制改以 `X-Forwarded-For` 的第一段作為來源 IP。僅在後端確實位於可信任的反向代理之後才可開啟 | `false` |
 | `NEXT_PUBLIC_API_URL` | 瀏覽器端存取後端 API 的外部 URL | `http://localhost:4005` |
 | `ALLOWED_DEV_ORIGINS` | 允許進行開發連線的外部來源網域或 IP (如 Tailscale) | *(空)* |
 | `UPLOADS_MOUNT_SOURCE` | 附件上傳的儲存掛載路徑或 Docker Volume 名稱 | `app_uploads` |
@@ -103,7 +104,7 @@ docker compose exec backend pnpm run db:seed
 | 服務名稱 | 訪問網址 | 描述 |
 | :--- | :--- | :--- |
 | **前端應用 (Frontend)** | [http://localhost:3005](http://localhost:3005) | 主 Next.js 網頁應用介面 |
-| **後端服務 (Backend API)** | [http://localhost:4005](http://localhost:4005) | Express API 及 Socket.IO 伺服器 |
+| **後端服務 (Backend API)** | [http://localhost:4005](http://localhost:4005) | Bun + Hono API 及 Socket.IO 伺服器 |
 | **PostgreSQL 資料庫** | `localhost:5435` | PostgreSQL 18 資料庫 (容器內部對應 `5432` 連接埠) |
 
 ---

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -11,15 +11,15 @@ This directory contains the Bun + Hono TypeScript API server for the chat applic
 | File | Description |
 |------|-------------|
 | [src/index.ts](src/index.ts) | Composition Root: Instantiates database pool, repositories, services, Hono routes, Socket.IO handlers, and launches the HTTP server |
-| [src/db.ts](src/db.ts) | Exports the shared `pg.Pool` instance initialized from the `DATABASE_URL` environment variable |
+| [src/models/db.ts](src/models/db.ts) | Exports the shared `pg.Pool` instance initialized from the `DATABASE_URL` environment variable |
 | [migrations/](migrations/) | PostgreSQL migration files written in raw SQL managed by `node-pg-migrate` |
-| [package.json](package.json) | NPM scripts (`pnpm dev` for tsx/bun, `pnpm run test`) and dependencies |
+| [package.json](package.json) | NPM scripts (`pnpm run dev` for `bun --watch`, `pnpm run test`) and dependencies |
 
 ## Subdirectories
 
 | Directory | Purpose | Detail Orientation |
 |-----------|---------|--------------------|
-| [src/](src/) | TypeScript source code (routes, services, repositories) | See [backend/src/CLAUDE.md](src/CLAUDE.md) |
+| [src/](src/) | TypeScript source code (routes, services, models, middlewares, realtime, utils) | See [backend/src/CLAUDE.md](src/CLAUDE.md) |
 | [tests/](tests/) | Unit, integration, and E2E test suites | Written using Bun test |
 
 ## For AI Agents
@@ -33,7 +33,7 @@ This directory contains the Bun + Hono TypeScript API server for the chat applic
 The server strictly implements a 3-tier Hono architecture:
 1. **Routes**: Mount Hono route endpoints, validate inputs via `zValidator`, extract JWT context (`c.get('user')`), and call services. (Located in `src/routes/`).
 2. **Services**: Contain all business logic, authorization checks, state invariants. (Located in `src/services/`).
-3. **Repositories**: Execute raw SQL queries to persist and retrieve data. (Located in `src/repositories/`).
+3. **Repositories**: Execute raw SQL queries to persist and retrieve data. (Located in `src/models/`).
 
 Do not bypass these layers (e.g., calling repositories directly from route handlers).
 

--- a/backend/src/CLAUDE.md
+++ b/backend/src/CLAUDE.md
@@ -35,4 +35,4 @@ This directory contains the TypeScript source code for the backend service built
     // ...
   });
   ```
-- Make sure to write Zod schemas for any new request payloads under `routes/`, in the `*Schemas.ts` file matching the route module.
+- Make sure to write Zod schemas for any new request payloads under `routes/`, in the existing `*Schemas.ts` module that owns that domain rather than one file per route module — `authRoutes.ts` and `friendRoutes.ts` both draw from `userSchemas.ts`.

--- a/backend/src/CLAUDE.md
+++ b/backend/src/CLAUDE.md
@@ -10,10 +10,10 @@ This directory contains the TypeScript source code for the backend service built
 
 | Directory | Layer & Role | Code Standards & Guidelines |
 |-----------|--------------|----------------------------|
-| [routes/](routes/) | **Routing Layer** | Defines Hono HTTP endpoints, mounts validation middleware via `zValidator`, extracts auth context (`c.get('user')`), and delegates to the Service layer. |
+| [routes/](routes/) | **Routing Layer** | Defines Hono HTTP endpoints, mounts validation middleware via `zValidator`, extracts auth context (`c.get('user')`), and delegates to the Service layer. Also holds the Zod schemas validating each route's payloads (e.g. `userSchemas.ts`, `roomSchemas.ts`, `folderSchemas.ts`, `messageSchemas.ts`). |
 | [services/](services/) | **Business Logic Layer** | Domain orchestration and permission checking. Throws `AppError` subclasses. |
-| [repositories/](repositories/) | **Data Access Layer** | Executes raw SQL statements. Repositories must conform to corresponding interfaces (e.g., `IRoomRepository.ts`) to allow mock testing. |
-| [validators/](validators/) | **Validation Schemas** | Contains Zod validation schemas (e.g. `userSchemas.ts`, `roomSchemas.ts`, `folderSchemas.ts`) to validate HTTP payload structures. |
+| [models/](models/) | **Data Access Layer** | Executes raw SQL statements, and holds the shared `pg.Pool` in `db.ts`. Repositories must conform to corresponding interfaces (e.g., `IRoomRepository.ts`) to allow mock testing. |
+| [utils/](utils/) | **Shared Utilities** | Cross-cutting helpers: `AppError.ts` / `mapError.ts`, JWT and cookie handling, upload path resolution, and the `inactivityJob.ts` emergency-alert scheduler. |
 | [middlewares/](middlewares/) | **Middlewares** | Intercepts HTTP requests (JWT validation in `authMiddleware.ts`, security headers, global exception catching in `errorHandler.ts`). |
 | [realtime/](realtime/) | **WebSocket layer** | Handles Socket.IO connection handshakes, JWT authorization via Socket middlewares, and registers listeners for instant messages, typing indicators, and read receipts. |
 
@@ -21,7 +21,7 @@ This directory contains the TypeScript source code for the backend service built
 
 ### 1. Interface-Driven Design
 - Repositories utilize interface declarations (e.g., `IMessageRepository`) which are instantiated in the composition root [index.ts](index.ts).
-- This structure enables unit tests to inject mocked repositories via Vitest/Bun test, checking services in isolation. Always write unit tests by mocking interfaces.
+- This structure enables unit tests to inject mocked repositories via Bun test, checking services in isolation. Always write unit tests by mocking interfaces.
 
 ### 2. JWT & Socket Authorization
 - The Socket.IO server authenticates client connections via the token passed during handshake.
@@ -35,4 +35,4 @@ This directory contains the TypeScript source code for the backend service built
     // ...
   });
   ```
-- Make sure to write Zod schemas for any new request payloads under `validators/`.
+- Make sure to write Zod schemas for any new request payloads under `routes/`, in the `*Schemas.ts` file matching the route module.

--- a/backend/tests/CLAUDE.md
+++ b/backend/tests/CLAUDE.md
@@ -4,7 +4,7 @@
 # tests
 
 ## Purpose
-Vitest integration tests for the backend service layer. Tests call the actual service functions against a real PostgreSQL database — no mocking. Each suite manages its own test data via `beforeAll`/`afterAll` setup and teardown.
+Bun test integration tests for the backend service layer. Tests call the actual service functions against a real PostgreSQL database — no mocking. Each suite manages its own test data via `beforeAll`/`afterAll` setup and teardown.
 
 ## Current State
 
@@ -19,7 +19,7 @@ Vitest integration tests for the backend service layer. Tests call the actual se
 
 ### Working In This Directory
 - Tests require a live PostgreSQL database; start the test DB with `docker compose -f docker-compose.test.yml up -d` before running.
-- Run all tests from `backend/`: `npx vitest run` for a single pass.
+- Run all tests from `backend/`: `bun test` for a single pass.
 - Test isolation: each suite creates a unique named record in `beforeAll` and deletes it in `afterAll`. Avoid using names like "TestRoomForAPI" or "TestUserAPI" in manual DB operations to prevent conflicts.
 
 ### Testing Requirements
@@ -37,6 +37,6 @@ Vitest integration tests for the backend service layer. Tests call the actual se
 - `../src/services/` — tested modules (reimplemented in #6–#8)
 
 ### External
-- `vitest` — test runner (imported as `describe`, `it`, `expect`, `beforeAll`, `afterAll`)
+- `bun:test` — test runner (imported as `describe`, `it`, `expect`, `beforeAll`, `afterAll`)
 
 <!-- MANUAL: Any manually added notes below this line are preserved on regeneration -->

--- a/backend/tests/CLAUDE.md
+++ b/backend/tests/CLAUDE.md
@@ -19,7 +19,7 @@ Bun test integration tests for the backend service layer. Tests call the actual 
 
 ### Working In This Directory
 - Tests require a live PostgreSQL database; start the test DB with `docker compose -f docker-compose.test.yml up -d` before running.
-- Run all tests from `backend/`: `bun test` for a single pass.
+- Run all tests from `backend/`: `bun run test` for a single pass. It runs the unit, integration and e2e tiers as three separate processes on purpose — a bare `bun test` loads all three into one runner, where the unit tier's process-global `mock.module()` calls leak into the tiers that need a real database.
 - Test isolation: each suite creates a unique named record in `beforeAll` and deletes it in `afterAll`. Avoid using names like "TestRoomForAPI" or "TestUserAPI" in manual DB operations to prevent conflicts.
 
 ### Testing Requirements

--- a/qa_onboarding_guide.md
+++ b/qa_onboarding_guide.md
@@ -12,7 +12,7 @@
    - 封鎖使用者功能、檔案與圖片傳輸
 2. **架構概念**：
    - **Frontend (前端)**：使用 Next.js，負責畫面與使用者互動。
-   - **Backend (後端)**：使用 Node.js (Express) + Socket.io，處理 API 請求與即時通訊。
+   - **Backend (後端)**：使用 Bun (Hono) + Socket.io，處理 API 請求與即時通訊。
    - **Database (資料庫)**：PostgreSQL。
 3. **系統環境需求**：
    - 電腦需安裝並執行 **Docker** 以及 **Docker Compose**。


### PR DESCRIPTION
## 變更描述 (Description)

每週文件漂移掃描（掃描區間：2026-07-22 至 2026-07-29 UTC）。

近七天合併的後端重構已將技術棧由 Node.js / Express 遷移為 **Bun + Hono**，同時把 `backend/src/` 扁平化為 6 個核心資料夾，並將測試執行器由 Vitest 換成 `bun test`。多份文件仍描述舊架構或指向已不存在的路徑，本 PR 僅修正這些與現況牴觸的敘述。

**未改動任何應用程式原始碼，只改文件。**

### 關於 base 分支的重要說明

本掃描任務原本設定以 `dev` 為 base，但掃描區間內合併的 **#427「將主要分支收斂為 main 並移除 dev 分支設定」** 已把 CI 觸發、Dependabot target-branch、CONTRIBUTING 與 DEVELOPMENT 的分支策略全數收斂到 `main`，`dev` 不再是收 PR 的分支。經確認 repo 的預設分支為 `main`，且 `main` 內容已涵蓋 `dev`，因此本 PR 改以 **`main`** 為 base。此點請一併覆核。

## 相關的 Issue (Related Issue)

無（例行文件漂移掃描）。

## 掃描的已合併 PR 清單

| PR | 標題 | 是否驅動本次文件修正 |
| :--- | :--- | :--- |
| [#427](https://github.com/nearcsie/near-chat/pull/427) | chore(ci): 將主要分支收斂為 main 並移除 dev 分支設定 | 否（該 PR 已自行同步文件），但決定了本 PR 的 base |
| [#426](https://github.com/nearcsie/near-chat/pull/426) | Dev | 否（合併用） |
| [#425](https://github.com/nearcsie/near-chat/pull/425) | fix(security): 修正 next/brace-expansion 漏洞並改用 CVE ratcheting 閘門 | 否 |
| [#423](https://github.com/nearcsie/near-chat/pull/423) | build: 收斂為單一 root lockfile 的 pnpm monorepo | 否（已同步 DEVELOPMENT.md） |
| [#419](https://github.com/nearcsie/near-chat/pull/419) | Migrate backend tooling to Bun in CI, Dockerfiles, and compose | **是** |
| [#414](https://github.com/nearcsie/near-chat/pull/414) | refactor(test): 對齊 unit test 目錄結構與 src | **是** |
| [#412](https://github.com/nearcsie/near-chat/pull/412) | Add comprehensive unit tests and security improvements | **是** |
| [#403](https://github.com/nearcsie/near-chat/pull/403) | refactor(backend): 使用 bun 與 hono 重構後端 | **是** |
| [#404](https://github.com/nearcsie/near-chat/pull/404) | chore: set effort level to xhigh in Claude settings | 否 |
| [#400](https://github.com/nearcsie/near-chat/pull/400) | chore: 新增 Dependabot 自動升級與安全維護設定 | 否 |
| [#397](https://github.com/nearcsie/near-chat/pull/397) | feat: 實作 CI/CD 自動化版本控制與發布流程 | 否 |
| [#396](https://github.com/nearcsie/near-chat/pull/396) | perf: optimize React render performance in chat | 否 |
| [#391](https://github.com/nearcsie/near-chat/pull/391) | Replace dynamic Icon imports with static Boxicons components | 否（僅前端內部實作） |
| [#377](https://github.com/nearcsie/near-chat/pull/377) | fix: 訊息操作選單支援行動裝置長按與桌面懸停三點觸發 | 否（僅前端 UI） |
| [#374](https://github.com/nearcsie/near-chat/pull/374) | feat: 新增聊天室一鍵分類篩選與排序 | 否（純前端，未改動 REST 介面） |

## 文件修改對照表

| 文件 | 修正內容 | 對應的 API / 架構變更 |
| :--- | :--- | :--- |
| `README.md` | 技術棧 `Node.js, Express v5` 改為 `Bun, Hono v4`；專案結構註解改為 Hono；`src/` 子目錄由 `controllers, repositories` 更正為實際的 6 個資料夾；連接埠表格改為 `Bun + Hono API` | #403、#419 |
| `README.zh-TW.md` | 同上（繁中版） | #403、#419 |
| `README.md` / `README.zh-TW.md` | 環境變數表補上 `TRUST_PROXY` | #403 新增（`.env.example` 與 `docker-compose.yml` 內已有，README 漏列） |
| `CONTRIBUTING.md` | 專案簡介改為 Bun/Hono；「Running Vitest Tests」改為「Running Bun Tests」；協定驗證段落的「Express controllers」改為「Hono routes, backend services」 | #403、#412、#414 |
| `CONTRIBUTING.zh-TW.md` | 同上（繁中版） | #403、#412、#414 |
| `CLAUDE.md`（`AGENTS.md` 為其符號連結） | 專案簡介、compose 服務說明、`backend/` 用途皆由 Express 改為 Bun + Hono | #403、#419 |
| `backend/CLAUDE.md` | `src/db.ts` 更正為實際存在的 `src/models/db.ts`；dev script 說明由 `tsx/bun` 更正為 `bun --watch`；分層說明中 `src/repositories/` 更正為 `src/models/`；`src/` 子目錄清單更新 | #403 目錄扁平化 |
| `backend/src/CLAUDE.md` | 移除已不存在的 `repositories/` 與 `validators/` 兩列，改為實際的 `models/` 與 `utils/`；補述 Zod schema 現與路由同置於 `routes/`；「Vitest/Bun test」更正為「Bun test」 | #403、#412 |
| `backend/tests/CLAUDE.md` | 測試執行器由 `vitest` / `npx vitest run` 更正為 `bun:test` / `bun test` | #412、#414（backend 已完全移除 vitest 相依） |

## 標記為「可能過時」但未自動修改的項目

以下項目我判斷不確定或屬於刻意保留的史料，**未**動手修改，請人工覆核：

1. **`docs/RELEASE.md` 與 `docs/ZH-TW/RELEASE.md` 中的 Express 字樣**（第 5、44 行）。第 44 行明確寫的是「維持對 legacy Express 部署的相容性」，屬於描述 migration window 的歷史脈絡；第 5 行「不只是 Express 後端」則是在對比 `v1.0.0` 的後端專用版本。兩者可能是刻意保留的史料，也可能需要隨本次遷移更新措辭，交由人工判斷。

2. **`backend/tests/CLAUDE.md` 的「Current State」表格**仍記載 `user.test.ts` / `room.test.ts` 已於 issue #0 被隔離刪除、新測試於 #6–#8 撰寫中。這段內容早於本次掃描區間，且與 #414 重整後的實際測試目錄結構明顯不符，但重寫已超出「同步本週 API 變更」的範圍。

3. **`docs/frontend-bundle-analysis.md` 與 `docs/frontend-turbopack-code-splitting.md` 提到的 `@iconify/react` runtime**。#391 已改為 `@iconify-react/boxicons` 靜態元件匯入，但這兩份文件是帶有量測數據與日期的分析報告快照，改寫會破壞其歷史意義，故保留。

4. **本次重構新增但 `docs/api-documentation.md` 尚未收錄的路由別名**：`POST /rooms/:id/leave`、`GET /friend-requests/pending`、`POST /friend-requests/:id/respond`、`POST /folders/:id/rooms`、`POST /users/me/emergency-contacts/check-inactivity`、`GET /users/search`。這些是 #403 新增的相容別名，屬於「文件缺漏」而非「文件與程式碼牴觸」，且補齊需要逐一確認回應結構，因此僅在此列出，未自行新增章節。

5. **`docs/DEVELOPMENT.md` 與 `CONTRIBUTING.md` 的指令風格不一致**：前者已改用 `docker compose exec backend bun run <script>`，後者仍為 `pnpm run <script>`。兩者目前都能正常運作，非錯誤，故未統一。

## 變更類型 (Type of Change)

- [x] `docs`: 修改文件

## 驗證與測試計畫 (Verification & Test Plan)

### 本地測試 (Local Tests)

本 PR 僅修改 Markdown 文件，未觸及任何原始碼，故未執行型別檢查與測試套件：

- [ ] 後端型別檢查
- [ ] 前端型別檢查
- [ ] 前端 Linter 檢查
- [ ] 單元測試
- [ ] 整合測試

### 手動驗證 (Manual Verification)

每一處修改皆對照目前 `main` 的實際程式碼確認：

- 確認 `backend/package.json` 已無 `express` 與 `vitest` 相依，且 `hono`、`bun-types` 在列。
- 確認 `backend/Dockerfile` 以 `oven/bun:1.3.14-slim` 為 base image。
- 確認 `backend/src/` 實際只有 `middlewares`、`models`、`realtime`、`routes`、`services`、`utils` 六個資料夾，`repositories/`、`validators/`、`controllers/` 皆已不存在。
- 確認 `backend/src/models/db.ts` 存在而 `backend/src/db.ts` 不存在。
- 確認各 `*Schemas.ts` 皆位於 `backend/src/routes/` 之下。
- 確認 `TRUST_PROXY` 已存在於 `.env.example` 與 `docker-compose.yml`，且在掃描區間開始時尚未存在。

## 資料庫變更 (Database Changes)

* 此變更是否包含資料庫 Schema 修改？ **否**

## API 與 WebSocket 協定一致性 (API & WebSocket Contract Check)

* 此變更是否涉及 API 路由或 WebSocket 事件的資料結構變更？ **否**（本 PR 只更新文件敘述以追上既有實作，未改動任何介面）
* 是否已確認與 [docs/api-documentation.md](../docs/api-documentation.md) 規範完全一致？ **是** — 已逐一比對 `docs/api-documentation.md` 與現行 Hono 路由，既有章節的路徑、請求欄位與回應結構均與實作相符，故本次未修改該文件；僅有上述第 4 點所列的新增別名尚未收錄。

Generated with Claude Code (https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011aykuV3JVaSAbvqtMcinva)_