### PR TITLE
ci: 將 frontend-test 納入 release 發布閘門

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,6 +323,7 @@ jobs:
     needs:
       - frontend-lint
       - frontend-typecheck
+      - frontend-test
       - frontend-build
       - backend-build
       - unit-tests
@@ -335,6 +336,7 @@ jobs:
       github.event_name == 'push' &&
       (needs.frontend-lint.result == 'success' || needs.frontend-lint.result == 'skipped') &&
       (needs.frontend-typecheck.result == 'success' || needs.frontend-typecheck.result == 'skipped') &&
+      (needs.frontend-test.result == 'success' || needs.frontend-test.result == 'skipped') &&
       (needs.frontend-build.result == 'success' || needs.frontend-build.result == 'skipped') &&
       (needs.backend-build.result == 'success' || needs.backend-build.result == 'skipped') &&
       (needs.unit-tests.result == 'success' || needs.unit-tests.result == 'skipped') &&


### PR DESCRIPTION
## 摘要

`release` job 的 `needs` 與 `if` 條件都遺漏了 `frontend-test`，導致前端測試失敗時仍會發版。本 PR 補上該閘門。

問題由 Codex 在 #399 的 review 中指出（[review comment](https://github.com/nearcsie/near-chat/pull/399#pullrequestreview-4807470866)），但 `ci.yml` 並非該 PR 的變更內容——它是因為 #399 的 base 分支錯位才被算進 diff。缺陷本身存在於 `main`，故獨立處理。

## 問題說明

`.github/workflows/ci.yml` 的 `release` job 使用 `always()` 搭配逐一檢查 `needs.<job>.result`。在這個模式下，**未列入 `needs` 的 job 對發布判斷完全沒有影響**。

`frontend-test`（L108）是獨立 job，但既不在 `release.needs`，`if` 也未檢查其 `result`。因此只要其餘八個 job 通過，即使 `frontend-test` 失敗或仍在執行，`semantic-release` 仍會建立版本提交、git tag 與 GitHub Release——等於發布一個已被測試判定有回歸的版本。

`frontend-test` 是唯一的遺漏項；其餘所有 job 皆已正確納入。

## 變更內容

比照既有 job 的既有寫法：

- `release.needs` 新增 `frontend-test`
- `if` 新增 `(needs.frontend-test.result == 'success' || needs.frontend-test.result == 'skipped')`

沿用 `success || skipped` 的判斷，保留「前端無變更時 `frontend-test` 被 `changes` 過濾器 skip，發布仍可正常進行」的既有行為。

## 測試計畫

- [x] `yaml.safe_load` 解析 `ci.yml` 通過
- [x] 以程式驗證 `jobs - {changes, release}` 已完全被 `release.needs` 涵蓋，無遺漏
- [x] 以程式驗證 `needs` 中每個 job 都有對應的 `needs.<job>.result` 檢查
- [ ] 合併後觀察下一次 `main` push 的 release 流程

## 風險

僅新增閘門條件，不放寬任何既有檢查。最壞情況是前端測試不穩時會擋下發布，而這正是預期行為。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011SUnoHgqwCbHZoE5Wyr1A5