### PR TITLE
fix(deps): 修補 security-scan 回報的 5 項相依套件漏洞

### DIFF
--- a/.cve-lite/baseline.json
+++ b/.cve-lite/baseline.json
@@ -3,14 +3,6 @@
   "createdAt": "2026-07-28T15:52:33.532Z",
   "findings": [
     {
-      "name": "brace-expansion",
-      "version": "1.1.15",
-      "advisoryIds": [
-        "GHSA-3jxr-9vmj-r5cp",
-        "GHSA-mh99-v99m-4gvg"
-      ]
-    },
-    {
       "name": "sharp",
       "version": "0.34.5",
       "advisoryIds": [

--- a/backend/package.json
+++ b/backend/package.json
@@ -28,7 +28,7 @@
     "config": "^4.4.2",
     "dotenv": "^17.4.2",
     "dotenv-expand": "^13.0.0",
-    "hono": "^4.12.32",
+    "hono": "^4.12.34",
     "hono-rate-limiter": "^0.5.3",
     "node-pg-migrate": "^9.0.0",
     "pg": "^8.22.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,11 +5,13 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  postcss: '>=8.5.10'
+  postcss: '>=8.5.23'
   ws: ^8.21.0
   '@babel/core': ^7.29.7
   form-data: ^4.0.6
-  brace-expansion@>=5: 5.0.8
+  socket.io-parser: ^4.2.7
+  brace-expansion@<2: ^1.1.18
+  brace-expansion@>=5: ^5.0.9
 
 importers:
 
@@ -19,10 +21,10 @@ importers:
     dependencies:
       '@hono/node-server':
         specifier: ^2.0.11
-        version: 2.0.12(hono@4.12.32)
+        version: 2.0.12(hono@4.12.34)
       '@hono/zod-validator':
         specifier: ^0.9.0
-        version: 0.9.0(hono@4.12.32)(zod@4.4.3)
+        version: 0.9.0(hono@4.12.34)(zod@4.4.3)
       config:
         specifier: ^4.4.2
         version: 4.4.2
@@ -33,11 +35,11 @@ importers:
         specifier: ^13.0.0
         version: 13.0.0
       hono:
-        specifier: ^4.12.32
-        version: 4.12.32
+        specifier: ^4.12.34
+        version: 4.12.34
       hono-rate-limiter:
         specifier: ^0.5.3
-        version: 0.5.3(hono@4.12.32)
+        version: 0.5.3(hono@4.12.34)
       node-pg-migrate:
         specifier: ^9.0.0
         version: 9.0.0(@types/pg@8.20.0)(pg@8.22.0)
@@ -1400,11 +1402,11 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
-  brace-expansion@1.1.15:
-    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -1998,8 +2000,8 @@ packages:
       unstorage:
         optional: true
 
-  hono@4.12.32:
-    resolution: {integrity: sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==}
+  hono@4.12.34:
+    resolution: {integrity: sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==}
     engines: {node: '>=16.9.0'}
 
   html-encoding-sniffer@6.0.0:
@@ -2355,8 +2357,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.15:
-    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -2545,8 +2547,8 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
-  postcss@8.5.19:
-    resolution: {integrity: sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==}
+  postcss@8.5.25:
+    resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
     engines: {node: ^10 || ^12 || >=14}
 
   postgres-array@2.0.0:
@@ -2716,8 +2718,8 @@ packages:
     resolution: {integrity: sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==}
     engines: {node: '>=10.0.0'}
 
-  socket.io-parser@4.2.6:
-    resolution: {integrity: sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==}
+  socket.io-parser@4.2.7:
+    resolution: {integrity: sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==}
     engines: {node: '>=10.0.0'}
 
   socket.io@4.8.3:
@@ -3449,13 +3451,13 @@ snapshots:
     optionalDependencies:
       '@noble/hashes': 1.8.0
 
-  '@hono/node-server@2.0.12(hono@4.12.32)':
+  '@hono/node-server@2.0.12(hono@4.12.34)':
     dependencies:
-      hono: 4.12.32
+      hono: 4.12.34
 
-  '@hono/zod-validator@0.9.0(hono@4.12.32)(zod@4.4.3)':
+  '@hono/zod-validator@0.9.0(hono@4.12.34)(zod@4.4.3)':
     dependencies:
-      hono: 4.12.32
+      hono: 4.12.34
       zod: 4.4.3
 
   '@humanfs/core@0.19.2':
@@ -3795,7 +3797,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.3.3
       '@tailwindcss/oxide': 4.3.3
-      postcss: 8.5.19
+      postcss: 8.5.25
       tailwindcss: 4.3.3
 
   '@testing-library/dom@10.4.1':
@@ -4338,12 +4340,12 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
 
-  brace-expansion@1.1.15:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -5137,11 +5139,11 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
-  hono-rate-limiter@0.5.3(hono@4.12.32):
+  hono-rate-limiter@0.5.3(hono@4.12.34):
     dependencies:
-      hono: 4.12.32
+      hono: 4.12.34
 
-  hono@4.12.32: {}
+  hono@4.12.34: {}
 
   html-encoding-sniffer@6.0.0(@noble/hashes@1.8.0):
     dependencies:
@@ -5461,11 +5463,11 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.15
+      brace-expansion: 1.1.18
 
   minimist@1.2.8: {}
 
@@ -5473,7 +5475,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.15: {}
+  nanoid@3.3.16: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -5487,7 +5489,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.40
       caniuse-lite: 1.0.30001799
-      postcss: 8.5.19
+      postcss: 8.5.25
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
       styled-jsx: 5.1.6(@babel/core@7.29.7(supports-color@7.2.0))(react@19.2.8)
@@ -5661,9 +5663,9 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss@8.5.19:
+  postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.15
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -5905,13 +5907,13 @@ snapshots:
       '@socket.io/component-emitter': 3.1.2
       debug: 4.4.3(supports-color@7.2.0)
       engine.io-client: 6.6.6(supports-color@7.2.0)
-      socket.io-parser: 4.2.6(supports-color@7.2.0)
+      socket.io-parser: 4.2.7(supports-color@7.2.0)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  socket.io-parser@4.2.6(supports-color@7.2.0):
+  socket.io-parser@4.2.7(supports-color@7.2.0):
     dependencies:
       '@socket.io/component-emitter': 3.1.2
       debug: 4.4.3(supports-color@7.2.0)
@@ -5926,7 +5928,7 @@ snapshots:
       debug: 4.4.3(supports-color@7.2.0)
       engine.io: 6.6.9(supports-color@7.2.0)
       socket.io-adapter: 2.5.8(supports-color@7.2.0)
-      socket.io-parser: 4.2.6(supports-color@7.2.0)
+      socket.io-parser: 4.2.7(supports-color@7.2.0)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -6201,7 +6203,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
-      postcss: 8.5.19
+      postcss: 8.5.25
       rolldown: 1.1.5
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,12 @@ packages:
 
 dangerouslyAllowAllBuilds: true
 
+# hono 4.12.34 is the fix for GHSA-8j4g-w8fx-2239 and is younger than the
+# default minimum release age. Waiting out the quarantine would leave the
+# advisory unpatched and `security-scan` red, so this one version is excluded.
+minimumReleaseAgeExclude:
+  - hono@4.12.34
+
 # pnpm honours `overrides` only at the workspace root. These were previously
 # split across frontend/pnpm-workspace.yaml and backend/pnpm-workspace.yaml;
 # consolidating to a single root lockfile requires merging them here, or the
@@ -16,14 +22,24 @@ dangerouslyAllowAllBuilds: true
 # `^7.3.5` does not match 8.x, so hoisting that pin would force a major
 # downgrade of the frontend toolchain rather than raise a security floor.
 overrides:
-  postcss: ">=8.5.10"       # was frontend/; resolves 8.5.14, already satisfied
-  ws: "^8.21.0"             # was in both, identical; resolves 8.21.0
-  "@babel/core": "^7.29.7"  # was ^7.29.6 in frontend/, weaker than the ^7.29.7
-                            # already declared in frontend/package.json
-  form-data: "^4.0.6"       # was backend/
-  # GHSA-3jxr-9vmj-r5cp / GHSA-mh99-v99m-4gvg. Scoped to the 5.x line via the
-  # `pkg@range` selector: `minimatch@10` (node-pg-migrate -> glob) pulls 5.0.6,
-  # while eslint 9 -> minimatch@3 still pulls 1.1.15, whose v1-line fix is
-  # 1.1.16 — an unscoped pin would force that consumer onto an incompatible
-  # major. The 1.1.15 path stays open on purpose; see the eslint 10 note below.
-  "brace-expansion@>=5": "5.0.8"
+  postcss: ">=8.5.23"
+    # GHSA-fxqj-rqcc-2cmp affects <=8.5.22; the previous
+    # ">=8.5.10" floor resolved 8.5.19 and was flagged
+  ws: "^8.21.0" # was in both, identical; resolves 8.21.0
+  "@babel/core": "^7.29.7"
+    # was ^7.29.6 in frontend/, weaker than the ^7.29.7
+    # already declared in frontend/package.json
+  form-data: "^4.0.6" # was backend/
+  socket.io-parser: "^4.2.7"
+    # GHSA-2m8v-j782-fhvr affects >=4.0.0 <4.2.7.
+    # Transitive via socket.io (backend) and
+    # socket.io-client (both packages); neither
+    # parent has released a bump yet, so pin here.
+  # brace-expansion is reached through two incompatible major lines and each
+  # needs its own floor — an unscoped pin would force one consumer onto the
+  # other's major. Both lines carry GHSA-rgw5-rvv9-x895; the 1.x line also
+  # carries GHSA-3jxr-9vmj-r5cp and GHSA-mh99-v99m-4gvg.
+  #   1.x: eslint 9 -> minimatch@3, fixed in 1.1.18
+  #   5.x: node-pg-migrate -> glob -> minimatch@10, fixed in 5.0.9
+  "brace-expansion@<2": "^1.1.18"
+  "brace-expansion@>=5": "^5.0.9"


### PR DESCRIPTION
## 變更描述 (Description)

#510 的 `security-scan` job 轉紅，回報 5 項超出 `.cve-lite/baseline.json` ratchet 基準的發現。五項在上游**皆已有修補版本**，因此本 PR 直接升版，而非重新產生 baseline —— 後者會靜默降低安全門檻。

| 套件 | 修正前 → 修正後 | Advisory |
|------|----------------|----------|
| brace-expansion（1.x 線） | 1.1.15 → 1.1.18 | GHSA-rgw5-rvv9-x895、GHSA-3jxr-9vmj-r5cp、GHSA-mh99-v99m-4gvg |
| brace-expansion（5.x 線） | 5.0.8 → 5.0.9 | GHSA-rgw5-rvv9-x895 |
| socket.io-parser | 4.2.6 → 4.2.7 | GHSA-2m8v-j782-fhvr |
| hono | 4.12.32 → 4.12.34 | GHSA-8j4g-w8fx-2239 |
| postcss | 8.5.19 → 8.5.25 | GHSA-fxqj-rqcc-2cmp（影響 <=8.5.22） |

### 實作說明

1. **brace-expansion 需要兩條各自獨立的下限。** 原本 `pnpm-workspace.yaml` 的註解已正確指出：無範圍限定的 pin 會把 eslint 9 → `minimatch@3` 這條路徑拉上不相容的主版本。因此改為兩個範圍選擇器 `brace-expansion@<2: ^1.1.18` 與 `brace-expansion@>=5: ^5.0.9`。原註解所謂「1.1.15 路徑刻意保留開放」的前提已不成立 —— 1.x 線現在有 1.1.18 可用。

2. **socket.io-parser 為傳遞相依**，來自 `socket.io`（backend）與 `socket.io-client`（兩個 package）。兩個上游皆尚未釋出對應升版，故以 root override 釘住。

3. **hono 4.12.34 發布時間過短**，會被 pnpm 的 `minimumReleaseAge` 擋下。若等待隔離期結束，advisory 會持續未修補且 CI 持續紅燈，因此僅針對這一個版本加入 `minimumReleaseAgeExclude`，並附註原因。

4. **`.cve-lite/baseline.json` 移除 `brace-expansion@1.1.15` 條目。** 該版本已不再被解析出來，留著只是失效的抑制項；移除只會讓門檻更嚴格，不可能遮蔽任何東西。`sharp@0.34.5` 條目**維持不變** —— 其修補版 0.35.0 屬主版本升級，不在本 PR 範圍。

## 相關的 Issue (Related Issue)

無對應 issue；起因為 #510 的 CI 留言 https://github.com/nearcsie/near-chat/pull/510#issuecomment-5172810828 。與 #424 主題相關。

## 變更類型 (Type of Change)

- [ ] `feat`: 新增功能 (Feature)
- [x] `fix`: 修復 Bug
- [ ] `refactor`: 重構代碼
- [ ] `docs`: 修改文件
- [ ] `test`: 新增或修正測試案例
- [x] `chore`: 建置流程或輔助工具變更
- [ ] `perf`: 效能優化
- [ ] `ci`: CI 設定變更

## 驗證與測試計畫 (Verification & Test Plan)

### 關於本 PR 的 CI

本 PR 的 base 是 `fix/issue-467`（#510 的分支），而 `.github/workflows/ci.yml` 的 `pull_request` 觸發條件為 `branches: [main]`。**因此本 PR 目前不會跑任何 CI**，這是設定使然，不是失敗。`security-scan` job 另有 `github.base_ref == 'main'` 的條件。

待 #510 併入 `main` 後，GitHub 會自動將本 PR 的 base 改指向 `main`，屆時 CI（含 `security-scan`）才會實際執行。若希望提早驗證，可改為先合併本 PR 到 `main`，但那會讓 diff 同時包含 #510 的 commit。

### 本地驗證結果

本沙箱環境的網路政策封鎖 `api.osv.dev`（403），`cve-lite` 掃描器無法在此執行，因此改以 `pnpm audit` 對同一批 GHSA 編號驗證：

| 項目 | 結果 |
|------|------|
| `pnpm audit`（修正前） | 上述 5 項 + 已 baseline 的 `sharp` |
| `pnpm audit`（修正後） | **僅剩已 baseline 的 `sharp@0.34.5`** |
| backend `bun test tests/unit` | **436 pass / 0 fail** |
| backend `pnpm run lint`（`eslint src && tsc --noEmit`） | 通過 |
| frontend `pnpm exec tsc --noEmit` | 通過 |
| frontend `pnpm run test`（vitest） | **30 pass / 0 fail** |
| frontend `next build` | 成功 |

lockfile 已以 `pnpm install` 實際解析並驗證，五個套件皆解析到修補版本。未建立巢狀 lockfile（僅動到 root `pnpm-lock.yaml`）。

- [x] 後端型別檢查
- [x] 後端 lint
- [x] 單元測試
- [ ] 整合測試 — 本環境無 Docker daemon，無法執行
- [ ] e2e 測試 — 本環境無 Docker daemon，無法執行
- [x] 前端型別檢查／測試／build

### 手動測試 (Manual Verification)

無 UI 或行為變更。四個變更檔案皆為相依版本與掃描設定，未觸及任何 `src/` 程式碼。

## 資料庫變更 (Database Changes)

* 此變更是否包含資料庫 Schema 修改？ **否**
* 若為是，請寫明 Migration 檔案名稱：`N/A`
* 是否已確認遷移與 docs/database-design.md 設計一致？ **N/A**

## API 與 WebSocket 協定一致性 (API & WebSocket Contract Check)

* 此變更是否涉及 API 路由或 WebSocket 事件的資料結構變更？ **否**
* 是否已確認與 docs/api-documentation.md 規範完全一致？ **是**（無協定變更）