### PR TITLE
docs: 更新發布文件以反映 required-checks gate

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -29,7 +29,7 @@ Release PR review and merge → CI → release-please.yml → vX.Y.Z + GitHub Re
 vX.Y.Z push → release-stack.yml → images + attestations + bundle
 ```
 
-1. **`ci.yml` — the gate.** Every `main` commit produces a completed CI run. Existing path filters skip expensive application jobs for documentation-only commits; code changes must pass frontend lint/typecheck/test/build, backend build/unit/integration/E2E, and dependency security jobs. CI has no release credentials and publishes nothing.
+1. **`ci.yml` — the gate.** Every `main` commit produces a completed CI run. A single `detect` job decides which lanes must run, so documentation-only commits skip the expensive ones; code changes must pass the frontend lane (lint/typecheck/test/build), the backend lane (lint/unit/build), the database lane (integration and E2E against Postgres), and the dependency security lane. Those lanes are reusable workflows, and one aggregate job — `required-checks` — collapses their outcomes into the single status check that branch protection and the release workflow rely on. CI has no release credentials and publishes nothing.
 2. **`release-please.yml` — the review boundary.** After the exact `main` commit passes CI, Release Please parses its Conventional Commits. It creates or updates one Release PR using `release-please-config.json` and `.release-please-manifest.json`. The PR proposes the version, updates `CHANGELOG.md`, and synchronizes `version` in the root, backend, and frontend `package.json` files. No tag is created while this PR remains open.
 3. **Merge the Release PR.** A maintainer checks the proposed version, English changelog structure, and all four version files before merging. After that merge passes CI, Release Please creates the matching `vX.Y.Z` tag and GitHub Release. The tag points to the reviewed commit containing the three synchronized package versions, manifest version, and changelog.
 4. **`release-stack.yml` — the stack.** The App-generated tag push starts this workflow. It builds and pushes four immutable GHCR references, signs both provenance attestations, appends an English Stack section with a full diff link to the GitHub Release, and uploads `near-chat-stack-vX.Y.Z.tar.gz`.
@@ -46,7 +46,7 @@ If `main` advances after a CI run completes, the older Release Please run exits 
 
 ### What is still enforced
 
-Release Please is the source of truth for tags. `release-stack.yml` refuses to publish unless the tag matches `vX.Y.Z` exactly, its numeric version equals all three `package.json` versions, the tag commit is in `main` history, and that exact commit has a successful main CI run whose required frontend, backend, test, and security jobs succeeded or were skipped by the path filter.
+Release Please is the source of truth for tags. `release-stack.yml` refuses to publish unless the tag matches `vX.Y.Z` exactly, its numeric version equals all three `package.json` versions, the tag commit is in `main` history, and that exact commit has a successful main CI run containing a successful `required-checks` job. `required-checks` is where lane-level judgement lives: a lane that `detect` marked as required must have succeeded, a lane that was legitimately not required may be skipped, and any failed or cancelled lane fails the gate. The release workflow therefore names no individual lane, so lanes can be renamed, split, or added without touching it.
 
 ### Manual entry points
 

--- a/docs/ZH-TW/RELEASE.md
+++ b/docs/ZH-TW/RELEASE.md
@@ -29,7 +29,7 @@ PR 一律以 squash merge 合併，因此進入 `main` 的 commit 就是 **PR �
 vX.Y.Z push → release-stack.yml → 映像、attestation、bundle
 ```
 
-1. **`ci.yml` — Gate。** 每個 `main` commit 都會產生完整結束的 CI run；純文件變更仍由既有 path filter 跳過昂貴的應用 jobs。程式變更必須通過 frontend lint／typecheck／test／build、backend build／unit／integration／E2E，以及 dependency security jobs。CI 不持有發布 credential，也不發布內容。
+1. **`ci.yml` — Gate。** 每個 `main` commit 都會產生完整結束的 CI run。單一 `detect` job 決定哪些 lane 必須執行，純文件變更因此會跳過昂貴的 lane；程式變更必須通過 frontend lane（lint／typecheck／test／build）、backend lane（lint／unit／build）、database lane（對 Postgres 執行 integration 與 E2E），以及 dependency security lane。這些 lane 都是 reusable workflow，最後由單一彙總 job `required-checks` 把結果收斂成 branch protection 與發布流程唯一依賴的 status check。CI 不持有發布 credential，也不發布內容。
 2. **`release-please.yml` — 審查邊界。** `main` 的同一個 commit 通過 CI 後，Release Please 依 `release-please-config.json` 與 `.release-please-manifest.json` 建立或更新一份 Release PR。該 PR 提出版本號、更新 `CHANGELOG.md`，並同步 root、backend、frontend 三份 `package.json` 的 `version`。PR 尚未合併時不建立 tag。
 3. **合併 Release PR。** 維護者先審查預計版本、英文 changelog 結構、manifest 與三份 package 版本。合併後再次通過 CI，Release Please 才建立對應的 `vX.Y.Z` tag 與 GitHub Release；tag 指向的 commit 已包含所有受審查的版本資產。
 4. **`release-stack.yml` — Stack。** App 產生的 tag push 會啟動此 workflow，建置並推送四個不可變 GHCR 參照、簽署兩份 provenance attestation、附加含完整 diff 連結的英文 Stack 區段，再上傳 `near-chat-stack-vX.Y.Z.tar.gz`。
@@ -46,7 +46,7 @@ Repository 的「Allow GitHub Actions to create and approve pull requests」只�
 
 ### 仍然強制的條件
 
-Tag 以 Release Please 為準。若 tag 不完全符合 `vX.Y.Z`、數字版本不等於三份 `package.json`、tag commit 不在 `main` 歷史上，或該 exact commit 沒有成功的 main CI run，`release-stack.yml` 都會拒絕發布。必要的 frontend、backend、test 與 security jobs 必須成功或由 path filter 略過。
+Tag 以 Release Please 為準。若 tag 不完全符合 `vX.Y.Z`、數字版本不等於三份 `package.json`、tag commit 不在 `main` 歷史上，或該 exact commit 的 main CI run 中沒有成功的 `required-checks` job，`release-stack.yml` 都會拒絕發布。lane 層級的判斷收在 `required-checks` 內部：`detect` 標記為必要的 lane 必須成功，確實不需要執行的 lane 才可以是 skipped，任何 failed 或 cancelled 的 lane 都會讓 gate 失敗。因此發布流程不再指名任何個別 lane，lane 可以改名、拆分或新增而不必動到它。
 
 ### 手動入口
 


### PR DESCRIPTION
## 變更描述 (Description)

`release-stack.yml` 在 #516 已改為只驗證單一 `required-checks` gate，不再逐一比對 `frontend-lint`、`unit-tests`、`e2e-tests` 等九個內部 job 名稱。但 `docs/RELEASE.md` 與 `docs/ZH-TW/RELEASE.md` 仍描述舊行為，會誤導日後排查發布問題的人。

本 PR 同步兩處中英文敘述：

1. **`ci.yml` — Gate 段落**：補上現在的結構 —— `detect` 決定哪些 lane 必須執行、四條 lane（frontend／backend／database／security）是 reusable workflow、`required-checks` 把結果收斂成單一 status check。
2. **「仍然強制的條件」段落**：改成「該 exact commit 的 main CI run 中必須有成功的 `required-checks` job」，並說明 lane 層級的判斷收在 gate 內部（該跑的 lane 必須 success、確實不需要的才可 skipped、failed 或 cancelled 一律失敗），因此發布流程不再指名任何個別 lane。

### 附帶用途：docs-only 路徑回歸測試

#516 移除了 `pull_request` 的 `paths-ignore`，改由 `detect` 讓所有 lane skip。這條路徑在 #516 自己身上驗不到（該 PR 的 diff 含 `.github/workflows/**`，四條 lane 必跑），因此本 PR 兼作該回歸點的 smoke test。

預期行為：
- CI workflow **有被觸發**（不是被 path filter 整個跳過）
- `frontend` / `backend` / `database` / `security` 四條 lane 全部 skipped
- `required-checks` 為 success，PR 可合併

若 `required-checks` 停在 Pending 而非 success，代表 docs-only PR 會被永久卡住，需要回頭修 `ci.yml`。

## 相關的 Issue (Related Issue)

無（#516 的後續文件同步）

## 變更類型 (Type of Change)

- [x] `docs`: 修改文件

## 驗證與測試計畫 (Verification & Test Plan)

### 本地測試 (Local Tests)

不適用 —— 本 PR 只變更 Markdown，不含任何程式碼、設定或 workflow 變更。上列各項檢查由 CI 自行判定為不需執行，這正是本 PR 要驗證的行為。

### 手動驗證 (Manual Verification)

- 已確認 diff 僅涵蓋 `docs/RELEASE.md` 與 `docs/ZH-TW/RELEASE.md`，未觸及 `frontend/**`、`backend/**`、`shared/**`、`.github/**` 或任何 workspace 檔案
- 已比對中英兩版敘述一致
- 新敘述與 `.github/workflows/ci.yml` 的 `required-checks` job 及 `release-stack.yml` 實際查詢的 `required='required-checks'` 相符

## 資料庫變更 (Database Changes)

* 此變更是否包含資料庫 Schema 修改？ **否**

## API 與 WebSocket 協定一致性 (API & WebSocket Contract Check)

* 此變更是否涉及 API 路由或 WebSocket 事件的資料結構變更？ **否**

---
_Generated by [Claude Code](https://claude.ai/code/session_01VWJcEmk7WVQ5JYhwaGDDz8)_