### PR TITLE
chore(deps): 將 pnpm 建置腳本授權收斂為 sharp allowlist

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,23 +6,32 @@ packages:
 # where a compromised (or merely new) transitive dependency executes arbitrary
 # code on a developer machine and in CI. The previous
 # `dangerouslyAllowAllBuilds: true` granted that to every package in the graph;
-# only `sharp` ever needed it, so the grant is now an explicit allowlist and
-# adding a native dependency becomes a deliberate review step.
+# only `sharp` ever needed it, so the grant is now an explicit decision per
+# package and adding a native dependency becomes a deliberate review step.
 #
-# `sharp` — `install: node install/check.js || npm run build` resolves or builds
-# the libvips binding that avatar/attachment compression depends on.
-onlyBuiltDependencies:
-  - sharp
-
-# Acknowledged as skipped rather than left unlisted, so `pnpm install` stays
-# quiet and the decision is recorded instead of rediscovered.
+# `sharp: true` — its `install: node install/check.js || npm run build` resolves
+# or builds the libvips binding that avatar/attachment compression depends on.
+# On platforms with a matching `@img/sharp-*` prebuild the script only selects
+# the existing binary, but it must still be allowed to run for platforms without
+# one.
 #
-# `unrs-resolver` — transitive via eslint-import-resolver-typescript. Its
-# postinstall (`napi-postinstall`) only verifies that the platform's
+# `unrs-resolver: false` — denied rather than left unlisted, so `pnpm install`
+# stays quiet and the decision is recorded instead of rediscovered. It arrives
+# transitively via eslint-import-resolver-typescript, and its postinstall
+# (`napi-postinstall`) only verifies that the platform's
 # `@unrs/resolver-binding-*` package is present; the lockfile already resolves
 # that binding as an optional dependency, so the script has nothing to do.
-ignoredBuiltDependencies:
-  - unrs-resolver
+#
+# NOTE: this is `allowBuilds` (a name -> boolean map), not the pnpm 10
+# `onlyBuiltDependencies` / `ignoredBuiltDependencies` lists. pnpm 11 renamed
+# these and **silently ignores the old keys** — an install then still blocks
+# every build script and fails with ERR_PNPM_IGNORED_BUILDS, while the config
+# looks correct. `pnpm ignored-builds` prints what is actually in effect; it
+# should report no automatically-ignored builds and `unrs-resolver` under the
+# explicitly-ignored list.
+allowBuilds:
+  sharp: true
+  unrs-resolver: false
 
 # hono 4.12.34 is the fix for GHSA-8j4g-w8fx-2239 and is younger than the
 # default minimum release age. Waiting out the quarantine would leave the

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,7 +2,27 @@ packages:
   - 'frontend'
   - 'backend'
 
-dangerouslyAllowAllBuilds: true
+# Install-time lifecycle scripts run with full privileges, so they are the point
+# where a compromised (or merely new) transitive dependency executes arbitrary
+# code on a developer machine and in CI. The previous
+# `dangerouslyAllowAllBuilds: true` granted that to every package in the graph;
+# only `sharp` ever needed it, so the grant is now an explicit allowlist and
+# adding a native dependency becomes a deliberate review step.
+#
+# `sharp` — `install: node install/check.js || npm run build` resolves or builds
+# the libvips binding that avatar/attachment compression depends on.
+onlyBuiltDependencies:
+  - sharp
+
+# Acknowledged as skipped rather than left unlisted, so `pnpm install` stays
+# quiet and the decision is recorded instead of rediscovered.
+#
+# `unrs-resolver` — transitive via eslint-import-resolver-typescript. Its
+# postinstall (`napi-postinstall`) only verifies that the platform's
+# `@unrs/resolver-binding-*` package is present; the lockfile already resolves
+# that binding as an optional dependency, so the script has nothing to do.
+ignoredBuiltDependencies:
+  - unrs-resolver
 
 # hono 4.12.34 is the fix for GHSA-8j4g-w8fx-2239 and is younger than the
 # default minimum release age. Waiting out the quarantine would leave the


### PR DESCRIPTION
## 變更描述 (Description)

根目錄 `pnpm-workspace.yaml` 目前設定 `dangerouslyAllowAllBuilds: true`，代表相依圖中**任何**套件都可以在 `pnpm install` 階段執行 lifecycle script。安裝階段的腳本以完整權限執行，正是新增或遭供應鏈污染的相依套件得以在開發者機器與 CI 上執行任意程式碼的位置。

實際需要此授權的只有 `sharp`，因此改為逐套件的明確決定：

```yaml
allowBuilds:
  sharp: true
  unrs-resolver: false
```

掃描 `node_modules/.pnpm` 後，整個相依圖中帶有 `preinstall`/`install`/`postinstall` 的套件只有兩個：

| 套件 | 腳本 | 處置 |
|---|---|---|
| `sharp@0.34.5` | `install: node install/check.js \|\| npm run build` | `true`。頭像與附件壓縮依賴此 libvips binding。在有對應 `@img/sharp-*` 預建套件的平台上，該腳本只是挑選既有 binary，但沒有預建套件的平台仍必須能執行它 |
| `unrs-resolver@1.12.2` | `postinstall: napi-postinstall` | `false`。經 `eslint-import-resolver-typescript` 引入，該腳本只檢查平台對應的 `@unrs/resolver-binding-*` 是否存在，而 lockfile 已將其解析為 optional dependency，因此無事可做 |

`unrs-resolver` 明確標為 `false` 而非放著不管，是為了讓 `pnpm install` 輸出保持乾淨，並把這個判斷記錄下來，避免日後有人重新調查一次。

### ⚠️ 設定鍵的陷阱（本 PR 第二個 commit）

本 PR 第一版依 pnpm 10 的寫法使用 `onlyBuiltDependencies` / `ignoredBuiltDependencies`，CI 全數失敗：

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: sharp@0.34.5
```

**pnpm 11 已把這兩個列表改名為 `allowBuilds`（名稱對布林值的 mapping），而且會靜默忽略舊的設定鍵** —— 設定看起來完全正確，實際上所有建置腳本仍被封鎖。這正是 issue #469 當初的故障形態（該 issue 提到殘留檔案中的 `allowBuilds: sharp: set this to true or false`，正是 pnpm 在安裝失敗時自動追加的樣板）。

第一版之所以在本機通過，是因為 sharp 早在 `dangerouslyAllowAllBuilds` 時期就已建置完成，`pnpm install` 判定無事可做而根本沒走到授權設定；只有全新安裝才會觸及這條路徑。已改用**全新 checkout** 重新驗證，詳見下方。

程式碼中已加註說明，避免日後有人依 pnpm 10 的文件改回舊寫法。

## 相關的 Issue (Related Issue)

Refs #469

## 變更類型 (Type of Change)
- [x] `chore`: 建置流程或輔助工具變更

## 驗證與測試計畫 (Verification & Test Plan)

### 本地測試 (Local Tests)
- [x] 後端型別檢查 (`pnpm exec tsc --noEmit`)
- [x] 前端型別檢查 (`pnpm exec tsc --noEmit`)
- [x] Linter 檢查（前後端 `eslint` 皆 exit 0，用於確認 `unrs-resolver` 的 import resolver 仍可正常載入）
- [x] 單元測試（450 passed）
- [x] 整合測試（33 passed，含 ephemeral db-test）

### 手動測試 (Manual Verification)

**全新安裝驗證**（關鍵步驟——既有 `node_modules` 會讓 pnpm 跳過建置階段，使驗證失去意義）。以乾淨 checkout 執行 CI 實際使用的指令：

```bash
pnpm install --frozen-lockfile --filter "near-chat-backend..."
pnpm install --frozen-lockfile --filter "near-chat-frontend..."
```

兩個 lane 的輸出皆為：

```
.../sharp@0.34.5/node_modules/sharp install$ node install/check.js || npm run build
.../sharp@0.34.5/node_modules/sharp install: Done
```

`pnpm ignored-builds` 回報實際生效的狀態：

```
Automatically ignored builds during installation:
  None

Explicitly ignored package builds (via allowBuilds):
  unrs-resolver
```

亦確認 pnpm 未在 `pnpm-workspace.yaml` 追加待填寫的樣板區塊（安裝失敗時才會發生，正是 issue #469 中殘留檔案的來源）。

**其他確認**：

- `pnpm-lock.yaml` 無變動（build 授權不寫入 lockfile 的 `settings` 區塊）。
- sharp 仍可運作：`imageCompression.test.ts` 與 `avatarUpload.test.ts` 共 26 項通過；`require("sharp").versions.vips` 回報 8.17.3。
- eslint import resolver 未受影響：前後端 `eslint` 均 exit 0（若 `unrs-resolver` 的 native binding 無法解析會直接拋錯）。

## 資料庫變更 (Database Changes)
* 此變更是否包含資料庫 Schema 修改？ **否**

## API 與 WebSocket 協定一致性 (API & WebSocket Contract Check)
* 此變更是否涉及 API 路由或 WebSocket 事件的資料結構變更？ **否**

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6mD6HGYtTphyzsAW1DFmL
