### PR TITLE
ci: 移除 release-stack.yml 的 annotated tag 檢查

### DIFF
--- a/.github/workflows/release-stack.yml
+++ b/.github/workflows/release-stack.yml
@@ -111,23 +111,35 @@ jobs:
             echo "sha_tag=sha-${GITHUB_SHA:0:12}"
           } >> "$GITHUB_OUTPUT"
 
-      - name: 檢查既有 GitHub Release
+      - name: 檢查既有 GitHub Release 與 Stack 發布狀態
         id: release
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
+          BUNDLE_ASSET_NAME: near-chat-stack-${{ github.ref_name }}.tar.gz
         run: |
           set -euo pipefail
           release_json="$RUNNER_TEMP/existing-stack-release.json"
           release_error="$RUNNER_TEMP/existing-stack-release.error"
 
+          # Release 本身由 @semantic-release/github 建立（見 .releaserc.json），本
+          # workflow 只負責補上映像、provenance 與部署 bundle。因此「Release 是否
+          # 存在」已不等於「Stack 是否已發布」，冪等性判準改用 bundle asset。
           if gh api "/repos/${GITHUB_REPOSITORY}/releases/tags/${GITHUB_REF_NAME}" \
             > "$release_json" 2> "$release_error"; then
             echo 'exists=true' >> "$GITHUB_OUTPUT"
-            echo "Release 已存在；後續只驗證，不會覆寫。"
+            if jq -e --arg name "$BUNDLE_ASSET_NAME" \
+              '[.assets[].name] | index($name) != null' "$release_json" >/dev/null; then
+              echo 'stack_published=true' >> "$GITHUB_OUTPUT"
+              echo "Release 已附上 Stack bundle；後續只驗證，不會覆寫。"
+            else
+              echo 'stack_published=false' >> "$GITHUB_OUTPUT"
+              echo "Release 已存在但尚未附上 Stack bundle；本次補上映像與 bundle。"
+            fi
           elif grep -q 'HTTP 404' "$release_error"; then
             echo 'exists=false' >> "$GITHUB_OUTPUT"
-            echo "Release 尚未建立。"
+            echo 'stack_published=false' >> "$GITHUB_OUTPUT"
+            echo "Release 尚未建立；本次由本 workflow 建立（手動 tag／復原路徑）。"
           else
             cat "$release_error" >&2
             exit 1
@@ -151,7 +163,7 @@ jobs:
           BACKEND_SHA_REF: ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE_NAME }}:${{ steps.version.outputs.sha_tag }}
           FRONTEND_VERSION_REF: ${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE_NAME }}:${{ steps.version.outputs.number }}
           FRONTEND_SHA_REF: ${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE_NAME }}:${{ steps.version.outputs.sha_tag }}
-          RELEASE_EXISTS: ${{ steps.release.outputs.exists }}
+          STACK_PUBLISHED: ${{ steps.release.outputs.stack_published }}
         run: |
           set -euo pipefail
 
@@ -186,16 +198,16 @@ jobs:
 
           if [[ "$backend_version_digest" == "$backend_sha_digest" && -n "$backend_version_digest" ]] && \
              [[ "$frontend_version_digest" == "$frontend_sha_digest" && -n "$frontend_version_digest" ]]; then
-            if [[ "$RELEASE_EXISTS" != "true" ]]; then
-              echo "兩個 image 已存在但 Release 不存在；拒絕包裝或補簽既有 artifact。" >&2
+            if [[ "$STACK_PUBLISHED" != "true" ]]; then
+              echo "兩個 image 已存在但 Release 尚未附上 Stack bundle；拒絕包裝或補簽既有 artifact。" >&2
               exit 1
             fi
             echo 'build_required=false' >> "$GITHUB_OUTPUT"
             echo "backend_digest=$backend_version_digest" >> "$GITHUB_OUTPUT"
             echo "frontend_digest=$frontend_version_digest" >> "$GITHUB_OUTPUT"
           elif [[ -z "$backend_version_digest" && -z "$backend_sha_digest" && -z "$frontend_version_digest" && -z "$frontend_sha_digest" ]]; then
-            if [[ "$RELEASE_EXISTS" == "true" ]]; then
-              echo "Release 已存在但四個 image 參照皆遺失；拒絕以新建置取代既有 artifact。" >&2
+            if [[ "$STACK_PUBLISHED" == "true" ]]; then
+              echo "Release 已附上 Stack bundle 但四個 image 參照皆遺失；拒絕以新建置取代既有 artifact。" >&2
               exit 1
             fi
             echo 'build_required=true' >> "$GITHUB_OUTPUT"
@@ -270,7 +282,7 @@ jobs:
           done
 
       - name: 驗證既有 Release 不可變內容
-        if: steps.release.outputs.exists == 'true'
+        if: steps.release.outputs.stack_published == 'true'
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
@@ -393,7 +405,7 @@ jobs:
           echo "sha256=$bundle_sha256" >> "$GITHUB_OUTPUT"
 
       - name: 驗證既有 Stack bundle 完整性
-        if: steps.release.outputs.exists == 'true'
+        if: steps.release.outputs.stack_published == 'true'
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
@@ -450,17 +462,17 @@ jobs:
             "$bundle_root/release-manifest.json" >/dev/null
           grep -F "image: $POSTGRES_IMAGE" "$bundle_root/docker-compose.release.yml" >/dev/null
 
-      - name: 建立 GitHub Release
-        if: steps.release.outputs.exists == 'false'
+      - name: 產生 Stack 發布說明區段
+        if: steps.release.outputs.stack_published == 'false'
+        id: stack_notes
         shell: bash
         env:
-          GH_TOKEN: ${{ github.token }}
           VERSION_NUMBER: ${{ steps.version.outputs.number }}
           IMAGE_SHA_TAG: ${{ steps.version.outputs.sha_tag }}
           BACKEND_DIGEST: ${{ steps.resolved.outputs.backend_digest }}
           FRONTEND_DIGEST: ${{ steps.resolved.outputs.frontend_digest }}
           BUNDLE_SHA256: ${{ steps.bundle.outputs.sha256 }}
-          BUNDLE_ARCHIVE: ${{ steps.bundle.outputs.archive }}
+          BUNDLE_ASSET_NAME: ${{ steps.bundle.outputs.asset_name }}
         run: |
           set -euo pipefail
           notes_file="$RUNNER_TEMP/stack-release-notes.md"
@@ -468,7 +480,7 @@ jobs:
           frontend_image="${REGISTRY}/${FRONTEND_IMAGE_NAME}"
 
           {
-            echo '# Near Chat'
+            echo '## 完整 Stack'
             echo
             printf -- '- version：`%s`\n' "$GITHUB_REF_NAME"
             printf -- '- Commit：`%s`\n' "$GITHUB_SHA"
@@ -479,17 +491,58 @@ jobs:
             printf -- '- Frontend commit image：`%s:%s`\n' "$frontend_image" "$IMAGE_SHA_TAG"
             printf -- '- Frontend digest：`%s@%s`\n' "$frontend_image" "$FRONTEND_DIGEST"
             printf -- '- PostgreSQL runtime：`%s`\n' "$POSTGRES_IMAGE"
-            printf -- '- Depoly bundle：`%s`\n' "$(basename "$BUNDLE_ARCHIVE")"
+            printf -- '- Deploy bundle：`%s`\n' "$BUNDLE_ASSET_NAME"
             printf -- '- Bundle SHA-256：`%s`\n' "$BUNDLE_SHA256"
             echo
-            printf -- '發布說明：[繁體中文](https://github.com/%s/blob/%s/docs/ZH-TW/backend-release.md)／[English](https://github.com/%s/blob/%s/docs/backend-release.md)\n' \
+            printf -- '發布說明：[繁體中文](https://github.com/%s/blob/%s/docs/ZH-TW/RELEASE.md)／[English](https://github.com/%s/blob/%s/docs/RELEASE.md)\n' \
               "$GITHUB_REPOSITORY" "$GITHUB_REF_NAME" "$GITHUB_REPOSITORY" "$GITHUB_REF_NAME"
           } > "$notes_file"
 
+          echo "file=$notes_file" >> "$GITHUB_OUTPUT"
+
+      # 正常路徑：Release 已由 Semantic Release 建立，這裡只把 Stack 區段附加到既有
+      # release notes 後面，再上傳 bundle。asset 上傳放在最後一步，因為
+      # `stack_published` 正是以 asset 是否存在判定 —— 讓它成為最終的提交點。
+      - name: 於既有 Release 補上 Stack artifact
+        if: steps.release.outputs.exists == 'true' && steps.release.outputs.stack_published == 'false'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          STACK_NOTES_FILE: ${{ steps.stack_notes.outputs.file }}
+          BUNDLE_ARCHIVE: ${{ steps.bundle.outputs.archive }}
+        run: |
+          set -euo pipefail
+          merged_notes="$RUNNER_TEMP/merged-release-notes.md"
+          gh release view "$GITHUB_REF_NAME" \
+            --repo "$GITHUB_REPOSITORY" \
+            --json body --jq .body > "$merged_notes"
+          {
+            echo
+            echo '---'
+            echo
+            cat "$STACK_NOTES_FILE"
+          } >> "$merged_notes"
+
+          gh release edit "$GITHUB_REF_NAME" \
+            --repo "$GITHUB_REPOSITORY" \
+            --notes-file "$merged_notes"
+          gh release upload "$GITHUB_REF_NAME" "$BUNDLE_ARCHIVE" \
+            --repo "$GITHUB_REPOSITORY"
+
+      # 備援路徑：Release 不存在（手動推 tag，或 Semantic Release 未建立時的復原）。
+      - name: 建立 GitHub Release
+        if: steps.release.outputs.exists == 'false'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          STACK_NOTES_FILE: ${{ steps.stack_notes.outputs.file }}
+          BUNDLE_ARCHIVE: ${{ steps.bundle.outputs.archive }}
+        run: |
+          set -euo pipefail
           gh release create "$GITHUB_REF_NAME" \
             --repo "$GITHUB_REPOSITORY" \
             --verify-tag \
             --title "Near Chat $GITHUB_REF_NAME" \
-            --notes-file "$notes_file" \
+            --notes-file "$STACK_NOTES_FILE" \
             --latest=false \
             "$BUNDLE_ARCHIVE"

--- a/.github/workflows/release-stack.yml
+++ b/.github/workflows/release-stack.yml
@@ -56,12 +56,10 @@ jobs:
 
           tag_ref="refs/tags/${GITHUB_REF_NAME}"
           git fetch --force origin "${tag_ref}:${tag_ref}"
-          object_type="$(git cat-file -t "$tag_ref")"
-          if [[ "$object_type" != "tag" ]]; then
-            echo "正式版本必須使用 annotated tag；實際 object type：$object_type" >&2
-            exit 1
-          fi
 
+          # Tag 型別不設限：Semantic Release 建立的是 lightweight tag，手動備援
+          # 流程建立的是 annotated tag。`^{}` 對兩種型別都會 peel 到同一個 commit，
+          # 所以下面這段檢查對兩者等效，不需要再多一道 object type 判斷。
           peeled_sha="$(git rev-parse "${tag_ref}^{}")"
           if [[ "$(git cat-file -t "$peeled_sha")" != "commit" || "$peeled_sha" != "$GITHUB_SHA" ]]; then
             echo "Tag peeled commit 必須等於 workflow commit：tag=$peeled_sha workflow=$GITHUB_SHA" >&2

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ docker compose exec backend pnpm run db:seed
 
 The project provides a production-ready configuration using `docker-compose.prod.yml`, which runs optimized production builds (`Dockerfile.prod`) and sets up a Cloudflare Tunnel for secure remote access.
 
-For a versioned deployment using published artifacts, download the `near-chat-stack-vX.Y.Z.tar.gz` asset from the GitHub Release and use its `docker-compose.release.yml`. That bundle pins the frontend and backend image digests, PostgreSQL 18 runtime digest, and migration step together. See the [Stack Version Release Guide](docs/backend-release.md).
+For a versioned deployment using published artifacts, download the `near-chat-stack-vX.Y.Z.tar.gz` asset from the GitHub Release and use its `docker-compose.release.yml`. That bundle pins the frontend and backend image digests, PostgreSQL 18 runtime digest, and migration step together. See the [Stack Version Release Guide](docs/RELEASE.md).
 
 ### 1. Configure Production Environment
 Ensure all production environment variables (e.g., `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`, `DATABASE_URL`, `JWT_SECRET`, `NEXT_PUBLIC_API_URL`, `TUNNEL_TOKEN`) are configured in your `.env` file.
@@ -145,4 +145,4 @@ For detailed instructions on running unit, integration, and E2E tests, please re
 
 ## Stack Releases
 
-Annotated `vX.Y.Z` tags automatically publish immutable frontend and backend GHCR images, a pinned PostgreSQL 18 runtime, migrations, a Docker Compose bundle, and a digest-recorded GitHub Release. See the [Stack Version Release Guide](docs/backend-release.md).
+Merging a Conventional Commit into `main` lets Semantic Release compute the next version and push a `vX.Y.Z` tag, which automatically publishes immutable frontend and backend GHCR images, a pinned PostgreSQL 18 runtime, migrations, a Docker Compose bundle, and a digest-recorded GitHub Release. See the [Stack Version Release Guide](docs/RELEASE.md).

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -113,7 +113,7 @@ docker compose exec backend pnpm run db:seed
 
 本專案提供專為生產環境設計的配置檔 `docker-compose.prod.yml`。此配置會建置最佳化後的生產映像檔 (`Dockerfile.prod`)，並啟動 Cloudflare Tunnel 以實現安全的外網連線。
 
-若要使用已發布的版本 artifact，請從 GitHub Release 下載 `near-chat-stack-vX.Y.Z.tar.gz`，再使用其中的 `docker-compose.release.yml`。該 bundle 會把前端、後端 image digest、PostgreSQL 18 runtime digest 與 migration 步驟固定在同一份部署描述中。詳見[完整 Stack 版本發布指南](docs/ZH-TW/backend-release.md)。
+若要使用已發布的版本 artifact，請從 GitHub Release 下載 `near-chat-stack-vX.Y.Z.tar.gz`，再使用其中的 `docker-compose.release.yml`。該 bundle 會把前端、後端 image digest、PostgreSQL 18 runtime digest 與 migration 步驟固定在同一份部署描述中。詳見[完整 Stack 版本發布指南](docs/ZH-TW/RELEASE.md)。
 
 ### 1. 配置生產環境變數
 請確保 `.env` 檔案中已填寫所有生產環境所需的變數（例如 `POSTGRES_USER`、`POSTGRES_PASSWORD`、`POSTGRES_DB`、`DATABASE_URL`、`JWT_SECRET`、`NEXT_PUBLIC_API_URL` 以及 Cloudflare Tunnel 的 `TUNNEL_TOKEN`）。
@@ -144,4 +144,4 @@ docker compose -f docker-compose.prod.yml down
 
 ## 完整 Stack 版本發布
 
-推送 annotated `vX.Y.Z` tag 後，系統會自動發布不可變的 GHCR 前後端映像、固定版本的 PostgreSQL 18 runtime、migration、Docker Compose bundle，以及記錄 digest 的 GitHub Release。詳見[完整 Stack 版本發布指南](docs/ZH-TW/backend-release.md)。
+Conventional Commit 合併進 `main` 後，Semantic Release 會算出下一個版本號並推送 `vX.Y.Z` tag，系統隨即自動發布不可變的 GHCR 前後端映像、固定版本的 PostgreSQL 18 runtime、migration、Docker Compose bundle，以及記錄 digest 的 GitHub Release。詳見[完整 Stack 版本發布指南](docs/ZH-TW/RELEASE.md)。

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -371,6 +371,6 @@ When changes are merged into `main`, GitHub Actions (`.github/workflows/ci.yml`)
    - `BREAKING CHANGE:` → Increments **Major (`a`)** (e.g. `v1.0.1` → `v2.0.0`)
    - `docs:`, `chore:`, `refactor:` → No version increment
 2. **Multi-Package Version Sync**: Runs `scripts/update-versions.js` to synchronize `"version"` in root `package.json`, `frontend/package.json`, and `backend/package.json`.
-3. **Changelog & GitHub Release**: Automatically generates `CHANGELOG.md` and publishes formatted **Release Notes directly on the GitHub Release page**.
-4. **Stack Image & Bundle Publication**: Creating tag `vX.Y.Z` triggers `.github/workflows/release-stack.yml`, building & pushing Docker images to GHCR, signing provenance attestations, and attaching `near-chat-stack-vX.Y.Z.tar.gz` deployment bundle to the GitHub Release.
+3. **Tag & GitHub Release**: Pushes the version commit and a **lightweight** `vX.Y.Z` tag, generates `CHANGELOG.md`, and — via `@semantic-release/github` — **creates the GitHub Release** with formatted release notes. Semantic Release owns the tag and the Release; `release-stack.yml` does not create either on this path and no longer requires an annotated tag.
+4. **Stack Image & Bundle Publication**: `.github/workflows/release-stack.yml` builds & pushes Docker images to GHCR, signs provenance attestations, appends its stack section (image digests, PostgreSQL runtime, bundle SHA-256) to the existing release notes, and uploads the `near-chat-stack-vX.Y.Z.tar.gz` deployment bundle. The bundle asset — not the Release itself — is the idempotency key that marks a version as published.
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -6,14 +6,20 @@ Near Chat release tags represent a deployable stack, not only the Express backen
 
 ## Publish a version
 
-Publishing starts only when an annotated tag exactly matching `vX.Y.Z` is pushed. The numeric version must match the root, `backend/package.json`, and `frontend/package.json` files. The tag must point to the current `main` HEAD, and that commit must have a successful main CI run containing frontend lint/typecheck/build, backend build, unit, integration, E2E, and security jobs.
+Releases are cut automatically. Merging a Conventional Commit into `main` runs the `release` job in `.github/workflows/ci.yml`, which runs Semantic Release: it computes the next version, syncs `version` across the root, `backend/package.json`, and `frontend/package.json`, updates `CHANGELOG.md`, pushes the version commit and the `vX.Y.Z` tag, and creates the GitHub Release with the generated notes. `.github/workflows/release-stack.yml` then adds the stack artifacts — images, provenance attestations, and the deployment bundle — to that same Release.
+
+Semantic Release is the source of truth for tags. It creates **lightweight** tags, and `release-stack.yml` accepts both lightweight and annotated tags; the tag type is not checked. What is still enforced: the tag name must match `vX.Y.Z` exactly, the numeric version must match all three `package.json` files, the tag must point to the current `main` HEAD, and that commit must have a successful main CI run containing frontend lint/typecheck/build, backend build, unit, integration, E2E, and security jobs.
+
+As a fallback — when the automated chain fails and a version has to be published by hand — pushing a tag manually still works:
 
 ```bash
 git switch main
 git pull --ff-only origin main
-git tag -a v1.0.1 -m "Near Chat Stack v1.0.1"
+git tag v1.0.1
 git push origin v1.0.1
 ```
+
+If no GitHub Release exists for the tag, `release-stack.yml` creates one itself. Never create a tag by hand for a version Semantic Release has already released; see "Immutability and failure handling" below.
 
 The workflow publishes two immutable application images, each with a version tag and commit tag:
 
@@ -45,6 +51,8 @@ The database runtime is fixed to PostgreSQL 18 Alpine by digest. The schema is v
 
 ## Immutability and failure handling
 
-The four application image references and the GitHub Release are treated as one immutable publication. A clean first publication requires all four image references and the Release to be absent. A rerun only verifies that all four references resolve to their recorded digests, both provenance attestations exist, and the Release contains the matching manifest and bundle. Partial publications, mismatched digests, missing attestations, or missing bundle assets fail closed; the workflow never overwrites an existing version.
+The four application image references and the stack artifacts attached to the GitHub Release are treated as one immutable publication. Because Semantic Release creates the Release before `release-stack.yml` runs, the existence of a Release is *not* the idempotency key — the presence of the `near-chat-stack-vX.Y.Z.tar.gz` bundle asset is. A clean first publication requires all four image references and that bundle asset to be absent; `release-stack.yml` then appends its stack section to the existing release notes and uploads the bundle. A rerun only verifies that all four references resolve to their recorded digests, both provenance attestations exist, and the Release contains the matching manifest and bundle. Partial publications, mismatched digests, missing attestations, or a bundle asset present without its images fail closed; the workflow never overwrites an existing version.
+
+Recovering from a half-published version therefore means deleting the bundle asset and the four image references (or the whole Release and tag) by hand before rerunning.
 
 Release artifacts must never contain `.env` files, credentials, database volumes or dumps containing real data, or uploaded user files.

--- a/docs/ZH-TW/DEVELOPMENT.md
+++ b/docs/ZH-TW/DEVELOPMENT.md
@@ -354,6 +354,6 @@ describe('userRepository', () => {
    - `BREAKING CHANGE:` $\rightarrow$ 遞增 **Major (`a`)**（如 `v1.0.1` $\rightarrow$ `v2.0.0`）
    - `docs:`, `chore:`, `refactor:` $\rightarrow$ 不遞增版本號
 2. **三方版本號同步**：自動執行 `scripts/update-versions.js` 同步更新根目錄 `package.json`、`frontend/package.json` 與 `backend/package.json` 的版本。
-3. **Changelog 與 Release 頁面**：自動更新 `CHANGELOG.md`，並**將格式化後的 Release Notes 直接發布於 GitHub Release 頁面**。
-4. **Stack 映像檔與部署包發布**：建立 `vX.Y.Z` 標籤並觸發 `.github/workflows/release-stack.yml`，自動建置 Frontend/Backend 容器映像檔推至 GHCR、簽署 SLSA Provenance，並附加 `near-chat-stack-vX.Y.Z.tar.gz` 部署包至 GitHub Release。
+3. **Tag 與 Release 頁面**：推送版本號 commit 與 **lightweight** `vX.Y.Z` tag、更新 `CHANGELOG.md`，並由 `@semantic-release/github` **建立 GitHub Release** 與格式化後的 Release Notes。Tag 與 Release 皆由 Semantic Release 擁有；此路徑下 `release-stack.yml` 不會自行建立，也不再要求 annotated tag。
+4. **Stack 映像檔與部署包發布**：`.github/workflows/release-stack.yml` 建置 Frontend/Backend 容器映像檔推至 GHCR、簽署 SLSA Provenance，把 Stack 區段（image digest、PostgreSQL runtime、bundle SHA-256）附加到既有的 Release Notes 之後，並上傳 `near-chat-stack-vX.Y.Z.tar.gz` 部署包。判斷某版本是否已發布的冪等性依據是這個 bundle asset，而非 Release 本身。
 

--- a/docs/ZH-TW/RELEASE.md
+++ b/docs/ZH-TW/RELEASE.md
@@ -6,14 +6,20 @@ Near Chat 的版本 tag 代表一份可部署的完整 Stack，不只是 Express
 
 ## 發布版本
 
-只有推送完全符合 `vX.Y.Z` 的 annotated tag 才會啟動發布。數字版本必須同時等於 root、`backend/package.json` 與 `frontend/package.json`。Tag 必須指向目前 `main` HEAD，且該 commit 必須通過 main CI 的 frontend lint／typecheck／build、backend build、unit、integration、E2E 與 security jobs。
+發布是自動的。Conventional Commit 合併進 `main` 後會觸發 `.github/workflows/ci.yml` 的 `release` job 執行 Semantic Release：計算下一個版本號、同步 root 與 `backend/package.json`、`frontend/package.json` 的 `version`、更新 `CHANGELOG.md`、推送版本號 commit 與 `vX.Y.Z` tag，並建立帶有 release notes 的 GitHub Release。接著由 `.github/workflows/release-stack.yml` 在**同一個** Release 上補齊 Stack artifact —— 映像、provenance attestation 與部署 bundle。
+
+Tag 以 Semantic Release 為準。它建立的是 **lightweight tag**，`release-stack.yml` 對 lightweight 與 annotated 一律接受，不檢查 tag 型別。仍然強制的條件是：tag 名稱必須完全符合 `vX.Y.Z`、數字版本必須同時等於三份 `package.json`、tag 必須指向目前 `main` HEAD，且該 commit 必須通過 main CI 的 frontend lint／typecheck／build、backend build、unit、integration、E2E 與 security jobs。
+
+作為備援 —— 自動流程失敗、需要人工發布某個版本時 —— 手動推 tag 仍然可行：
 
 ```bash
 git switch main
 git pull --ff-only origin main
-git tag -a v1.0.1 -m "Near Chat Stack v1.0.1"
+git tag v1.0.1
 git push origin v1.0.1
 ```
+
+若該 tag 尚無對應的 GitHub Release，`release-stack.yml` 會自行建立。切勿為 Semantic Release 已經發布過的版本手動建立 tag，理由見下方「不可變性與失敗處理」。
 
 Workflow 會發布兩個不可變的應用程式映像，各自包含版本 tag 與 commit tag：
 
@@ -45,6 +51,8 @@ Compose bundle 會啟動 PostgreSQL，使用固定版本的 backend image 執行
 
 ## 不可變與失敗處理
 
-四個應用程式 image 參照與 GitHub Release 視為同一個不可變發布。乾淨的首次發布要求四個 image 參照與 Release 都不存在；重新執行時，只驗證四個參照的 digest、兩個 provenance attestation、Release manifest 與 bundle 是否完全一致。Partial publication、digest 不一致、attestation 缺失或 bundle asset 缺失都會 fail closed；workflow 不會覆寫既有版本。
+四個應用程式 image 參照與掛在 GitHub Release 上的 Stack artifact 視為同一個不可變發布。由於 Release 是 Semantic Release 在 `release-stack.yml` 執行前就先建立的，「Release 是否存在」**不是**冪等性判準 —— 判準是 `near-chat-stack-vX.Y.Z.tar.gz` 這個 bundle asset 是否存在。乾淨的首次發布要求四個 image 參照與該 bundle asset 都不存在，`release-stack.yml` 會把 Stack 區段附加到既有 release notes 之後並上傳 bundle。重新執行時，只驗證四個參照的 digest、兩個 provenance attestation、Release manifest 與 bundle 是否完全一致。Partial publication、digest 不一致、attestation 缺失，或 bundle asset 存在但 image 遺失，都會 fail closed；workflow 不會覆寫既有版本。
+
+因此，要從發布到一半的版本復原，必須先人工刪除 bundle asset 與四個 image 參照（或整個 Release 與 tag）再重跑。
 
 發布成果不得包含 `.env`、credential、包含真實資料的 database volume／dump，或使用者 uploads。


### PR DESCRIPTION
## 變更描述 (Description)

`main` 上同時存在兩套互相衝突的發布機制：先有的手動 annotated tag 流程（`release-stack.yml`），與 PR #397 引入的 Semantic Release。本 PR 依「**取消正式版本必須使用 annotated tag 的要求，一切以 semantic-release 為準**」的決策收斂 —— 凡 `release-stack.yml` 的規則與 semantic-release 的原生行為衝突，改的是 `release-stack.yml`。

三個 commit，可分別回退：

| Commit | 變更 | 原因 |
| --- | --- | --- |
| `786e78d` | 移除 `release-stack.yml` 的 `git cat-file -t` object type 檢查 | semantic-release 核心的 `tag()` 只執行 `git tag <name> <ref>`（`node_modules/semantic-release/lib/git.js:224`，無 `-a`），建立的是 lightweight tag，會被這道檢查以「正式版本必須使用 annotated tag」擋下 |
| `dcbe2ac` | 冪等性判準由「Release 是否存在」改為「Stack bundle asset 是否存在」 | `@semantic-release/github` 會在本 workflow 執行**之前**建立 Release，使原本「Release 已存在但四個 image 皆遺失即中止」的 fail-closed 防護在每次自動發布首發時誤觸 |
| `0e27878` | 同步六份文件 | 文件仍描述手動 annotated tag 為唯一路徑，且 README 的發布指南連結指向不存在的檔案 |

### `dcbe2ac` 的判斷矩陣

`檢查既有 GitHub Release` 步驟新增 `stack_published` 輸出（以 assets 中是否已有 `near-chat-stack-vX.Y.Z.tar.gz` 判定），`exists` 保留給「Release 不存在」的備援路徑。**fail-closed 語意完全不變**，只是判準換掉：

| 四個 image | `stack_published` | 行為 |
| --- | --- | --- |
| 皆存在且 digest 一致 | `true` | `build_required=false`（重跑，只驗證） |
| 皆不存在 | `false` | `build_required=true`（首次發布） |
| 皆存在 | `false` | 中止：拒絕包裝或補簽既有 artifact |
| 皆不存在 | `true` | 中止：拒絕以新建置取代既有 artifact |
| 部分存在／digest 不一致 | — | 中止（維持現狀） |

新增的「於既有 Release 補上 Stack artifact」步驟會讀出 semantic-release 寫的 release notes，把 Stack 區段**附加**在後面再寫回，最後上傳 bundle。asset 上傳刻意放最後一步 —— `stack_published` 正是以 asset 判定，讓它成為整個發布的最終提交點。`建立 GitHub Release` 收斂為 `exists == 'false'` 的備援路徑（手動推 tag／復原），內容不變。

順帶修正：release notes 中兩個指向 `docs/backend-release.md`／`docs/ZH-TW/backend-release.md` 的死連結（該檔不存在，正確路徑為 `docs/RELEASE.md`），README 中的同樣兩個死連結，以及 `Depoly bundle` 拼字。

## 相關的 Issue (Related Issue)

Closes #406

## 變更類型 (Type of Change)

- [ ] `feat`: 新增功能 (Feature)
- [ ] `fix`: 修復 Bug
- [ ] `refactor`: 重構代碼
- [x] `docs`: 修改文件
- [ ] `test`: 新增或修正測試案例
- [ ] `chore`: 建置流程或輔助工具變更
- [ ] `perf`: 效能優化
- [x] `ci`: CI 設定變更

## 驗證與測試計畫 (Verification & Test Plan)

### 本地測試 (Local Tests)

本 PR **未變更任何應用程式碼**（只動 `.github/workflows/release-stack.yml` 與六份 Markdown），因此範本中的型別檢查、Linter 與前後端測試對本變更不具鑑別力，未在本地重跑；CI 上這些 job 全數執行且通過（見下方）。

- [ ] 後端型別檢查 — 不適用（未動 `backend/`）
- [ ] 前端型別檢查 — 不適用（未動 `frontend/`）
- [ ] 前端 Linter 檢查 — 不適用（未動 `frontend/`）
- [ ] 單元測試 — 不適用
- [ ] 整合測試 — 不適用

### 針對本變更實際執行的驗證

**1. Workflow 靜態檢查** — `actionlint` 對 `.github/workflows/*.yml` 全數通過（exit 0）；以 `bash -n` 逐一檢查 `release-stack.yml` 中每個 `run:` 區塊的語法，全部通過。

**2. 判斷矩陣實測** — 把 `檢查既有 GitHub Release` 與 `檢查四個不可變映像參照` 兩段 shell 抽出，以假的 `gh`（回傳受控的 release JSON 或 HTTP 404）與假的 `docker buildx imagetools inspect`（回傳 digest 或 `manifest unknown`）跑過六種組合：

```
PROCEED         | 1. Release+bundle, 4 images        → exists=true  stack_published=true  build_required=false
PROCEED         | 2. Release 無 bundle, 無 image      → exists=true  stack_published=false build_required=true
ABORT@registry  | 3. Release 無 bundle, 4 images      → 兩個 image 已存在但 Release 尚未附上 Stack bundle；拒絕包裝或補簽既有 artifact。
ABORT@registry  | 4. Release+bundle, 無 image         → Release 已附上 Stack bundle 但四個 image 參照皆遺失；拒絕以新建置取代既有 artifact。
PROCEED         | 5. 無 Release, 無 image             → exists=false stack_published=false build_required=true
ABORT@registry  | 6. Release 無 bundle, 部分 image     → 完整 Stack 發布不完整或 image digest 不一致，拒絕自動修補。
```

情境 2 是自動發布的正常首發路徑（改動前會在情境 2 被誤判為情境 4 而中止），情境 5 是手動推 tag 的備援路徑。三個中止情境確實 `exit 1`。

**3. Tag 型別 peel 行為實測** — 證明移除 object type 檢查後，緊接其後的 peeled commit 驗證強度不變：

```
lightweight: object type=commit peeled=d2d5fd29fb4a... peeled_type=commit
annotated  : object type=tag    peeled=d2d5fd29fb4a... peeled_type=commit
HEAD       : d2d5fd29fb4a...
```

兩種型別的 `refs/tags/x^{}` 都 peel 到同一個 commit，`git cat-file -t` 都回 `commit`。

**4. Semantic Release 設定載入** — `npx semantic-release --dry-run` 成功載入全部外掛（含**保留**的 `@semantic-release/github`），無 plugin 解析錯誤；因當前分支非 `main` 而正常停在「不會發布新版本」。

**5. CI** — 本 PR 的 16 個 check 全數 success。`release` job 為 `skipped`，屬正確行為（其條件為 `github.ref == 'refs/heads/main' && github.event_name == 'push'`）。

### 手動測試 (Manual Verification)

端到端發布驗證需 #405 與 #407 合併後才做得完整（目前 tag 與 Release 都由 `GITHUB_TOKEN` 產生，不會觸發 `release-stack.yml`）。待驗證項目已列在 #406 的驗收標準中。

## 不在本 PR 範圍 (Out of Scope)

以下三項各自獨立立案，本 PR 刻意不含 —— 這也正是兩則 Codex review 意見指出的內容：

- **#405**：移除 `.releaserc.json` 的 `[skip ci]`、為 `release` job 補 `fetch-depth: 0`（進行中：PR #449）
- **#407**：`ci.yml` → `release-stack.yml` 的 `workflow_run` 橋接與 `workflow_dispatch` 入口。**這是整條鏈的最後一環** —— 本 PR 合併後 `release-stack.yml` 仍需靠 #407 才會被自動觸發
- **#408**：`docs/RELEASE.md` 中英雙語的完整流程改寫（本 PR 只修正了「annotated tag 是硬性要求」與「Release 由誰建立」兩件事實）

完整狀態總表見 #373。

## 資料庫變更 (Database Changes)

* 此變更是否包含資料庫 Schema 修改？ **否**
* 若為是，請寫明 Migration 檔案名稱：不適用
* 是否已確認遷移與 [docs/database-design.md](../docs/database-design.md) 設計一致？ 不適用

## API 與 WebSocket 協定一致性 (API & WebSocket Contract Check)

* 此變更是否涉及 API 路由或 WebSocket 事件的資料結構變更？ **否**
* 是否已確認與 [docs/api-documentation.md](../docs/api-documentation.md) 規範完全一致？ 不適用（未觸及 API 或 Socket.IO 層）