### PR TITLE
chore(backend): 補上 package 描述並觸發 v2 發布

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "near-chat-backend",
   "version": "1.1.0",
-  "description": "",
+  "description": "Bun + Hono backend API for Near Chat",
   "main": "src/index.ts",
   "scripts": {
     "dev": "bun --watch src/index.ts",


### PR DESCRIPTION
## 問題

PR #461 的 breaking-change commit 已正確合併至 `main`，但該 commit 沒有任何檔案 tree diff。`ci.yml` 使用 push path filtering；零 changed path 的 push 不會建立 `CI` run，因此監聽成功 CI 的 `release.yml` 也沒有機會執行。

## 修正

補上 `backend/package.json` 原本空白的 package description：

```text
Bun + Hono backend API for Near Chat
```

這是有意義且實際位於 `backend/**` 的變更，因此合併後會觸發 backend CI。PR #461 的 `feat(backend)!` 與 `BREAKING CHANGE:` 仍位於 `v1.1.0` 之後，Semantic Release 會在 CI 成功後一併分析。

## 版本影響

以專案實際使用的 `@semantic-release/commit-analyzer` 分析 `v1.1.0..HEAD`：

- release type：`major`
- current：`1.1.0`
- next：`2.0.0`

## 驗證

- `backend/package.json` JSON parse
- `./backend/node_modules/.bin/tsc -p backend/tsconfig.json --noEmit`
- `git diff --check`
- `@semantic-release/commit-analyzer`：`major → 2.0.0`