### PR TITLE
fix(backend): 在串流層強制上傳大小上限，取代 Content-Length 預檢

### DIFF
--- a/backend/src/utils/fileUpload.ts
+++ b/backend/src/utils/fileUpload.ts
@@ -33,11 +33,92 @@ export const sanitizeStoredFileName = (rawName: string): string => {
 };
 
 /**
- * Slack allowed between the declared Content-Length and the file's own size, to
- * cover multipart boundaries, part headers and other field values. Generous on
- * purpose: this check only exists to reject the clearly-too-large early.
+ * Slack allowed on top of the file's own size, to cover multipart boundaries,
+ * part headers and other field values. Generous on purpose: it only has to keep
+ * a legitimate at-the-limit upload from tripping the envelope check, because the
+ * authoritative per-file check still runs on the decoded `File`.
  */
 const MULTIPART_OVERHEAD_ALLOWANCE = 64 * 1024;
+
+/**
+ * Wrap a request body so it stops being read once `maxBytes` have gone past.
+ *
+ * This is what makes the upload cap real rather than advisory. Parsing the body
+ * first and checking `File.size` afterwards means the whole payload is received
+ * and decoded before it can be rejected, so any authenticated user can make the
+ * server buffer an arbitrarily large request; the `Content-Length` pre-check
+ * below does not close that off, since a client is free to under-declare the
+ * length or omit it entirely with `Transfer-Encoding: chunked`.
+ *
+ * Counting the bytes as they arrive is independent of anything the client
+ * declares. On the first chunk that crosses the limit the source is cancelled —
+ * which tears down the underlying request — and the error surfaces out of
+ * whichever parser is consuming this stream.
+ */
+const limitBodyStream = (
+  body: ReadableStream<Uint8Array>,
+  maxBytes: number,
+): ReadableStream<Uint8Array> => {
+  const reader = body.getReader();
+  let received = 0;
+
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      const { done, value } = await reader.read();
+
+      if (done) {
+        controller.close();
+        return;
+      }
+
+      received += value.byteLength;
+      if (received > maxBytes) {
+        await reader.cancel('upload exceeded its size limit');
+        controller.error(new ValidationError('File size limit exceeded'));
+        return;
+      }
+
+      controller.enqueue(value);
+    },
+    async cancel(reason) {
+      await reader.cancel(reason);
+    },
+  });
+};
+
+/**
+ * Decode the request's form body, reading at most `maxBytes` from the wire.
+ *
+ * `Response.formData()` is used in place of Hono's `c.req.parseBody()` because
+ * it can be pointed at our own limited stream; `parseBody()` always reads
+ * `c.req.raw` in full. The accepted content types are the same ones Hono parses
+ * (`multipart/form-data` and `application/x-www-form-urlencoded`), so a request
+ * that used to yield an empty body still ends up at the same `file is required`
+ * rejection below — as does a malformed multipart body, which the old path let
+ * escape as a 500.
+ */
+const parseFormBody = async (c: Context, maxBytes?: number): Promise<FormData> => {
+  const raw = c.req.raw;
+  const contentType = raw.headers.get('content-type') ?? '';
+  const body = raw.body;
+
+  if (!body) {
+    throw new ValidationError('file is required');
+  }
+
+  const stream = maxBytes ? limitBodyStream(body, maxBytes + MULTIPART_OVERHEAD_ALLOWANCE) : body;
+
+  try {
+    return await new Response(stream, { headers: { 'content-type': contentType } }).formData();
+  } catch (error) {
+    // Our own limit error has to keep its identity; anything else means the
+    // client sent a body this endpoint cannot read a file out of.
+    if (error instanceof ValidationError) {
+      throw error;
+    }
+    throw new ValidationError('file is required');
+  }
+};
 
 export interface ParseFileOptions {
   fieldName?: string;
@@ -54,10 +135,9 @@ export async function parseSingleFile(
 ): Promise<UploadedFile> {
   const fieldName = options.fieldName ?? 'file';
 
-  // Reject obviously oversized uploads before `parseBody()` buffers the whole
-  // request. This is a declared-size check only, so it is a cheap early exit
-  // rather than a real streaming limit; the authoritative check on the decoded
-  // file still runs below. Enforcing the cap at the stream level is issue #411.
+  // Honest clients that declare an oversized upload are turned away without a
+  // single byte being read. This is only an optimisation — the declared length
+  // is client-controlled, so `limitBodyStream` is what actually enforces the cap.
   if (options.maxBytes) {
     const declaredLength = Number(c.req.header('content-length'));
     if (Number.isFinite(declaredLength) && declaredLength > options.maxBytes + MULTIPART_OVERHEAD_ALLOWANCE) {
@@ -65,8 +145,8 @@ export async function parseSingleFile(
     }
   }
 
-  const body = await c.req.parseBody();
-  const file = body[fieldName];
+  const body = await parseFormBody(c, options.maxBytes);
+  const file = body.get(fieldName);
 
   if (!file || typeof file === 'string') {
     throw new ValidationError('file is required');

--- a/backend/tests/unit/utils/fileUpload.test.ts
+++ b/backend/tests/unit/utils/fileUpload.test.ts
@@ -179,4 +179,137 @@ describe('parseSingleFile size limits', () => {
 
     expect(res.status).toBe(200);
   });
+
+  describe('stream-level enforcement', () => {
+    const BOUNDARY = '----streamtest';
+    const CHUNK_BYTES = 64 * 1024;
+    const WOULD_BE_TOTAL = 64 * 1024 * 1024;
+
+    /**
+     * A multipart body that keeps producing until it is cancelled, reporting how
+     * much of it the server actually pulled.
+     *
+     * The point of these tests is not the status code — the pre-existing cases
+     * above already cover that — but that the server stops reading. A limit
+     * applied after `parseBody()` returns the same 400 while still having taken
+     * the whole payload into memory.
+     */
+    const endlessUpload = () => {
+      const counter = { produced: 0 };
+      const chunk = new Uint8Array(CHUNK_BYTES).fill(0x78);
+      const head =
+        `--${BOUNDARY}\r\n` +
+        'Content-Disposition: form-data; name="file"; filename="big.bin"\r\n' +
+        'Content-Type: application/octet-stream\r\n\r\n';
+
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(head));
+        },
+        pull(controller) {
+          if (counter.produced >= WOULD_BE_TOTAL) {
+            controller.enqueue(new TextEncoder().encode(`\r\n--${BOUNDARY}--\r\n`));
+            controller.close();
+            return;
+          }
+          counter.produced += chunk.byteLength;
+          controller.enqueue(chunk);
+        },
+      });
+
+      return { body, counter };
+    };
+
+    const post = (app: Hono, headers: Record<string, string>, body: ReadableStream<Uint8Array>) =>
+      app.request('/upload', {
+        method: 'POST',
+        headers: { 'content-type': `multipart/form-data; boundary=${BOUNDARY}`, ...headers },
+        body,
+        // Required to send a stream as a request body.
+        duplex: 'half',
+      } as RequestInit);
+
+    it('aborts an oversized body instead of receiving all of it', async () => {
+      const maxBytes = 1024;
+      const { body, counter } = endlessUpload();
+
+      const res = await post(makeApp(maxBytes), {}, body);
+
+      expect(res.status).toBe(400);
+      expect((await res.json() as { message?: string }).message).toBe('File size limit exceeded');
+      // Bounded by the cap plus the overhead allowance and one in-flight chunk,
+      // and nowhere near what the client was willing to send.
+      expect(counter.produced).toBeLessThan(maxBytes + 64 * 1024 + 2 * CHUNK_BYTES);
+      expect(counter.produced).toBeLessThan(WOULD_BE_TOTAL);
+    });
+
+    it('cannot be bypassed by omitting Content-Length', async () => {
+      // No declared length at all, as with `Transfer-Encoding: chunked`, so the
+      // cheap pre-check has nothing to act on.
+      const { body, counter } = endlessUpload();
+
+      const res = await post(makeApp(1024), {}, body);
+
+      expect(res.status).toBe(400);
+      expect(counter.produced).toBeLessThan(WOULD_BE_TOTAL);
+    });
+
+    it('cannot be bypassed by under-declaring Content-Length', async () => {
+      // A forged length that sails through the pre-check; only the byte counter
+      // in the stream stops this.
+      const { body, counter } = endlessUpload();
+
+      const res = await post(makeApp(1024), { 'content-length': '32' }, body);
+
+      expect(res.status).toBe(400);
+      expect((await res.json() as { message?: string }).message).toBe('File size limit exceeded');
+      expect(counter.produced).toBeLessThan(WOULD_BE_TOTAL);
+    });
+
+    it('leaves an unlimited caller unrestricted', async () => {
+      // `maxBytes` is per route; a caller that sets none must keep working.
+      const app = new Hono();
+      app.onError(errorHandler);
+      app.post('/upload', async (c) => c.json({ size: (await parseSingleFile(c)).size }));
+
+      const form = new FormData();
+      form.append('file', new File(['x'.repeat(200_000)], 'blob.bin', { type: 'application/octet-stream' }));
+      const res = await app.request('/upload', { method: 'POST', body: form });
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ size: 200_000 });
+    });
+  });
+
+  describe('non-file bodies', () => {
+    it('rejects a JSON body as a missing file rather than failing to parse', async () => {
+      const res = await makeApp(1024).request('/upload', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ file: 'not-a-file' }),
+      });
+
+      expect(res.status).toBe(400);
+      expect((await res.json() as { message?: string }).message).toBe('file is required');
+    });
+
+    it('rejects a form field that is not a file', async () => {
+      const form = new FormData();
+      form.append('file', 'just a string');
+      const res = await makeApp(1024).request('/upload', { method: 'POST', body: form });
+
+      expect(res.status).toBe(400);
+      expect((await res.json() as { message?: string }).message).toBe('file is required');
+    });
+
+    it('rejects a malformed multipart body with a client error, not a 500', async () => {
+      const res = await makeApp(1024).request('/upload', {
+        method: 'POST',
+        headers: { 'content-type': 'multipart/form-data; boundary=----nope' },
+        body: 'this is not multipart at all',
+      });
+
+      expect(res.status).toBe(400);
+    });
+  });
 });


### PR DESCRIPTION
## 變更描述 (Description)

`parseSingleFile` 目前先呼叫 `c.req.parseBody()` 完整解析 multipart body，程式直到取得 `File` 物件後才比對 `fileObj.size` 與上限。因此已通過驗證的使用者可以送出遠大於 2 MB（頭像）／10 MB（附件）的 body，迫使伺服器先完整接收並解碼全部內容才拒絕。

既有的 `Content-Length` 預檢是**宣告值**檢查，擋不住這件事：用戶端可以少報長度，或以 `Transfer-Encoding: chunked` 完全不帶長度。

### 作法

把 request body 包一層計數用的 `ReadableStream`，累計位元組超過 `maxBytes + MULTIPART_OVERHEAD_ALLOWANCE` 的當下即 `reader.cancel()` 取消來源串流（連帶中止底層請求），再以 `Response.formData()` 解析這條受限串流。

改用 `Response.formData()` 而非 `parseBody()` 的原因是後者只能讀取完整的 `c.req.raw`，無法指向自訂串流。兩者接受的 content type 相同（`multipart/form-data` 與 `application/x-www-form-urlencoded`），因此原本回傳空 body 的請求仍落在同一個 `file is required` 分支。

`Content-Length` 預檢保留為便宜的提早退出——誠實申報過大上傳的用戶端可在讀取任何位元組前被擋下——但它已不再是唯一防線。

### 相容性

- 錯誤碼與訊息維持 `400` / `File size limit exceeded`，`docs/api-documentation.md` 無需變更，前端錯誤處理不受影響。
- 附件與頭像各自的上限維持獨立，仍由既有環境變數設定。
- 未設定 `maxBytes` 的呼叫端行為不變（不套用上限）。
- **附帶修正**：格式錯誤的 multipart body 原本會讓 `formData()` 的例外冒泡成 `500`，現在歸類為 `400`。

本 PR 為 `docs/reports/deep-research-report.md` 中列為 P0 的第二項。

## 相關的 Issue (Related Issue)

Closes #411

## 變更類型 (Type of Change)
- [x] `fix`: 修復 Bug
- [x] `test`: 新增或修正測試案例

## 驗證與測試計畫 (Verification & Test Plan)

### 本地測試 (Local Tests)
- [x] 後端型別檢查 (`pnpm exec tsc --noEmit`)
- [x] 後端 Linter 檢查 (`pnpm exec eslint src`)
- [x] 單元測試（450 passed，其中 `fileUpload.test.ts` 由 16 項增至 23 項）
- [x] 整合測試（33 passed，含 ephemeral db-test）
- [x] E2E 測試（68 passed，涵蓋 `attachment` / `attachmentCompression` / `room` 的上傳路徑）

### 新增測試

針對 issue 的驗收標準補上：

| 測試 | 驗證內容 |
|---|---|
| `aborts an oversized body instead of receiving all of it` | 伺服器實際讀取的位元組數受上限約束，遠低於用戶端願意送出的量 |
| `cannot be bypassed by omitting Content-Length` | 不帶長度（等同 chunked）仍被擋下 |
| `cannot be bypassed by under-declaring Content-Length` | 偽造的短 `Content-Length` 通過預檢後仍被串流層擋下 |
| `leaves an unlimited caller unrestricted` | 未設 `maxBytes` 的呼叫端不受影響 |
| `rejects a JSON body as a missing file` / `rejects a form field that is not a file` / `rejects a malformed multipart body with a client error, not a 500` | 非檔案 body 的錯誤行為 |

重點在於這些測試不只檢查狀態碼——上限若只在 `parseBody()` 之後套用，同樣會回傳 400，卻已經把整包內容吃進記憶體。測試的來源串流會回報實際被讀取的位元組數。

### 手動測試 (Manual Verification)

**對照驗證**：把實作暫時改回 `c.req.parseBody()` 後重跑，新增測試中有 4 項失敗，確認測試確實在測新行為而非兩邊都通過：

```
(fail) aborts an oversized body instead of receiving all of it
(fail) cannot be bypassed by omitting Content-Length
(fail) cannot be bypassed by under-declaring Content-Length
      Expected: < 67108864
      Received: 67108864
(fail) rejects a malformed multipart body with a client error, not a 500
      Expected: 400
      Received: 500
```

以 1 KB 上限、來源願意送出 64 MB 的 chunked multipart 串流實測：

| 實作 | 伺服器實際讀取 |
|---|---|
| 修改前 | 67,108,864 bytes（全部） |
| 修改後 | 約 128 KB 後中止 |

邊界值（檔案大小恰好等於上限）仍可正常上傳，既有的中文檔名、路徑穿越防護與各類允許格式測試全數通過。

## 資料庫變更 (Database Changes)
* 此變更是否包含資料庫 Schema 修改？ **否**

## API 與 WebSocket 協定一致性 (API & WebSocket Contract Check)
* 此變更是否涉及 API 路由或 WebSocket 事件的資料結構變更？ **否**
* 錯誤碼與訊息維持與 `docs/api-documentation.md` 一致（未改為 413）。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6mD6HGYtTphyzsAW1DFmL
