### PR TITLE
fix: 在串流層強制上傳大小上限，不再信任 Content-Length (#411)

### DIFF
--- a/backend/src/utils/fileUpload.ts
+++ b/backend/src/utils/fileUpload.ts
@@ -33,11 +33,126 @@ export const sanitizeStoredFileName = (rawName: string): string => {
 };
 
 /**
- * Slack allowed between the declared Content-Length and the file's own size, to
- * cover multipart boundaries, part headers and other field values. Generous on
- * purpose: this check only exists to reject the clearly-too-large early.
+ * Slack added on top of `maxBytes` to cover multipart boundaries, part headers
+ * and other field values, which all ride along in the request body.
+ *
+ * This is no longer just a hint for an early exit: it is the authoritative
+ * whole-request bound enforced while reading (see `readUploadForm`). Two
+ * consequences worth keeping in mind before touching the value:
+ *   - It caps the *whole request*, not the file part, so a metadata field
+ *     larger than this alongside a near-limit file reports a size error.
+ *   - The real memory high-water for a rejected upload is
+ *     `maxBytes + MULTIPART_OVERHEAD_ALLOWANCE + one upstream chunk`, because a
+ *     chunk is read before it can be counted. Under `@hono/node-server` a chunk
+ *     is a socket read, so budget another 64 KB.
+ * The exact per-file limit is still `options.maxBytes`, checked on the decoded
+ * `File` below.
  */
 const MULTIPART_OVERHEAD_ALLOWANCE = 64 * 1024;
+
+/**
+ * Media types whose body Hono's `parseBody()` actually reads. Anything else
+ * yields `{}` there without touching the body, and we mirror that: an upload
+ * request with an unrelated content type must still fail as `file is required`
+ * without a single byte being read.
+ */
+const FORM_MEDIA_TYPES = new Set(['multipart/form-data', 'application/x-www-form-urlencoded']);
+
+/** Raised through the body stream once the cap is passed. */
+class UploadSizeExceededError extends Error {}
+
+/** Mutable out-param so the caller can tell "we aborted" from "parse failed". */
+interface CapState {
+  exceeded: boolean;
+}
+
+/**
+ * Wrap a body stream so that no more than `capBytes` is ever handed downstream.
+ *
+ * Counting here rather than after parsing is the whole point of issue #411: the
+ * limit applies to bytes actually read off the wire, so omitting or forging
+ * `Content-Length` (including `Transfer-Encoding: chunked`) cannot bypass it.
+ */
+const capBodyStream = (
+  source: ReadableStream<Uint8Array>,
+  capBytes: number,
+  state: CapState
+): ReadableStream<Uint8Array> => {
+  const reader = source.getReader();
+  let readBytes = 0;
+
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      const { done, value } = await reader.read();
+      if (done) {
+        controller.close();
+        return;
+      }
+
+      readBytes += value.byteLength;
+      if (readBytes > capBytes) {
+        // Stop pulling from the client and fail the parse. Note that
+        // `@hono/node-server` still drains the abandoned request (bounded by its
+        // own 64 MB / 500 ms limits) so the client gets our response rather than
+        // a reset connection; nothing further is buffered by us either way.
+        state.exceeded = true;
+        await reader.cancel().catch(() => {});
+        controller.error(new UploadSizeExceededError('File size limit exceeded'));
+        return;
+      }
+
+      controller.enqueue(value);
+    },
+    cancel(reason) {
+      void reader.cancel(reason);
+    },
+  });
+};
+
+/**
+ * Read the request body as `FormData`, refusing to read past `capBytes`.
+ *
+ * Deliberately parses `c.req.raw.body` into a fresh `Response` instead of
+ * wrapping `c.req.raw` and letting `c.req.parseBody()` run: reassigning
+ * `c.req.raw` with a lazily-pulled stream (the shape `hono/body-limit` uses) was
+ * prototyped against Bun 1.3.11 + Hono 4.12.32 and made `parseBody()` return an
+ * empty body for *valid* uploads.
+ */
+async function readUploadForm(c: Context, capBytes: number | null, state: CapState): Promise<FormData> {
+  const contentType = c.req.header('content-type') ?? '';
+  const mediaType = contentType.split(';')[0].trim().toLowerCase();
+
+  if (!FORM_MEDIA_TYPES.has(mediaType)) {
+    return new FormData();
+  }
+
+  const raw = c.req.raw;
+  if (!raw.body || raw.bodyUsed) {
+    // No stream to meter (bodyless request, or something upstream already read
+    // it). Fall back to the platform parser, which fails exactly as before.
+    return raw.formData();
+  }
+
+  const source = capBytes === null ? raw.body : capBodyStream(raw.body, capBytes, state);
+
+  // Normalise the media type case while preserving parameters like the
+  // boundary, mirroring Hono's own `bufferToFormData`. Without this, an
+  // upper-case `MULTIPART/FORM-DATA` that `parseBody()` accepts today would make
+  // `formData()` throw on the MIME type.
+  const normalizedContentType = contentType.replace(/^[^;]+/, (media) => media.toLowerCase());
+  const form = await new Response(source, {
+    headers: { 'Content-Type': normalizedContentType },
+  }).formData();
+
+  // Leave the result where Hono's parser would have cached it, so a later
+  // `c.req.parseBody()` on this request still resolves even though the raw body
+  // has now been consumed. Hono caches the pending promise here and awaits on
+  // read; storing the settled value is equivalent for that reader and matches
+  // the published `BodyCache` type.
+  c.req.bodyCache.formData = form;
+
+  return form;
+}
 
 export interface ParseFileOptions {
   fieldName?: string;
@@ -54,10 +169,11 @@ export async function parseSingleFile(
 ): Promise<UploadedFile> {
   const fieldName = options.fieldName ?? 'file';
 
-  // Reject obviously oversized uploads before `parseBody()` buffers the whole
-  // request. This is a declared-size check only, so it is a cheap early exit
-  // rather than a real streaming limit; the authoritative check on the decoded
-  // file still runs below. Enforcing the cap at the stream level is issue #411.
+  // Cheap early exit for a client that honestly declares an oversized body: it
+  // costs nothing and reads zero bytes. It is only an optimisation now — the
+  // streaming cap below is what a forged or absent `Content-Length` runs into.
+  // Keep this check first: `fileUpload.test.ts` covers a request whose declared
+  // length lies about a body that would otherwise parse to an empty form.
   if (options.maxBytes) {
     const declaredLength = Number(c.req.header('content-length'));
     if (Number.isFinite(declaredLength) && declaredLength > options.maxBytes + MULTIPART_OVERHEAD_ALLOWANCE) {
@@ -65,8 +181,29 @@ export async function parseSingleFile(
     }
   }
 
-  const body = await c.req.parseBody();
-  const file = body[fieldName];
+  const capState: CapState = { exceeded: false };
+  const capBytes = options.maxBytes ? options.maxBytes + MULTIPART_OVERHEAD_ALLOWANCE : null;
+
+  let form: FormData;
+  try {
+    form = await readUploadForm(c, capBytes, capState);
+  } catch (err) {
+    // `capState.exceeded` is the primary signal; matching the error identity is
+    // only a fallback, since whether the runtime rethrows our exact instance out
+    // of `formData()` is an implementation detail we should not depend on.
+    if (capState.exceeded || err instanceof UploadSizeExceededError) {
+      // Deliberately a 400, byte-identical to the pre-existing rejection, so
+      // this stays a pure security fix. Note `mapError.ts` maps the legacy
+      // Multer `LIMIT_FILE_SIZE` to 413; aligning the two is a separate change
+      // that has to touch the API docs.
+      throw new ValidationError('File size limit exceeded');
+    }
+    throw err;
+  }
+
+  // `getAll(...).at(-1)` keeps `parseBody()`'s last-wins semantics for repeated
+  // fields; `FormData.get()` would return the first instead.
+  const file = form.getAll(fieldName).at(-1);
 
   if (!file || typeof file === 'string') {
     throw new ValidationError('file is required');

--- a/backend/tests/unit/utils/fileUpload.test.ts
+++ b/backend/tests/unit/utils/fileUpload.test.ts
@@ -180,3 +180,267 @@ describe('parseSingleFile size limits', () => {
     expect(res.status).toBe(200);
   });
 });
+
+describe('parseSingleFile streaming size cap', () => {
+  const MAX_BYTES = 4096;
+  const OVERHEAD_ALLOWANCE = 64 * 1024;
+  const RAW_CAP = MAX_BYTES + OVERHEAD_ALLOWANCE;
+  const BOUNDARY = 'boundary411';
+  const MULTIPART_TYPE = `multipart/form-data; boundary=${BOUNDARY}`;
+
+  const makeApp = (options: Parameters<typeof parseSingleFile>[1] = { maxBytes: MAX_BYTES }) => {
+    const app = new Hono();
+    app.onError(errorHandler);
+    app.post('/upload', async (c) => {
+      const file = await parseSingleFile(c, options);
+      return c.json({ size: file.size, name: file.originalname, path: file.path });
+    });
+    return app;
+  };
+
+  /**
+   * A request body the server has to pull chunk by chunk, reporting how many
+   * bytes it actually asked for. That count is the real assertion target here:
+   * it is deterministic, unlike socket-level byte counts, which `@hono/node-server`
+   * distorts by draining an abandoned request after the response is sent.
+   */
+  const meteredBody = (parts: string[], chunkBytes = 16 * 1024) => {
+    const encoder = new TextEncoder();
+    const payload = encoder.encode(parts.join(''));
+    let offset = 0;
+    let pulled = 0;
+
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (offset >= payload.byteLength) {
+          controller.close();
+          return;
+        }
+        const slice = payload.subarray(offset, offset + chunkBytes);
+        offset += slice.byteLength;
+        pulled += slice.byteLength;
+        controller.enqueue(slice);
+      },
+    });
+
+    return { stream, pulled: () => pulled, total: payload.byteLength };
+  };
+
+  const post = (
+    app: Hono,
+    body: ReadableStream<Uint8Array>,
+    headers: Record<string, string>,
+  ) => app.request('/upload', {
+    method: 'POST',
+    headers,
+    body,
+    // A streamed request body has no Content-Length, which is exactly the case
+    // the old declared-size precheck could not police.
+    duplex: 'half',
+  } as RequestInit);
+
+  const filePart = (bytes: number, filename = 'blob.bin') =>
+    `--${BOUNDARY}\r\nContent-Disposition: form-data; name="file"; filename="${filename}"\r\n`
+    + `Content-Type: application/octet-stream\r\n\r\n${'x'.repeat(bytes)}\r\n`;
+
+  const closing = `--${BOUNDARY}--\r\n`;
+
+  /** A well-formed multipart body of an exact total byte length. */
+  const multipartOfExactly = (totalBytes: number, fileBytes: number) => {
+    const fillerHead = `--${BOUNDARY}\r\nContent-Disposition: form-data; name="filler"\r\n\r\n`;
+    const fixed = filePart(fileBytes).length + fillerHead.length + 2 + closing.length;
+    const fillerBytes = totalBytes - fixed;
+    if (fillerBytes < 0) {
+      throw new Error(`cannot build a ${totalBytes}-byte body around a ${fileBytes}-byte file`);
+    }
+    return [filePart(fileBytes), fillerHead, 'y'.repeat(fillerBytes), '\r\n', closing];
+  };
+
+  it('rejects an oversized upload that declares no Content-Length', async () => {
+    const offered = 20 * 1024 * 1024;
+    const body = meteredBody([filePart(offered), closing]);
+    const res = await post(makeApp(), body.stream, { 'content-type': MULTIPART_TYPE });
+
+    expect(res.status).toBe(400);
+    expect((await res.json() as { message?: string }).message).toBe('File size limit exceeded');
+    // The whole point of #411: the body is refused on bytes read, not on a
+    // declared header, so only the cap plus the chunk that tripped it is pulled.
+    expect(body.pulled()).toBeLessThanOrEqual(RAW_CAP + 2 * 16 * 1024);
+    expect(body.pulled()).toBeLessThan(offered);
+  });
+
+  it('rejects an oversized upload whose Content-Length is forged small', async () => {
+    const body = meteredBody([filePart(20 * 1024 * 1024), closing]);
+    const res = await post(makeApp(), body.stream, {
+      'content-type': MULTIPART_TYPE,
+      'content-length': '128',
+    });
+
+    expect(res.status).toBe(400);
+    expect((await res.json() as { message?: string }).message).toBe('File size limit exceeded');
+    expect(body.pulled()).toBeLessThanOrEqual(RAW_CAP + 2 * 16 * 1024);
+  });
+
+  it('accepts a raw body exactly at the cap', async () => {
+    // The cap is exclusive, and the file itself stays well under maxBytes so
+    // only the whole-request bound is under test.
+    const body = meteredBody(multipartOfExactly(RAW_CAP, 1024));
+    const res = await post(makeApp(), body.stream, { 'content-type': MULTIPART_TYPE });
+
+    expect(body.total).toBe(RAW_CAP);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ size: 1024 });
+  });
+
+  it('rejects a raw body one byte past the cap', async () => {
+    const body = meteredBody(multipartOfExactly(RAW_CAP + 1, 1024));
+    const res = await post(makeApp(), body.stream, { 'content-type': MULTIPART_TYPE });
+
+    expect(body.total).toBe(RAW_CAP + 1);
+    expect(res.status).toBe(400);
+    expect((await res.json() as { message?: string }).message).toBe('File size limit exceeded');
+  });
+
+  it('caps an oversized urlencoded body as well', async () => {
+    // `parseBody()` buffers application/x-www-form-urlencoded through the same
+    // full-request `arrayBuffer()` as multipart, so the cap has to cover it too.
+    const offered = 20 * 1024 * 1024;
+    const body = meteredBody([`file=${'y'.repeat(offered)}`]);
+    const res = await post(makeApp(), body.stream, {
+      'content-type': 'application/x-www-form-urlencoded',
+    });
+
+    expect(res.status).toBe(400);
+    expect((await res.json() as { message?: string }).message).toBe('File size limit exceeded');
+    expect(body.pulled()).toBeLessThan(offered);
+  });
+
+  it('does not consume a body whose content type carries no form data', async () => {
+    const offered = 1024 * 1024;
+    const chunkBytes = 16 * 1024;
+    const body = meteredBody([`{"file":"${'z'.repeat(offered)}"}`], chunkBytes);
+    const res = await post(makeApp(), body.stream, { 'content-type': 'application/json' });
+
+    // Same 400 as before the change, and the body is never parsed. Bun's request
+    // dispatch reads one chunk ahead on its own even for a handler that ignores
+    // the body entirely, so one chunk is the floor here, not evidence of a read.
+    expect(res.status).toBe(400);
+    expect((await res.json() as { message?: string }).message).toBe('file is required');
+    expect(body.pulled()).toBeLessThanOrEqual(chunkBytes);
+  });
+
+  it('accepts an upper-case multipart content type', async () => {
+    // `formData()` rejects a non-lowercase media type, so the parser has to
+    // normalise it the way Hono's own `bufferToFormData` does.
+    const body = meteredBody([filePart(512), closing]);
+    const res = await post(makeApp(), body.stream, {
+      'content-type': `MULTIPART/FORM-DATA; boundary=${BOUNDARY}`,
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ size: 512 });
+  });
+
+  it('keeps last-wins semantics for a repeated file field', async () => {
+    const body = meteredBody([
+      filePart(16, 'first.bin'),
+      filePart(64, 'second.bin'),
+      closing,
+    ]);
+    const res = await post(makeApp(), body.stream, { 'content-type': MULTIPART_TYPE });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ size: 64, name: 'second.bin' });
+  });
+
+  it('leaves a zero-byte part to the downstream checks rather than the size cap', async () => {
+    const body = meteredBody([filePart(0), closing]);
+    const res = await post(makeApp(), body.stream, { 'content-type': MULTIPART_TYPE });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ size: 0 });
+  });
+
+  it('still surfaces a malformed multipart body as a parse failure', async () => {
+    // Unchanged behaviour: only the cap maps to a size error; anything else
+    // propagates as it did before.
+    const body = meteredBody(['not-multipart-at-all']);
+    const res = await post(makeApp(), body.stream, { 'content-type': MULTIPART_TYPE });
+
+    expect(res.status).toBe(500);
+  });
+
+  it('does not cap a caller that sets no maxBytes', async () => {
+    const offered = 512 * 1024;
+    const body = meteredBody([filePart(offered), closing]);
+    const res = await post(makeApp({}), body.stream, { 'content-type': MULTIPART_TYPE });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ size: offered });
+  });
+
+  it('lets a later parseBody() reuse the form the cap already parsed', async () => {
+    // The raw body is consumed by the metered read, so the parsed form has to be
+    // left in Hono's body cache or any downstream parseBody() would throw.
+    const app = new Hono();
+    app.onError(errorHandler);
+    app.post('/upload', async (c) => {
+      const file = await parseSingleFile(c, { maxBytes: MAX_BYTES });
+      const again = await c.req.parseBody();
+      return c.json({ size: file.size, keys: Object.keys(again) });
+    });
+
+    const body = meteredBody([filePart(128), closing]);
+    const res = await app.request('/upload', {
+      method: 'POST',
+      headers: { 'content-type': MULTIPART_TYPE },
+      body: body.stream,
+      duplex: 'half',
+    } as RequestInit);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ size: 128, keys: ['file'] });
+  });
+});
+
+describe('parseSingleFile streaming cap with storage', () => {
+  const MAX_BYTES = 4096;
+  const BOUNDARY = 'boundary411store';
+  let uploadDir: string;
+
+  beforeEach(async () => {
+    uploadDir = await fs.mkdtemp(path.join(os.tmpdir(), 'near-chat-cap-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(uploadDir, { recursive: true, force: true });
+  });
+
+  it('stores a streamed upload with a non-ASCII filename under the sanitized name', async () => {
+    // maxBytes and saveToDir together: the capped read has to produce a file the
+    // storage path can still write.
+    const app = new Hono();
+    app.onError(errorHandler);
+    app.post('/upload', async (c) => {
+      const file = await parseSingleFile(c, { maxBytes: MAX_BYTES, saveToDir: uploadDir });
+      return c.json({ path: file.path, filename: file.filename, originalname: file.originalname });
+    });
+
+    const payload = `--${BOUNDARY}\r\nContent-Disposition: form-data; name="file"; filename="測試報告.txt"\r\n`
+      + `Content-Type: text/plain\r\n\r\nhello\r\n--${BOUNDARY}--\r\n`;
+    const res = await app.request('/upload', {
+      method: 'POST',
+      headers: { 'content-type': `multipart/form-data; boundary=${BOUNDARY}` },
+      body: new Response(payload).body!,
+      duplex: 'half',
+    } as RequestInit);
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as { path: string; filename: string; originalname: string };
+    expect(body.originalname).toBe('測試報告.txt');
+    expect(path.dirname(body.path)).toBe(uploadDir);
+    expect(body.filename).toEndWith('.txt');
+    expect(body.filename).not.toInclude('/');
+    expect(await Bun.file(body.path).text()).toBe('hello');
+  });
+});


### PR DESCRIPTION
## 變更描述 (Description)

將上傳大小上限下推到「實際讀取位元組」的那一層，取代原本只檢查宣告值的 `Content-Length` 預檢。

### 根本原因 (Root Cause)

`backend/src/utils/fileUpload.ts` 的 `parseSingleFile()` 原本的順序是：

1. `Content-Length` 預檢（宣告值）
2. `await c.req.parseBody()` — 完整讀取並解碼整個 request body
3. 才比對 `fileObj.size > options.maxBytes`

因此已通過驗證的使用者可以：

- 省略或偽造 `Content-Length`（例如 `Transfer-Encoding: chunked`）繞過步驟 1；
- 即使預檢通過，超量內容仍會在步驟 2 被完整緩衝進記憶體，直到步驟 3 才被拒絕。

本次追加確認到一個原始 issue 未列出的同源問題：Hono 的 `parseBody()` 對
`application/x-www-form-urlencoded` 走的是**同一條**完整緩衝路徑
（`backend/node_modules/hono/dist/utils/body.js` 第 9-10 行分派、第 22 行 `await request.arrayBuffer()`）。
若只對 multipart 設限，同樣的資源耗用問題會原封不動留在 urlencoded 上。

### 變更內容 (What Changed & Why)

僅改動 `backend/src/utils/fileUpload.ts` 一個檔案與其單元測試：

- 新增 `capBodyStream()`：將 `c.req.raw.body` 包上一層計數 `ReadableStream`，累計超過
  `maxBytes + MULTIPART_OVERHEAD_ALLOWANCE` 時立即 `reader.cancel()` 上游並讓解析失敗。
  限制作用在「已讀取的位元組」上，所以偽造或省略 `Content-Length` 無法繞過。
- 新增 `readUploadForm()`：以 `new Response(cappedStream, { headers }).formData()` 解析，
  同時涵蓋 `multipart/form-data` 與 `application/x-www-form-urlencoded`。
- 超量時映射回既有的 `ValidationError('File size limit exceeded')`，**狀態碼與訊息與變更前完全相同**。
  判斷以 `capState.exceeded` 旗標為主、錯誤型別比對為輔，避免正確性依賴 runtime 是否原樣拋回自訂錯誤實例。
- 保留原本的 `Content-Length` 預檢作為零成本的提早退出，並保留 `fileObj.size > maxBytes`
  作為權威的「單檔」上限（串流上限是「整個 request」的上限）。

為維持行為完全一致而必要的處理：

- **媒體型別轉小寫**：比照 Hono 自己的 `bufferToFormData`（`utils/buffer.js` 第 68 行）。
  未做這件事會造成回歸 — 實測 `parseBody()` 可以接受大寫 `MULTIPART/FORM-DATA`（回 200），
  但直接交給 `formData()` 會拋 `Can't decode form data from body because of incorrect MIME type`。
- **`getAll(field).at(-1)`**：保留 `parseBody()` 重複欄位的 last-wins 語意
  （實測 `parseBody()` 取最後一個、`FormData.get()` 取第一個）。
- **回填 `c.req.bodyCache.formData`**：原始 body 已被讀走，不回填會讓後續任何
  `c.req.parseBody()` 拋錯。Hono 讀取該欄位時會 `await`，故存入已結算的值即可。
- **非表單媒體型別不讀 body**：維持原本的 `400 file is required`。

## 相關的 Issue (Related Issue)

Closes #411

## 變更類型 (Type of Change)

請勾選適用的選項：
- [ ] `feat`: 新增功能 (Feature)
- [x] `fix`: 修復 Bug
- [ ] `refactor`: 重構代碼
- [ ] `docs`: 修改文件
- [x] `test`: 新增或修正測試案例
- [ ] `chore`: 建置流程或輔助工具變更
- [ ] `perf`: 效能優化
- [ ] `ci`: CI 設定變更

## 驗證與測試計畫 (Verification & Test Plan)

### 本地測試 (Local Tests)

此環境為雲端 checkout，**沒有 Docker**，因此以下項目是在 `backend/` 直接以 bun 執行，
而非透過 `docker compose exec`。整合測試與 E2E 測試需要 `db-test`，請 reviewer 在
Docker 測試環境中執行。

- [x] 後端型別檢查（`bun x tsc --noEmit`，無錯誤）
- [x] 後端 Linter（`bun x eslint src/utils/fileUpload.ts`，無錯誤）
- [x] 單元測試 `tests/unit/utils/fileUpload.test.ts`：**29 pass / 0 fail**（變更前為 16 pass）
- [x] 完整單元測試層 `bun test tests/unit`：**434 pass / 5 fail**
- [ ] 前端型別檢查 / Linter：未執行，本 PR 未改動 frontend
- [ ] 整合測試（`test:integration`，需 Docker + `db-test`）：**未執行，請 reviewer 補跑**

關於那 5 個失敗：全部在 `tests/unit/utils/avatarUpload.test.ts`（`saveAvatarUpload`、
`removeManagedAvatar`）。已用 `git stash` 在**未修改**的樹上重跑同一指令確認為既有問題
（乾淨樹：421 pass / 5 fail；本 PR：434 pass / 5 fail — 相同的 5 個），
且單獨執行 `bun test tests/unit/utils/avatarUpload.test.ts` 時 14 pass / 0 fail，
屬 `backend/tests/CLAUDE.md` 已記載的單一 process 內 `mock.module()` 跨檔污染，與本變更無關。

### 新增測試 (New Tests)

`tests/unit/utils/fileUpload.test.ts` 新增 13 個案例。斷言對象是「串流生產端被拉取了多少位元組」
這個確定性數值，而非 socket 層位元組數（後者會被 `@hono/node-server` 的 drain 行為干擾）：

- 無 `Content-Length` 的超量上傳被拒，且拉取量遠低於提供量
- `Content-Length` 被偽造成很小、實際 body 很大時仍被拒
- 原始 body 恰好等於上限時通過；超過一個位元組時被拒（上限為 exclusive）
- 超量 `application/x-www-form-urlencoded` 同樣被上限攔下
- 非表單 content type 不會消耗 body（維持 `400 file is required`）
- 大寫 `MULTIPART/FORM-DATA` 仍可正常上傳（回歸防護）
- 重複 `file` 欄位維持 last-wins
- 零位元組 part 交給下游檢查，而非誤判為大小錯誤
- 格式錯誤的 multipart 仍照舊拋出解析失敗
- 未設定 `maxBytes` 的呼叫端不受限
- 後續的 `parseBody()` 仍可取用已解析的 form
- `maxBytes` 與 `saveToDir` 併用時，中文檔名可正確落地為 sanitized 名稱

### 手動測試 (Manual Verification)

以 `node:http` `createServer` + `getRequestListener(honoApp.fetch)`（與 `src/index.ts` 相同的組裝方式）
啟動真實伺服器，套用頭像上限 2 MB 實測：

| 情境 | 結果 |
| :--- | :--- |
| chunked multipart，提供 40 MB，無 `Content-Length` | `400 File size limit exceeded`；客戶端僅推送 2.2 MB 即被拒，耗時 32ms |
| chunked urlencoded，提供 40 MB | `400`；客戶端僅推送 0.1 MB |
| 正常小檔上傳（1234 bytes） | `200` |
| 恰好等於 2 MB 上限（2,097,152 bytes） | `200` |

## 資料庫變更 (Database Changes)

* 此變更是否包含資料庫 Schema 修改？ **否**
* 若為是，請寫明 Migration 檔案名稱：`N/A`
* 是否已確認遷移與 [docs/database-design.md](../docs/database-design.md) 設計一致？ **N/A**

## API 與 WebSocket 協定一致性 (API & WebSocket Contract Check)

* 此變更是否涉及 API 路由或 WebSocket 事件的資料結構變更？ **否**
* 是否已確認與 [docs/api-documentation.md](../docs/api-documentation.md) 規範完全一致？ **是**

拒絕時的狀態碼與訊息刻意維持 `400` / `File size limit exceeded` 不變，故無需更新 API 文件與前端。
已確認 `File size limit exceeded` 這個字串只出現在 `fileUpload.ts` 與其測試中，
未出現於 `docs/` 或 `frontend/`；`frontend/src/lib/api.ts` 的 `request()` 只對 `401` 做狀態碼分支。

## 架構審查意見 (Advisor Notes)

實作前先做了一輪架構審查，以下每一項都已在本次執行中重新驗證，並已反映到程式碼或本說明中：

1. **原先只針對 multipart 設限的方案會留下漏洞。** urlencoded 走同一條
   `arrayBuffer()` 緩衝路徑，等於把同樣的問題搬家而非修掉。已改為兩種媒體型別都設限。
2. **大寫媒體型別會造成回歸。** 若不做小寫正規化，現行可用的大寫
   `MULTIPART/FORM-DATA` 上傳會從 200 變成 500。已加上並補測試。
3. **`hono/body-limit` 已評估後排除**（已安裝於 4.12.32）。原因有兩個：
   它在有 `Content-Length` 且無 `Transfer-Encoding` 時**直接信任該標頭**
   （`middleware/body-limit/index.js` 第 17-21 行），正是本 issue 要修掉的行為；
   且其預設 `onError` 拋出的 `HTTPException` 不是 `AppError`，在本專案的
   `mapError.ts` 會落到未知錯誤分支變成 500。
4. **「包裝 `c.req.raw` 後照舊呼叫 `parseBody()`」的寫法已實作原型並確認不可行**：
   在 Bun 1.3.11 + Hono 4.12.32 下，*合法*上傳會讓 `parseBody()` 回傳空 body。
   因此本 PR 直接讀 `c.req.raw.body` 並餵給新的 `Response`，不碰 `c.req.raw`。
5. **對外聲明的界線要誠實。** 合法上傳的檔案內容依設計仍會完整進記憶體
   （`formData()` 一份、`fileObj.arrayBuffer()` 再一份，下游 `Bun.write` 與頭像壓縮都需要 buffer）。
   本 PR 真正改變的是：上限作用在**已讀取的位元組**而非宣告標頭，且**被拒絕**請求的
   記憶體高水位從「無上限」降為「上限 + 一個 chunk」。
6. **入口頻寬仍有殘留風險。** 被放棄的 request 由 `@hono/node-server` 自行 drain
   （`MAX_DRAIN_BYTES = 64 MB`、`DRAIN_TIMEOUT_MS = 500`，已在 `dist/index.mjs` 第 664-665 行確認）。
   這也是客戶端拿到乾淨 400 而非連線重置的原因。本 PR 不聲稱修掉 slowloris。
7. **Issue 驗收條件三的前提有誤，且刻意不處理。** 只有附件上限來自環境變數
   （`ATTACHMENT_MAX_BYTES`）；頭像上限是 `avatarUpload.ts:8` 的硬編碼常數
   `AVATAR_UPLOAD_MAX_BYTES`。為滿足字面敘述而新增 `AVATAR_MAX_BYTES` 環境變數屬範圍蔓延，故未做。
8. **建議的後續項目（本 PR 不做）：** `mapError.ts` 目前已把舊 Multer 的
   `LIMIT_FILE_SIZE` 映射為 `413`，與上傳上限回 `400` 並不一致。統一為 `413`
   需要同步更新 `docs/api-documentation.md` 與其 ZH-TW 版本，適合另開一個 issue 處理。

Generated with Claude Code (https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TLieWv3YDAdD3DvjiBGCD1)_