### PR TITLE
fix: 以注入 AvatarStore 消除 unit tests 跨檔案 mock 污染 (#467)

### DIFF
--- a/backend/src/services/roomService.ts
+++ b/backend/src/services/roomService.ts
@@ -2,7 +2,7 @@ import type { UploadedFile } from '../utils/fileUpload';
 import type { Room, RoomInvitePreview, RoomSummary } from '@shared/types';
 import { randomBytes } from 'crypto';
 import { isUserOnline } from '../realtime/presence';
-import { removeManagedAvatar, saveAvatarUpload } from '../utils/avatarUpload';
+import { defaultAvatarStore, type AvatarStore } from '../utils/avatarUpload';
 import type { IRoomRepository } from '../models/IRoomRepository';
 import type { IRoomMemberRepository } from '../models/IRoomMemberRepository';
 import type { IUserRepository } from '../models/IUserRepository';
@@ -31,6 +31,7 @@ export const makeRoomService = (
   // Used to notify users of events they cannot receive via room broadcast (e.g., being
   // approved into a group they haven't joined yet).
   emitToUser?: (userId: string, eventName: string, payload: unknown) => void,
+  avatarStore: AvatarStore = defaultAvatarStore,
 ) => {
   const ensureMember = async (roomId: string, userId: string) => {
     const existing = await roomMemberRepo.findMember(roomId, userId);
@@ -415,19 +416,19 @@ export const makeRoomService = (
         throw new ForbiddenError('Only owner or admin can update room avatar');
       }
 
-      const avatarUrl = await saveAvatarUpload(roomId, file);
+      const avatarUrl = await avatarStore.saveAvatarUpload(roomId, file);
 
       try {
         const updated = await repo.update(roomId, { avatarUrl });
         if (room.avatarUrl && room.avatarUrl !== avatarUrl) {
-          await removeManagedAvatar(room.avatarUrl);
+          await avatarStore.removeManagedAvatar(room.avatarUrl);
         }
         if (emitRoomEvent) {
           emitRoomEvent(roomId, 'room_update', { type: 'ROOM_AVATAR_UPDATED', data: { roomId, avatarUrl } });
         }
         return updated;
       } catch (error) {
-        await removeManagedAvatar(avatarUrl);
+        await avatarStore.removeManagedAvatar(avatarUrl);
         throw error;
       }
     },

--- a/backend/src/services/userService.ts
+++ b/backend/src/services/userService.ts
@@ -16,7 +16,7 @@ import type {
 } from '../../../shared/types';
 
 import { ConflictError, NotFoundError, ValidationError } from '../utils/AppError';
-import { removeManagedAvatar, saveAvatarUpload } from '../utils/avatarUpload';
+import { defaultAvatarStore, type AvatarStore } from '../utils/avatarUpload';
 import {
   updateMeSchema,
   updateSettingsSchema,
@@ -81,6 +81,7 @@ export const makeUserService = (
   notifyEmergencyContact?: (contactId: string, payload: { userId: string; message: string }) => void | Promise<void>,
   friendRepo?: { getFriends(userId: string): Promise<FriendResponse[]> },
   onUserUpdated?: (userId: string, data: { name?: string; avatarUrl?: string }) => void | Promise<void>,
+  avatarStore: AvatarStore = defaultAvatarStore,
 ) => {
   const notifyContacts = async (userId: string, fallbackMessage: string): Promise<EmergencyAlertResult> => {
     const user = await repo.findById(userId);
@@ -247,7 +248,7 @@ export const makeUserService = (
         throw new NotFoundError('user', userId);
       }
 
-      const avatarUrl = await saveAvatarUpload(userId, file);
+      const avatarUrl = await avatarStore.saveAvatarUpload(userId, file);
 
       try {
         const updated = await repo.update(userId, { avatarUrl });
@@ -256,11 +257,11 @@ export const makeUserService = (
           onUserUpdated(userId, { name: profile.name, avatarUrl: profile.avatarUrl });
         }
         if (currentUser.avatarUrl && currentUser.avatarUrl !== avatarUrl) {
-          await removeManagedAvatar(currentUser.avatarUrl, userId);
+          await avatarStore.removeManagedAvatar(currentUser.avatarUrl, userId);
         }
         return profile;
       } catch (error) {
-        await removeManagedAvatar(avatarUrl, userId);
+        await avatarStore.removeManagedAvatar(avatarUrl, userId);
         throw error;
       }
     },

--- a/backend/src/utils/avatarUpload.ts
+++ b/backend/src/utils/avatarUpload.ts
@@ -142,3 +142,25 @@ export const removeManagedAvatar = async (
     }
   }
 };
+
+/**
+ * The avatar side effects a service needs, as an injectable seam.
+ *
+ * Services take this instead of importing `saveAvatarUpload` /
+ * `removeManagedAvatar` directly so their unit tests can pass a stub through
+ * the factory. The alternative — `mock.module('../utils/avatarUpload', ...)` —
+ * mutates Bun's process-global module registry, so it also replaces the real
+ * implementation for every other test file in the same `bun test` process and
+ * cannot be undone (re-registering the original module does not restore the
+ * binding). That made this module's own tests pass or fail purely on test-file
+ * enumeration order. See issue #467.
+ */
+export interface AvatarStore {
+  saveAvatarUpload(ownerId: string, file: UploadedFile): Promise<string>;
+  removeManagedAvatar(avatarUrl?: string, ownerId?: string): Promise<void>;
+}
+
+export const defaultAvatarStore: AvatarStore = {
+  saveAvatarUpload,
+  removeManagedAvatar,
+};

--- a/backend/tests/CLAUDE.md
+++ b/backend/tests/CLAUDE.md
@@ -21,6 +21,7 @@ Bun test integration tests for the backend service layer. Tests call the actual 
 - Tests require a live PostgreSQL database; start the test DB with `docker compose -f docker-compose.test.yml up -d` before running.
 - Run all tests from `backend/`: `bun run test` for a single pass. It runs the unit, integration and e2e tiers as three separate processes on purpose — a bare `bun test` loads all three into one runner, where the unit tier's process-global `mock.module()` calls leak into the tiers that need a real database.
 - Test isolation: each suite creates a unique named record in `beforeAll` and deletes it in `afterAll`. Avoid using names like "TestRoomForAPI" or "TestUserAPI" in manual DB operations to prevent conflicts.
+- Do not reach for `mock.module()` to stub a collaborator. It is process-global *within* a tier too, and it cannot be undone: re-registering the module in `afterAll` via the `?original` specifier does not restore the binding, so every later test file in the same process keeps the stub. That made `utils/avatarUpload.test.ts` pass or fail purely on test-file enumeration order (issue #467). Inject the collaborator instead — give the service factory a trailing optional parameter that defaults to the real implementation (see `AvatarStore` / `defaultAvatarStore` in `src/utils/avatarUpload.ts`), and pass a stub from the test.
 
 ### Testing Requirements
 - `DATABASE_URL_TEST` env var must be set before running tests (points to the ephemeral test DB). Copy `.env.test.example` to `.env.test`.

--- a/backend/tests/unit/services/roomService.test.ts
+++ b/backend/tests/unit/services/roomService.test.ts
@@ -4,12 +4,6 @@ import { ConflictError, ForbiddenError, NotFoundError, ValidationError } from '.
 import type { IRoomRepository } from '../../../src/models/IRoomRepository';
 import type { IRoomMemberRepository } from '../../../src/models/IRoomMemberRepository';
 import type { Room, RoomMember } from '../../../../shared/types';
-import { saveAvatarUpload, removeManagedAvatar } from '../../../src/utils/avatarUpload';
-
-mock.module('../../../src/utils/avatarUpload', () => ({
-  saveAvatarUpload: mock(),
-  removeManagedAvatar: mock(),
-}));
 
 mock.module('../../../src/realtime/presence', () => ({
   isUserOnline: mock().mockReturnValue(false),
@@ -17,7 +11,6 @@ mock.module('../../../src/realtime/presence', () => ({
 
 afterAll(() => {
   mock.module('../../../src/realtime/presence', () => require('../../../src/realtime/presence?original'));
-  mock.module('../../../src/utils/avatarUpload', () => require('../../../src/utils/avatarUpload?original'));
 });
 
 type Mocked<T> = {
@@ -28,6 +21,10 @@ describe('roomService', () => {
   let mockRepo: Mocked<IRoomRepository>;
   let mockMemberRepo: Mocked<IRoomMemberRepository>;
   let roomService: ReturnType<typeof makeRoomService>;
+  // Injected instead of `mock.module('../../../src/utils/avatarUpload', ...)`:
+  // module mocks are process-global in Bun and cannot be undone, so stubbing
+  // the module here also stubbed it for avatarUpload.test.ts. See issue #467.
+  let avatarStore: any;
 
   const room: Room = {
     roomId: 'room-1',
@@ -66,7 +63,13 @@ describe('roomService', () => {
       remove: mock(),
       resolveMentions: mock(),
     };
-    roomService = makeRoomService(mockRepo, mockMemberRepo);
+    avatarStore = {
+      saveAvatarUpload: mock(),
+      removeManagedAvatar: mock(),
+    };
+    roomService = makeRoomService(
+      mockRepo, mockMemberRepo, undefined, undefined, undefined, undefined, undefined, avatarStore,
+    );
   });
 
   it('create validates input, trims name, and applies defaults', async () => {
@@ -415,10 +418,7 @@ describe('roomService', () => {
         originalname: 'avatar.png',
       } as any;
 
-      ((saveAvatarUpload as any) as Mock<any>).mockClear();
-      ((removeManagedAvatar as any) as Mock<any>).mockClear();
-      
-      ((saveAvatarUpload as any) as Mock<any>).mockResolvedValue('/uploads/avatars/new-avatar.png');
+      avatarStore.saveAvatarUpload.mockResolvedValue('/uploads/avatars/new-avatar.png');
     });
 
     it('updates room avatar successfully by owner', async () => {
@@ -432,7 +432,7 @@ describe('roomService', () => {
 
       expect(mockRepo.findById).toHaveBeenCalledWith('room-1');
       expect(mockMemberRepo.findMember).toHaveBeenCalledWith('room-1', 'user-1');
-      expect(saveAvatarUpload).toHaveBeenCalledWith('room-1', mockFile);
+      expect(avatarStore.saveAvatarUpload).toHaveBeenCalledWith('room-1', mockFile);
       expect(mockRepo.update).toHaveBeenCalledWith('room-1', { avatarUrl: '/uploads/avatars/new-avatar.png' });
       expect(result.avatarUrl).toBe('/uploads/avatars/new-avatar.png');
     });
@@ -474,7 +474,7 @@ describe('roomService', () => {
       mockRepo.update.mockRejectedValue(new Error('DB failure'));
 
       await expect(roomService.uploadAvatar('room-1', 'user-1', mockFile)).rejects.toThrow('DB failure');
-      expect(removeManagedAvatar).toHaveBeenCalledWith('/uploads/avatars/new-avatar.png');
+      expect(avatarStore.removeManagedAvatar).toHaveBeenCalledWith('/uploads/avatars/new-avatar.png');
     });
 
     it('deletes old avatar after successful update', async () => {
@@ -487,7 +487,7 @@ describe('roomService', () => {
 
       await roomService.uploadAvatar('room-1', 'user-1', mockFile);
 
-      expect(removeManagedAvatar).toHaveBeenCalledWith('/uploads/avatars/old-avatar.png');
+      expect(avatarStore.removeManagedAvatar).toHaveBeenCalledWith('/uploads/avatars/old-avatar.png');
     });
   });
 
@@ -810,8 +810,10 @@ describe('roomService', () => {
   describe('uploadAvatar with emitRoomEvent', () => {
     it('emits ROOM_AVATAR_UPDATED event when emitRoomEvent is provided', async () => {
       const emitRoomEvent = mock();
-      const serviceWithEmit = makeRoomService(mockRepo, mockMemberRepo, emitRoomEvent);
-      ((saveAvatarUpload as any) as Mock<any>).mockResolvedValue('/uploads/avatars/new.png');
+      const serviceWithEmit = makeRoomService(
+        mockRepo, mockMemberRepo, emitRoomEvent, undefined, undefined, undefined, undefined, avatarStore,
+      );
+      avatarStore.saveAvatarUpload.mockResolvedValue('/uploads/avatars/new.png');
       const updated = { ...room, avatarUrl: '/uploads/avatars/new.png' };
       mockRepo.findById.mockResolvedValue(room);
       mockMemberRepo.findMember.mockResolvedValue(ownerMember);

--- a/backend/tests/unit/services/userService.test.ts
+++ b/backend/tests/unit/services/userService.test.ts
@@ -1,5 +1,5 @@
 import type { UploadedFile } from '../../../src/utils/fileUpload';
-import { describe, it, expect, beforeEach, afterAll, mock, type Mock } from 'bun:test';
+import { describe, it, expect, beforeEach, mock, type Mock } from 'bun:test';
 
 import { ConflictError, NotFoundError, ValidationError } from '../../../src/utils/AppError';
 import type { IEmergencyContactRepository } from '../../../src/models/IEmergencyContactRepository';
@@ -7,19 +7,13 @@ import type { IUserRepository } from '../../../src/models/IUserRepository';
 import { makeUserService } from '../../../src/services/userService';
 import { loginSchema, registerSchema } from '../../../src/routes/userSchemas';
 import type { User } from '../../../../shared/types';
-import { saveAvatarUpload, removeManagedAvatar } from '../../../src/utils/avatarUpload';
-
-mock.module('../../../src/utils/avatarUpload', () => ({
-  saveAvatarUpload: mock(),
-  removeManagedAvatar: mock().mockResolvedValue(undefined),
-}));
-
-afterAll(() => {
-  mock.module('../../../src/utils/avatarUpload', () => require('../../../src/utils/avatarUpload?original'));
-});
 
 describe('userService', () => {
   let mockRepo: any;
+  // Injected instead of `mock.module('../../../src/utils/avatarUpload', ...)`:
+  // module mocks are process-global in Bun and cannot be undone, so stubbing
+  // the module here also stubbed it for avatarUpload.test.ts. See issue #467.
+  let avatarStore: any;
   let emergencyContactRepo: any;
   let mockRefreshTokenRepo: any;
   let mockJwt: { signToken: Mock<any>; generateRefreshToken: Mock<any>; hashToken: Mock<any> };
@@ -93,12 +87,19 @@ describe('userService', () => {
     mockJwt.generateRefreshToken.mockReturnValue('fake-refresh-token');
     mockJwt.hashToken.mockImplementation((t: string) => `hashed-${t}`);
     notifyEmergencyContact = mock();
+    avatarStore = {
+      saveAvatarUpload: mock(),
+      removeManagedAvatar: mock().mockResolvedValue(undefined),
+    };
     userService = makeUserService(
       mockRepo,
       emergencyContactRepo,
       mockRefreshTokenRepo,
       mockJwt,
-      notifyEmergencyContact
+      notifyEmergencyContact,
+      undefined,
+      undefined,
+      avatarStore
     );
   });
 
@@ -719,36 +720,30 @@ describe('userService', () => {
   describe('uploadAvatar', () => {
     const fakeFile = { originalname: 'avatar.png', buffer: Buffer.from('data') } as UploadedFile;
 
-    beforeEach(() => {
-      ((saveAvatarUpload as any) as Mock<any>).mockClear();
-      ((removeManagedAvatar as any) as Mock<any>).mockClear();
-      ((removeManagedAvatar as any) as Mock<any>).mockResolvedValue(undefined);
-    });
-
     it('throws NotFoundError when user does not exist', async () => {
       mockRepo.findById.mockResolvedValue(null);
       await expect(userService.uploadAvatar('u1', fakeFile)).rejects.toThrow(NotFoundError);
-      expect(saveAvatarUpload).not.toHaveBeenCalled();
+      expect(avatarStore.saveAvatarUpload).not.toHaveBeenCalled();
     });
 
     it('does not remove previous avatar when user had no avatarUrl', async () => {
       const user = { ...baseUser(), avatarUrl: undefined };
       const newUrl = '/uploads/avatars/u1-new.png';
       mockRepo.findById.mockResolvedValue(user);
-      ((saveAvatarUpload as any) as Mock<any>).mockResolvedValue(newUrl);
+      avatarStore.saveAvatarUpload.mockResolvedValue(newUrl);
       mockRepo.update.mockResolvedValue({ ...user, avatarUrl: newUrl });
       await userService.uploadAvatar('u1', fakeFile);
-      expect(removeManagedAvatar).not.toHaveBeenCalledWith(undefined, 'u1');
+      expect(avatarStore.removeManagedAvatar).not.toHaveBeenCalledWith(undefined, 'u1');
     });
 
     it('removes newly uploaded avatar and rethrows when repo.update fails', async () => {
       const user = { ...baseUser(), avatarUrl: '/old-avatar.png' };
       const newUrl = '/uploads/avatars/u1-new.png';
       mockRepo.findById.mockResolvedValue(user);
-      ((saveAvatarUpload as any) as Mock<any>).mockResolvedValue(newUrl);
+      avatarStore.saveAvatarUpload.mockResolvedValue(newUrl);
       mockRepo.update.mockRejectedValue(new Error('DB failure'));
       await expect(userService.uploadAvatar('u1', fakeFile)).rejects.toThrow('DB failure');
-      expect(removeManagedAvatar).toHaveBeenCalledWith(newUrl, 'u1');
+      expect(avatarStore.removeManagedAvatar).toHaveBeenCalledWith(newUrl, 'u1');
     });
   });
 
@@ -828,22 +823,16 @@ describe('userService', () => {
   describe('uploadAvatar with onUserUpdated and old avatar removal', () => {
     const fakeFile = { originalname: 'avatar.png', buffer: Buffer.from('data') } as UploadedFile;
 
-    beforeEach(() => {
-      ((saveAvatarUpload as any) as Mock<any>).mockClear();
-      ((removeManagedAvatar as any) as Mock<any>).mockClear();
-      ((removeManagedAvatar as any) as Mock<any>).mockResolvedValue(undefined);
-    });
-
     it('calls onUserUpdated callback on successful upload', async () => {
       const onUserUpdated = mock();
       const serviceWithCb = makeUserService(
         mockRepo, emergencyContactRepo, mockRefreshTokenRepo, mockJwt,
-        undefined, undefined, onUserUpdated,
+        undefined, undefined, onUserUpdated, avatarStore,
       );
       const user = { ...baseUser(), avatarUrl: undefined };
       const newUrl = '/uploads/avatars/u1-new.png';
       mockRepo.findById.mockResolvedValue(user);
-      ((saveAvatarUpload as any) as Mock<any>).mockResolvedValue(newUrl);
+      avatarStore.saveAvatarUpload.mockResolvedValue(newUrl);
       mockRepo.update.mockResolvedValue({ ...user, avatarUrl: newUrl });
       await serviceWithCb.uploadAvatar('u1', fakeFile);
       expect(onUserUpdated).toHaveBeenCalledWith('u1', expect.objectContaining({ avatarUrl: newUrl }));
@@ -854,10 +843,10 @@ describe('userService', () => {
       const newUrl = '/uploads/avatars/new.png';
       const user = { ...baseUser(), avatarUrl: oldUrl };
       mockRepo.findById.mockResolvedValue(user);
-      ((saveAvatarUpload as any) as Mock<any>).mockResolvedValue(newUrl);
+      avatarStore.saveAvatarUpload.mockResolvedValue(newUrl);
       mockRepo.update.mockResolvedValue({ ...user, avatarUrl: newUrl });
       await userService.uploadAvatar('u1', fakeFile);
-      expect(removeManagedAvatar).toHaveBeenCalledWith(oldUrl, 'u1');
+      expect(avatarStore.removeManagedAvatar).toHaveBeenCalledWith(oldUrl, 'u1');
     });
   });
 


### PR DESCRIPTION
## 變更描述 (Description)

`bun test tests/unit` 整批執行時，`tests/unit/utils/avatarUpload.test.ts` 會有 5 項失敗；但單獨執行同一個檔案則 14 項全數通過。本 PR 移除造成此差異的跨檔案 mock 污染。

### 根因

`tests/unit/services/userService.test.ts` 與 `tests/unit/services/roomService.test.ts` 都在模組頂層呼叫：

```ts
mock.module('../../../src/utils/avatarUpload', () => ({
  saveAvatarUpload: mock(),
  removeManagedAvatar: mock(),
}));
```

Bun 的 `mock.module()` 改寫的是 **process-global 的 module registry**，因此同一個 `bun test` 行程內所有後續載入的測試檔案都會拿到 stub。兩個檔案雖然都在 `afterAll` 內嘗試以 `require('...?original')` 重新註冊原模組還原，但**該還原並未生效**。

本次實測驗證（在測試檔案內加入 console.log 標記後執行整批測試，確認實際順序，事後已還原工作區）：

```
ORDER: roomService afterAll restore
ORDER: userService afterAll restore
ORDER: avatarUpload file loaded
```

兩個 restore hook 都在 `avatarUpload.test.ts` 載入**之前**就已執行完畢，該檔案仍然拿到 stub。失敗樣態也與 stub 完全吻合：`saveAvatarUpload` 回傳 `undefined` 而非 `.webp` 路徑、應當 reject 的案例全部 resolve、`removeManagedAvatar` 沒有真的刪檔。

因果關係以隔離實驗確認：僅將這兩處 `mock.module('.../avatarUpload', ...)` 暫時停用後重跑整批測試，`avatarUpload.test.ts` 的 5 項失敗**全部消失**，只剩下 13 項確實需要 stub 的 `uploadAvatar` service 測試失敗（實驗後工作區已還原乾淨）。

補充一點次要風險：`mock.module` 取代的是**整個模組**，不只那兩個函式。`avatarUpload.ts` 另外匯出 `AVATAR_UPLOAD_MAX_BYTES`、`ALLOWED_AVATAR_MIME_TYPES`、`avatarContentType`、`assertValidAvatarUpload`，分別被 `src/routes/userRoutes.ts`、`src/routes/roomRoutes.ts`、`src/index.ts` 使用。目前 `routes/` 剛好在 `services/` 之前載入所以尚未引爆，本 PR 一併消除這個潛在地雷。

### 為什麼 CI 目前是綠的

`main` 最新一次 CI run（`6a4898d`）的 `unit-tests` job 確實有執行 `pnpm --filter near-chat-backend test:unit` 且結果為 success。這不代表問題不存在，而是**測試檔案列舉順序**在不同環境不同：CI 上 `utils/` 先於 `services/` 載入時就不會踩到。本沙箱環境重現的正是會引爆的順序。這也正是 issue #467 所指的「測試結果不應依賴檔案執行順序」——問題是潛伏的 order-dependent flake，而非只在某個 Bun 版本出現。

已使用 CI 與 Dockerfile 所釘選的 **Bun 1.3.14**（自 npm `@oven/bun-linux-x64@1.3.14` 取得）重現：修正前 431 pass / 5 fail，與沙箱預設的 Bun 1.3.11 完全一致。

### 修正方式

依照 `backend/src/CLAUDE.md` 既有慣例（「Always write unit tests by mocking interfaces」）改為工廠注入，不再改寫全域 module registry：

- `src/utils/avatarUpload.ts`：新增 `AvatarStore` 介面與 `defaultAvatarStore`。
- `src/services/userService.ts`、`src/services/roomService.ts`：各新增一個帶預設值的尾端參數 `avatarStore: AvatarStore = defaultAvatarStore`，`uploadAvatar` 內改走 `avatarStore.*`。
- 兩個 service unit test：刪除 `mock.module` 與失效的 `afterAll` 還原，改在 `beforeEach` 建立 stub 並注入。
- `backend/tests/CLAUDE.md`：補上「不要用 `mock.module()` stub 協作者」的說明，避免同類問題再度出現。

刻意**未**變更的部分：

- `removeManagedAvatar` 的呼叫 arity 維持原狀（`roomService` 傳 1 個參數、`userService` 傳 2 個）。`roomService` 未傳 `ownerId` 是既有的小缺口，但那是行為變更，不應混在測試基礎建設的 PR 內，建議另開 issue 追蹤。
- `roomService.test.ts` 對 `src/realtime/presence` 的 `mock.module` 維持原狀。這是同一類的全域洩漏，但目前沒有造成任何失敗，且要修必須連同 `socketServer.test.ts` 與 `presence.test.ts`（後者直接 `import ... from '.../presence?original'`）一起改，超出單一可審查 PR 的範圍，建議另開 follow-up。
- issue #467 內文提到的 `inactivityJob.test.ts`：本次實測**無法重現**其順序相依。該檔案單獨執行、整批執行、以及與 `socketServer.test.ts` 兩種 CLI 順序組合執行皆全數通過，其相依皆已透過 `startInactivityJob(repo, service, intervalMs)` 注入。判定該描述對目前程式碼已過時，故未變更。

`src/index.ts` 與 e2e 測試的呼叫端都走預設值，行為完全不變。

## 相關的 Issue (Related Issue)

Closes #467

另與 #499 相關：#499 推測失敗來自 sandbox 的 `sharp` 相依或原生執行環境問題。本次驗證**否定**該假設——同一環境下單獨執行 `avatarUpload.test.ts` 為 14 pass / 0 fail，`sharp` 正常運作；失敗只在整批執行時出現。#499 回報的 5 項失敗即本 PR 所修。已於該 issue 留言說明，是否關閉留給維護者判斷。

## 變更類型 (Type of Change)

- [ ] `feat`: 新增功能 (Feature)
- [x] `fix`: 修復 Bug
- [ ] `refactor`: 重構代碼
- [ ] `docs`: 修改文件
- [x] `test`: 新增或修正測試案例
- [ ] `chore`: 建置流程或輔助工具變更
- [ ] `perf`: 效能優化
- [ ] `ci`: CI 設定變更

## 驗證與測試計畫 (Verification & Test Plan)

本環境**沒有 Docker daemon**（`/var/run/docker.sock` 不存在），測試 DB port 5436 未開啟，因此 integration 與 e2e 兩層**無法在此執行**，需由 reviewer 在 Docker 測試環境中執行確認。

### 本地測試 (Local Tests)

- [x] 後端型別檢查（`pnpm exec tsc --noEmit`，涵蓋 `tests/**`）
- [x] 後端 lint（`pnpm run lint` = `eslint src && tsc --noEmit`）
- [x] 單元測試（`bun test tests/unit`）
- [ ] 整合測試 — **無法在此環境執行**，需 reviewer 於 Docker 環境驗證
- [ ] e2e 測試 — **無法在此環境執行**，需 reviewer 於 Docker 環境驗證
- [ ] 前端型別檢查／Linter — 本 PR 未觸及 frontend

### 實際執行結果

| 項目 | 修正前 | 修正後 |
|------|--------|--------|
| `bun test tests/unit`（Bun 1.3.14，CI 釘選版本） | 431 pass / **5 fail** | **436 pass / 0 fail** |
| `bun test tests/unit`（Bun 1.3.11，沙箱預設） | 431 pass / **5 fail** | **436 pass / 0 fail** |
| `bun test tests/unit/utils/avatarUpload.test.ts` 單獨 | 14 pass / 0 fail | 14 pass / 0 fail |

順序無關性驗證（Bun 1.3.14），以下組合修正前會失敗、修正後全綠：

```bash
bun test tests/unit/services/userService.test.ts tests/unit/utils/avatarUpload.test.ts   # 84 pass / 0 fail
bun test tests/unit/utils/avatarUpload.test.ts tests/unit/services/userService.test.ts   # 84 pass / 0 fail
bun test tests/unit/services/roomService.test.ts tests/unit/utils/avatarUpload.test.ts   # 96 pass / 0 fail
```

各子目錄單獨執行（`middlewares` / `models` / `realtime` / `routes` / `services` / `utils`）皆 0 fail。

穩定度：連續 5 次執行 `bun test tests/unit` 均為 436 pass / 0 fail。

修正未使用跳過測試、放寬 assertion 或強制 serial 執行；`backend/uploads/avatars/` 執行後除 `.gitkeep` 外無殘留檔案。

### 手動測試 (Manual Verification)

無 UI 變更。`uploadAvatar` 的執行路徑在預設參數下與修改前完全相同（`defaultAvatarStore` 直接持有原本的 `saveAvatarUpload` / `removeManagedAvatar`）。

## 資料庫變更 (Database Changes)

* 此變更是否包含資料庫 Schema 修改？ **否**
* 若為是，請寫明 Migration 檔案名稱：`N/A`
* 是否已確認遷移與 docs/database-design.md 設計一致？ **N/A**

## API 與 WebSocket 協定一致性 (API & WebSocket Contract Check)

* 此變更是否涉及 API 路由或 WebSocket 事件的資料結構變更？ **否**
* 是否已確認與 docs/api-documentation.md 規範完全一致？ **是**（無協定變更；新增的僅是 service 工廠的尾端選填參數）

## Advisor 重點回饋

進行過一次架構 advisor 審查，主要採納與修正如下：

1. **維持 positional 尾端參數，不改為 options object。** 改成 options object 等同要重寫兩個工廠共約 30 個呼叫端，遠超單一可審查 PR；且兩個工廠既有慣例本就是「選填協作者往後接」。
2. **不要順手把 `roomService` 的 `removeManagedAvatar` 補上 `ownerId`。** 那是行為變更，且會打破 `toHaveBeenCalledWith` 的 arity-exact 斷言，應另開 issue。
3. **以「兩種順序組合皆通過」作為驗收證據，而非只看整批測試變綠**，因為檔案列舉順序本身在不同 Bun 版本／checkout 並不保證穩定。已據此補上上方的順序無關性驗證。
4. **在 `backend/tests/CLAUDE.md` 補說明**，避免未來再用 `mock.module()` 造成同類污染。已採納。
5. Advisor 另主張 `inactivityJob.test.ts` 目前是「僥倖通過」、並建議一併注入 `isUserOnline`。此項**經實測未能重現**（見上方「刻意未變更的部分」），因此未納入本 PR，以免在 PR 內寫入未經驗證的宣稱。
6. Advisor 建議暫不加 ESLint 規則禁用 `mock.module`：現行 `eslint.config.mjs` 只涵蓋 `src/**/*.ts`，要納管 tests 需新增區塊並為 6 處既存的 `src/models/db` mock 加豁免，噪音會蓋過本次修正。已採納，留待 presence follow-up 一併處理。

Generated with Claude Code (https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016aRHrkauWXekCAnDE3dMcq)_