### PR TITLE
fix(backend): 以可信代理層數解析來源 IP，並收斂正式環境入口

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,12 +13,21 @@ JWT_SECRET=dev_secret_key
 JWT_EXPIRES_IN=15m
 # 關閉速率限制（開發 / 測試用，正式環境請移除）
 RATE_LIMIT_DISABLED=true
-# 僅在後端確實位於可信任的反向代理之後才設為 true。
-# 設為 true 時速率限制會採用 X-Forwarded-For 的第一段作為來源 IP；
-# 若直接對外暴露後端埠而開啟此項，用戶端即可偽造標頭繞過限流。
-# 注意：Compose 會讀取本檔複製而成的 .env 進行插值，此處的值會覆寫
-# compose 檔中的 ${TRUST_PROXY:-...} 預設值。正式部署（cloudflared tunnel）
-# 下維持 false 會使所有外部流量共用同一個限流桶，詳見 issue #413。
+# 後端前方有幾層「我們自己維運」的反向代理。限流會取 X-Forwarded-For 由右
+# 數來第 n 段作為來源 IP：右側是各層代理自己寫入的，左側則可能是用戶端自行
+# 帶入的內容，因此取左端等同讓用戶端自選限流桶。
+#
+# 開發堆疊為瀏覽器直連，前方沒有代理，所以此處留空（等同 0，只採用實際連線
+# 位址）。正式堆疊（cloudflared tunnel）需要 1，該值已直接寫死在
+# docker-compose.prod.yml 中 —— Compose 會讀取本檔複製而成的 .env 進行插值，
+# 若在此設值會連帶覆寫正式環境的設定（issue #413 記錄過這個陷阱）。
+#
+# 僅在本機開發堆疊前方另外架設代理（如 Tailscale Serve、本機 nginx）時才需
+# 設定；驗證方式見 docs/DEVELOPMENT.md。
+# TRUST_PROXY_HOPS=
+#
+# 舊的布林開關，保留相容：未設定 TRUST_PROXY_HOPS 時 true 等同 1 層。新設定
+# 請改用 TRUST_PROXY_HOPS。
 TRUST_PROXY=false
 CORS_ORIGINS=http://localhost:3000,http://localhost:3005
 

--- a/.github/workflows/release-stack.yml
+++ b/.github/workflows/release-stack.yml
@@ -440,6 +440,13 @@ jobs:
           CORS_ORIGINS=http://localhost:3005
           NEXT_PUBLIC_API_URL=http://localhost:4005
           UPLOADS_MOUNT_SOURCE=app_uploads
+          # Number of reverse proxies you operate in front of the backend. This
+          # bundle publishes the backend port directly, so callers arrive as
+          # themselves and 0 is correct. Raise it per proxy you add: rate limiting
+          # then reads the client IP that many entries from the right of
+          # X-Forwarded-For. Too low behind a proxy puts every caller in one
+          # bucket; too high lets callers choose their own.
+          TRUST_PROXY_HOPS=0
           EOF
 
           jq -n \

--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ Here are the key environment parameters you can configure in `.env`:
 | `DATABASE_URL` | PostgreSQL connection URL | `postgresql://chatuser:chatpassword@db:5432/chatdb` |
 | `JWT_SECRET` | Secret key for signing JWT tokens | `dev_secret_key` |
 | `RATE_LIMIT_DISABLED` | Disables request rate limiting for testing | `true` (Set `false` or omit in production) |
-| `TRUST_PROXY` | Take the client IP for rate limiting from the first `X-Forwarded-For` entry. Only enable when the backend really sits behind a trusted reverse proxy | `false` |
+| `TRUST_PROXY_HOPS` | How many reverse proxies you operate sit in front of the backend. Rate limiting then reads the client IP that many entries from the **right** of `X-Forwarded-For`, so entries a caller prepends cannot select a bucket. Leave unset for the dev stack, which is reached directly; `docker-compose.prod.yml` pins `1` for cloudflared | *(Empty — trust nothing)* |
+| `TRUST_PROXY` | Legacy boolean, still honoured when `TRUST_PROXY_HOPS` is unset: `true` means one hop. Prefer `TRUST_PROXY_HOPS` | `false` |
 | `NEXT_PUBLIC_API_URL` | Browser-facing backend API URL | `http://localhost:4005` |
 | `ALLOWED_DEV_ORIGINS` | Allowed remote origins for dev (e.g., Tailscale IPs) | *(Empty)* |
 | `UPLOADS_MOUNT_SOURCE` | Storage path or Docker volume name for attachments | `app_uploads` |

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -75,7 +75,8 @@ cp .env.example .env
 | `DATABASE_URL` | PostgreSQL 連線 URL | `postgresql://chatuser:chatpassword@db:5432/chatdb` |
 | `JWT_SECRET` | 用於簽署 JWT 的密鑰鍵值 | `dev_secret_key` |
 | `RATE_LIMIT_DISABLED` | 關閉 API 請求速率限制（供測試使用） | `true`（生產環境請設為 `false` 或移除） |
-| `TRUST_PROXY` | 速率限制改以 `X-Forwarded-For` 的第一段作為來源 IP。僅在後端確實位於可信任的反向代理之後才可開啟 | `false` |
+| `TRUST_PROXY_HOPS` | 後端前方有幾層自行維運的反向代理。速率限制會取 `X-Forwarded-For` 由**右**數來第 n 段作為來源 IP，因此用戶端自行前綴的內容無法用來自選限流桶。開發堆疊為直連，留空即可；正式堆疊由 `docker-compose.prod.yml` 寫死為 `1`（cloudflared） | *(空，不信任任何代理)* |
+| `TRUST_PROXY` | 舊的布林開關，未設定 `TRUST_PROXY_HOPS` 時仍生效：`true` 等同 1 層。新設定請改用 `TRUST_PROXY_HOPS` | `false` |
 | `NEXT_PUBLIC_API_URL` | 瀏覽器端存取後端 API 的外部 URL | `http://localhost:4005` |
 | `ALLOWED_DEV_ORIGINS` | 允許進行開發連線的外部來源網域或 IP (如 Tailscale) | *(空)* |
 | `UPLOADS_MOUNT_SOURCE` | 附件上傳的儲存掛載路徑或 Docker Volume 名稱 | `app_uploads` |

--- a/backend/src/utils/clientIp.ts
+++ b/backend/src/utils/clientIp.ts
@@ -2,11 +2,30 @@ import type { Context } from 'hono';
 import { getConnInfo } from '@hono/node-server/conninfo';
 
 /**
- * `X-Forwarded-For` is client-controlled unless a proxy we trust rewrites it, so
- * it is only consulted when the deployment opts in via `TRUST_PROXY=true`.
+ * How many proxies we operate sit between the client and this process.
+ *
+ * `X-Forwarded-For` is append-only, and every hop adds the address it received
+ * the request from, so the chain ends with the entries our own infrastructure
+ * wrote and begins with whatever the client chose to send. The count is what
+ * tells the two apart: with `n` trusted proxies, the client's real address is
+ * the `n`-th entry from the right, and everything to its left is unverifiable.
+ *
+ * Configured via `TRUST_PROXY_HOPS`. The older boolean `TRUST_PROXY=true` still
+ * works and means one hop — the common single-reverse-proxy deployment — so an
+ * existing environment keeps working while no longer reading the spoofable end
+ * of the chain.
  */
-export const trustProxyEnabled = (): boolean =>
-  (process.env.TRUST_PROXY ?? '').trim().toLowerCase() === 'true';
+export const trustedProxyHops = (): number => {
+  const configured = (process.env.TRUST_PROXY_HOPS ?? '').trim();
+
+  if (configured) {
+    const hops = Number(configured);
+    // A malformed value must not silently grant trust.
+    return Number.isInteger(hops) && hops >= 0 ? hops : 0;
+  }
+
+  return (process.env.TRUST_PROXY ?? '').trim().toLowerCase() === 'true' ? 1 : 0;
+};
 
 /**
  * Resolve the caller's IP, preferring the real TCP peer address.
@@ -17,10 +36,21 @@ export const trustProxyEnabled = (): boolean =>
  * such request onto one shared identity.
  */
 export const getClientIp = (c: Context): string | undefined => {
-  if (trustProxyEnabled()) {
-    const forwarded = c.req.header('x-forwarded-for');
-    const first = forwarded?.split(',')[0]?.trim();
-    if (first) return first;
+  const hops = trustedProxyHops();
+
+  if (hops > 0) {
+    const forwarded = (c.req.header('x-forwarded-for') ?? '')
+      .split(',')
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+
+    // Counting from the right skips exactly the hops we vouch for. A client that
+    // prepends entries of its own only pads the untrusted left side and cannot
+    // move this index onto a value it controls. A chain shorter than `hops` means
+    // the request did not arrive through the expected path, so fall through to
+    // the peer address rather than accept the leftmost entry.
+    const candidate = forwarded[forwarded.length - hops];
+    if (candidate) return candidate;
   }
 
   try {

--- a/backend/tests/e2e/rateLimitBucketing.e2e.test.ts
+++ b/backend/tests/e2e/rateLimitBucketing.e2e.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'bun:test';
+import { Hono } from 'hono';
+import type { MiddlewareHandler } from 'hono';
+import { serve, type ServerType } from '@hono/node-server';
+import { makeGlobalRateLimiter } from '../../src/middlewares/securityMiddleware';
+import { errorHandler } from '../../src/middlewares/errorHandler';
+
+/**
+ * Rate-limit bucketing over a real socket.
+ *
+ * The unit tests drive `getClientIp` with synthetic contexts, which cannot show
+ * whether the peer address is actually recoverable at runtime — and that address
+ * is the whole fallback when no proxy is trusted. Here the requests genuinely
+ * travel over TCP through `@hono/node-server`, the same adapter production uses,
+ * so the header path and the socket path are exercised as they really compose.
+ *
+ * Covers the guarantees issue #413 asks for: one caller cannot exhaust another's
+ * budget, and no caller can pick its own bucket by sending `X-Forwarded-For`.
+ */
+
+const originalNodeEnv = process.env.NODE_ENV;
+const originalRateLimitDisabled = process.env.RATE_LIMIT_DISABLED;
+const originalTrustProxy = process.env.TRUST_PROXY;
+const originalTrustProxyHops = process.env.TRUST_PROXY_HOPS;
+
+let server: ServerType;
+let baseUrl: string;
+
+// One limiter instance holds one in-memory store, so each test takes a fresh one
+// to start from an empty count. Within a test it must stay the same instance or
+// nothing ever accumulates. `keyGenerator` and `skip` read the environment per
+// request, so swapping the instance is enough to re-read the trust settings too.
+let limiter: MiddlewareHandler;
+const resetLimiter = () => {
+  limiter = makeGlobalRateLimiter({ windowMs: 60_000, limit: 2 });
+};
+
+const app = new Hono();
+app.onError(errorHandler);
+app.use('/api/ping', (c, next) => limiter(c, next));
+app.get('/api/ping', (c) => c.json({ ok: true }));
+
+const ping = async (headers: Record<string, string> = {}): Promise<number> => {
+  const res = await fetch(`${baseUrl}/api/ping`, { headers });
+  await res.arrayBuffer();
+  return res.status;
+};
+
+const restore = (name: string, value: string | undefined) => {
+  if (value !== undefined) {
+    process.env[name] = value;
+  } else {
+    delete process.env[name];
+  }
+};
+
+beforeAll(async () => {
+  server = serve({ fetch: app.fetch, port: 0, hostname: '127.0.0.1' });
+  const address = server.address();
+  const port = typeof address === 'string' ? 0 : address?.port;
+  baseUrl = `http://127.0.0.1:${port}`;
+});
+
+afterAll(() => {
+  server?.close();
+});
+
+afterEach(() => {
+  restore('NODE_ENV', originalNodeEnv);
+  restore('RATE_LIMIT_DISABLED', originalRateLimitDisabled);
+  restore('TRUST_PROXY', originalTrustProxy);
+  restore('TRUST_PROXY_HOPS', originalTrustProxyHops);
+});
+
+const enableLimiter = () => {
+  process.env.NODE_ENV = 'production';
+  delete process.env.RATE_LIMIT_DISABLED;
+  resetLimiter();
+};
+
+describe('rate limit bucketing over a real connection', () => {
+  it('falls back to the peer address when no proxy is trusted', async () => {
+    enableLimiter();
+    delete process.env.TRUST_PROXY;
+    delete process.env.TRUST_PROXY_HOPS;
+
+    // Every request here shares one peer address (127.0.0.1), so the budget is
+    // spent in order — proving the socket address was resolved rather than
+    // silently coming back undefined and handing each request its own key.
+    expect(await ping()).toBe(200);
+    expect(await ping()).toBe(200);
+    expect(await ping()).toBe(429);
+  });
+
+  it('ignores X-Forwarded-For when no proxy is trusted', async () => {
+    enableLimiter();
+    delete process.env.TRUST_PROXY;
+    delete process.env.TRUST_PROXY_HOPS;
+
+    // A caller cannot mint fresh buckets for itself by varying the header.
+    expect(await ping({ 'x-forwarded-for': '203.0.113.1' })).toBe(200);
+    expect(await ping({ 'x-forwarded-for': '203.0.113.2' })).toBe(200);
+    expect(await ping({ 'x-forwarded-for': '203.0.113.3' })).toBe(429);
+  });
+
+  it('separates callers by the hop the trusted proxy appended', async () => {
+    enableLimiter();
+    process.env.TRUST_PROXY_HOPS = '1';
+
+    // Two distinct clients arriving through the same proxy: one exhausting its
+    // budget must not spend the other's, which is the tunnel failure mode.
+    expect(await ping({ 'x-forwarded-for': '198.51.100.1' })).toBe(200);
+    expect(await ping({ 'x-forwarded-for': '198.51.100.1' })).toBe(200);
+    expect(await ping({ 'x-forwarded-for': '198.51.100.1' })).toBe(429);
+
+    expect(await ping({ 'x-forwarded-for': '198.51.100.2' })).toBe(200);
+  });
+
+  it('does not let a caller escape its bucket by prepending to the chain', async () => {
+    enableLimiter();
+    process.env.TRUST_PROXY_HOPS = '1';
+
+    expect(await ping({ 'x-forwarded-for': '198.51.100.9' })).toBe(200);
+    expect(await ping({ 'x-forwarded-for': '198.51.100.9' })).toBe(200);
+    // Same caller as far as our proxy is concerned; the padding is untrusted.
+    expect(await ping({ 'x-forwarded-for': '203.0.113.7, 198.51.100.9' })).toBe(429);
+    expect(await ping({ 'x-forwarded-for': '10.0.0.1, 10.0.0.2, 198.51.100.9' })).toBe(429);
+  });
+
+  it('falls back to the peer address for a request that skipped the proxy', async () => {
+    enableLimiter();
+    process.env.TRUST_PROXY_HOPS = '2';
+
+    // Only one entry, but two hops are expected, so this did not come through the
+    // documented path. It must be attributed to the peer rather than to the
+    // caller-supplied entry — otherwise a direct connection picks its own bucket.
+    expect(await ping({ 'x-forwarded-for': '203.0.113.5' })).toBe(200);
+    expect(await ping({ 'x-forwarded-for': '203.0.113.6' })).toBe(200);
+    expect(await ping({ 'x-forwarded-for': '203.0.113.7' })).toBe(429);
+  });
+});

--- a/backend/tests/unit/middlewares/securityMiddleware.test.ts
+++ b/backend/tests/unit/middlewares/securityMiddleware.test.ts
@@ -11,6 +11,7 @@ describe('security middleware', () => {
   const originalNodeEnv = process.env.NODE_ENV;
   const originalRateLimitDisabled = process.env.RATE_LIMIT_DISABLED;
   const originalTrustProxy = process.env.TRUST_PROXY;
+  const originalTrustProxyHops = process.env.TRUST_PROXY_HOPS;
 
   afterEach(() => {
     process.env.NODE_ENV = originalNodeEnv;
@@ -23,6 +24,11 @@ describe('security middleware', () => {
       process.env.TRUST_PROXY = originalTrustProxy;
     } else {
       delete process.env.TRUST_PROXY;
+    }
+    if (originalTrustProxyHops !== undefined) {
+      process.env.TRUST_PROXY_HOPS = originalTrustProxyHops;
+    } else {
+      delete process.env.TRUST_PROXY_HOPS;
     }
   });
 
@@ -137,15 +143,34 @@ describe('security middleware', () => {
       expect((await app.request('/api/ping', { headers: { 'x-forwarded-for': '10.0.0.1' } })).status).toBe(429);
     });
 
-    it('uses only the first hop of a forwarded chain', async () => {
+    it('buckets on the hop our own proxy appended, not the head of the chain', async () => {
       process.env.NODE_ENV = 'production';
-      process.env.TRUST_PROXY = 'true';
+      process.env.TRUST_PROXY_HOPS = '1';
       delete process.env.RATE_LIMIT_DISABLED;
       const app = makeApp();
 
+      // 192.168.0.1 is what the one proxy we trust wrote; the two entries before
+      // it came from the caller.
       const headers = { 'x-forwarded-for': '10.0.0.9, 172.16.0.1, 192.168.0.1' };
       expect((await app.request('/api/ping', { headers })).status).toBe(200);
-      expect((await app.request('/api/ping', { headers: { 'x-forwarded-for': '10.0.0.9' } })).status).toBe(429);
+      expect((await app.request('/api/ping', { headers: { 'x-forwarded-for': '192.168.0.1' } })).status).toBe(429);
+    });
+
+    it('does not let a caller pad the chain to escape its own bucket', async () => {
+      // The regression that makes trusting the leftmost entry unsafe: one client
+      // could spend everyone else's budget, or dodge its own, just by choosing
+      // what to put in the header.
+      process.env.NODE_ENV = 'production';
+      process.env.TRUST_PROXY_HOPS = '1';
+      delete process.env.RATE_LIMIT_DISABLED;
+      const app = makeApp();
+
+      expect((await app.request('/api/ping', { headers: { 'x-forwarded-for': '198.51.100.4' } })).status).toBe(200);
+      // Same client as far as our proxy is concerned, however it dresses up the
+      // rest of the chain.
+      expect(
+        (await app.request('/api/ping', { headers: { 'x-forwarded-for': '203.0.113.7, 198.51.100.4' } })).status,
+      ).toBe(429);
     });
 
     it('ignores X-Forwarded-For when the proxy is not trusted', async () => {

--- a/backend/tests/unit/utils/clientIp.test.ts
+++ b/backend/tests/unit/utils/clientIp.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, afterEach } from 'bun:test';
 import type { Context } from 'hono';
-import { getClientIp, trustProxyEnabled } from '../../../src/utils/clientIp';
+import { getClientIp, trustedProxyHops } from '../../../src/utils/clientIp';
 
 const originalTrustProxy = process.env.TRUST_PROXY;
+const originalTrustProxyHops = process.env.TRUST_PROXY_HOPS;
 
 const makeContext = (
   headers: Record<string, string> = {},
@@ -13,30 +14,58 @@ const makeContext = (
     env: socket ? { incoming: { socket } } : {},
   }) as unknown as Context;
 
+const restore = (name: string, value: string | undefined) => {
+  if (value !== undefined) {
+    process.env[name] = value;
+  } else {
+    delete process.env[name];
+  }
+};
+
 describe('clientIp', () => {
   afterEach(() => {
-    if (originalTrustProxy !== undefined) {
-      process.env.TRUST_PROXY = originalTrustProxy;
-    } else {
-      delete process.env.TRUST_PROXY;
-    }
+    restore('TRUST_PROXY', originalTrustProxy);
+    restore('TRUST_PROXY_HOPS', originalTrustProxyHops);
   });
 
-  describe('trustProxyEnabled', () => {
-    it('defaults to false', () => {
+  describe('trustedProxyHops', () => {
+    it('defaults to trusting nothing', () => {
       delete process.env.TRUST_PROXY;
-      expect(trustProxyEnabled()).toBe(false);
+      delete process.env.TRUST_PROXY_HOPS;
+      expect(trustedProxyHops()).toBe(0);
     });
 
-    it('is case- and whitespace-insensitive', () => {
+    it('reads an explicit hop count', () => {
+      delete process.env.TRUST_PROXY;
+      process.env.TRUST_PROXY_HOPS = ' 2 ';
+      expect(trustedProxyHops()).toBe(2);
+    });
+
+    it('treats the legacy TRUST_PROXY=true as a single hop', () => {
+      delete process.env.TRUST_PROXY_HOPS;
       process.env.TRUST_PROXY = ' TRUE ';
-      expect(trustProxyEnabled()).toBe(true);
+      expect(trustedProxyHops()).toBe(1);
     });
 
-    it('treats any other value as false', () => {
+    it('treats any other legacy value as no trust', () => {
+      delete process.env.TRUST_PROXY_HOPS;
       for (const value of ['false', '1', 'yes', '']) {
         process.env.TRUST_PROXY = value;
-        expect(trustProxyEnabled()).toBe(false);
+        expect(trustedProxyHops()).toBe(0);
+      }
+    });
+
+    it('lets an explicit hop count win over the legacy flag', () => {
+      process.env.TRUST_PROXY = 'true';
+      process.env.TRUST_PROXY_HOPS = '0';
+      expect(trustedProxyHops()).toBe(0);
+    });
+
+    it('falls back to no trust for a malformed hop count', () => {
+      delete process.env.TRUST_PROXY;
+      for (const value of ['-1', 'two', '1.5', 'NaN']) {
+        process.env.TRUST_PROXY_HOPS = value;
+        expect(trustedProxyHops()).toBe(0);
       }
     });
   });
@@ -44,30 +73,68 @@ describe('clientIp', () => {
   describe('getClientIp', () => {
     it('prefers the socket peer address by default', () => {
       delete process.env.TRUST_PROXY;
+      delete process.env.TRUST_PROXY_HOPS;
       const c = makeContext({ 'x-forwarded-for': '10.0.0.1' }, { remoteAddress: '192.168.1.5' });
 
       expect(getClientIp(c)).toBe('192.168.1.5');
     });
 
-    it('uses the first forwarded hop when the proxy is trusted', () => {
-      process.env.TRUST_PROXY = 'true';
+    it('reads one hop back from the right when one proxy is trusted', () => {
+      process.env.TRUST_PROXY_HOPS = '1';
       const c = makeContext(
         { 'x-forwarded-for': ' 10.0.0.1 , 172.16.0.1 ' },
         { remoteAddress: '192.168.1.5' },
       );
 
-      expect(getClientIp(c)).toBe('10.0.0.1');
+      // Our single proxy appended 172.16.0.1 as the address it heard the request
+      // from, so that is the caller. 10.0.0.1 arrived with the request itself.
+      expect(getClientIp(c)).toBe('172.16.0.1');
+    });
+
+    it('ignores entries a client prepends to the chain', () => {
+      process.env.TRUST_PROXY_HOPS = '1';
+      const spoofed = makeContext(
+        { 'x-forwarded-for': '203.0.113.7, 203.0.113.8, 198.51.100.4' },
+        { remoteAddress: '192.168.1.5' },
+      );
+      const honest = makeContext(
+        { 'x-forwarded-for': '198.51.100.4' },
+        { remoteAddress: '192.168.1.5' },
+      );
+
+      // Padding the chain must not let a caller pick a different bucket.
+      expect(getClientIp(spoofed)).toBe('198.51.100.4');
+      expect(getClientIp(spoofed)).toBe(getClientIp(honest));
+    });
+
+    it('skips the declared number of hops', () => {
+      process.env.TRUST_PROXY_HOPS = '2';
+      const c = makeContext(
+        { 'x-forwarded-for': '10.0.0.1, 198.51.100.4, 172.16.0.1' },
+        { remoteAddress: '192.168.1.5' },
+      );
+
+      expect(getClientIp(c)).toBe('198.51.100.4');
+    });
+
+    it('falls back to the socket when the chain is shorter than the trusted hops', () => {
+      // A direct connection that bypassed the proxies cannot be attributed from
+      // the header, so it must not be read as the leftmost entry.
+      process.env.TRUST_PROXY_HOPS = '2';
+      const c = makeContext({ 'x-forwarded-for': '10.0.0.1' }, { remoteAddress: '192.168.1.5' });
+
+      expect(getClientIp(c)).toBe('192.168.1.5');
     });
 
     it('falls back to the socket when a trusted proxy sends no header', () => {
-      process.env.TRUST_PROXY = 'true';
+      process.env.TRUST_PROXY_HOPS = '1';
       const c = makeContext({}, { remoteAddress: '192.168.1.5' });
 
       expect(getClientIp(c)).toBe('192.168.1.5');
     });
 
     it('falls back to the socket when the forwarded header is blank', () => {
-      process.env.TRUST_PROXY = 'true';
+      process.env.TRUST_PROXY_HOPS = '1';
       const c = makeContext({ 'x-forwarded-for': '  ' }, { remoteAddress: '192.168.1.5' });
 
       expect(getClientIp(c)).toBe('192.168.1.5');
@@ -75,6 +142,7 @@ describe('clientIp', () => {
 
     it('returns undefined when no connection info is attached', () => {
       delete process.env.TRUST_PROXY;
+      delete process.env.TRUST_PROXY_HOPS;
 
       expect(getClientIp(makeContext())).toBeUndefined();
       expect(getClientIp(makeContext({ 'x-forwarded-for': '10.0.0.1' }))).toBeUndefined();
@@ -82,6 +150,7 @@ describe('clientIp', () => {
 
     it('returns undefined when the socket has no remote address', () => {
       delete process.env.TRUST_PROXY;
+      delete process.env.TRUST_PROXY_HOPS;
 
       expect(getClientIp(makeContext({}, {}))).toBeUndefined();
     });

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,8 +1,17 @@
+# Ingress topology: cloudflared is the only way in from the internet, and it
+# reaches `frontend` and `backend` over this compose network rather than through
+# any published host port. Every published port below is therefore bound to
+# 127.0.0.1 — enough for the documented local production walkthrough (browse
+# http://localhost:3005), and unreachable from the network, so nothing can skip
+# the tunnel to talk to the backend or the database directly.
+#
+# That binding is what makes trusting `X-Forwarded-For` safe here: see
+# TRUST_PROXY_HOPS on the backend service.
 services:
   db:
     image: postgres:18-alpine
     ports:
-      - "5435:5432"
+      - "127.0.0.1:5435:5432"
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
@@ -20,7 +29,7 @@ services:
       context: .
       dockerfile: ./backend/Dockerfile.prod
     ports:
-      - "4005:4000"
+      - "127.0.0.1:4005:4000"
     environment:
       - NODE_ENV=${NODE_ENV}
       - PORT=${PORT}
@@ -28,7 +37,18 @@ services:
       - JWT_SECRET=${JWT_SECRET}
       - JWT_EXPIRES_IN=${JWT_EXPIRES_IN}
       - RATE_LIMIT_DISABLED=${RATE_LIMIT_DISABLED}
-      - TRUST_PROXY=${TRUST_PROXY:-false}
+      # One trusted hop: cloudflared, which appends the caller's address to
+      # X-Forwarded-For. Without it every request through the tunnel is attributed
+      # to the tunnel container, so a single caller exhausting the auth limiter
+      # (10 attempts / 15 min) locks out logins for everyone.
+      #
+      # Written literally rather than as ${TRUST_PROXY_HOPS:-1}: Compose
+      # interpolates from the project .env, so a value carried over from
+      # .env.example would quietly replace this default and the deployment would
+      # be back to one shared bucket. Change it here, next to the topology that
+      # determines it — add a hop for each additional proxy you put in front, and
+      # verify with the procedure in docs/DEVELOPMENT.md.
+      - TRUST_PROXY_HOPS=1
       - CORS_ORIGINS=${CORS_ORIGINS}
       - ATTACHMENT_TYPE_RESTRICTION_ENABLED=${ATTACHMENT_TYPE_RESTRICTION_ENABLED:-false}
       - ATTACHMENT_ALLOWED_MIME_TYPES=${ATTACHMENT_ALLOWED_MIME_TYPES:-image/jpeg,image/png,image/gif,application/pdf,application/zip,text/plain}
@@ -48,7 +68,7 @@ services:
       args:
         - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
     ports:
-      - "3005:3000"
+      - "127.0.0.1:3005:3000"
     environment:
       - NODE_ENV=${NODE_ENV}
       - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}

--- a/docker-compose.release.yml
+++ b/docker-compose.release.yml
@@ -39,6 +39,13 @@ services:
       JWT_SECRET: ${JWT_SECRET:?JWT_SECRET is required}
       JWT_EXPIRES_IN: ${JWT_EXPIRES_IN:-15m}
       RATE_LIMIT_DISABLED: ${RATE_LIMIT_DISABLED:-false}
+      # This bundle publishes the backend port directly, so callers arrive as
+      # themselves and the peer address is the right thing to bucket on. Raise
+      # this to the number of reverse proxies you put in front — the client IP is
+      # then read that many entries from the right of X-Forwarded-For. Leaving it
+      # at 0 behind a proxy funnels every caller into one bucket; setting it above
+      # the real number of hops lets callers choose their own.
+      TRUST_PROXY_HOPS: ${TRUST_PROXY_HOPS:-0}
       CORS_ORIGINS: ${CORS_ORIGINS:?CORS_ORIGINS is required}
       ATTACHMENT_TYPE_RESTRICTION_ENABLED: ${ATTACHMENT_TYPE_RESTRICTION_ENABLED:-false}
       ATTACHMENT_ALLOWED_MIME_TYPES: ${ATTACHMENT_ALLOWED_MIME_TYPES:-image/jpeg,image/png,image/gif,application/pdf,application/zip,text/plain}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,13 @@ services:
       - JWT_SECRET=${JWT_SECRET}
       - JWT_EXPIRES_IN=${JWT_EXPIRES_IN}
       - RATE_LIMIT_DISABLED=${RATE_LIMIT_DISABLED}
+      # The dev stack is reached directly on the published ports, with nothing in
+      # front to write X-Forwarded-For, so no hop is trusted here. Both names are
+      # pass-through only: set TRUST_PROXY_HOPS on the host if you put a proxy
+      # (Tailscale Serve, a local nginx) in front of this stack. Production does
+      # not read either — docker-compose.prod.yml pins its own value.
       - TRUST_PROXY=${TRUST_PROXY:-false}
+      - TRUST_PROXY_HOPS
       - CORS_ORIGINS=${CORS_ORIGINS}
       - ATTACHMENT_TYPE_RESTRICTION_ENABLED=${ATTACHMENT_TYPE_RESTRICTION_ENABLED:-false}
       - ATTACHMENT_ALLOWED_MIME_TYPES=${ATTACHMENT_ALLOWED_MIME_TYPES:-image/jpeg,image/png,image/gif,application/pdf,application/zip,text/plain}

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -88,6 +88,62 @@ For browser-facing frontend requests, set the API environment variable to:
 NEXT_PUBLIC_API_URL=http://localhost:4005
 ```
 
+### Production Ingress & Proxy Trust
+
+`docker-compose.prod.yml` publishes every host port on `127.0.0.1`, so the local
+walkthrough (`http://localhost:3005`) still works while the only route in from the
+network is the Cloudflare Tunnel. `cloudflared` reaches `frontend:3000` and
+`backend:4000` over the compose network, which does not involve published ports at
+all.
+
+Rate limiting buckets callers by IP, so it needs to know the caller's real address.
+Through a tunnel the peer address is always the `cloudflared` container, which
+would put every external user in one bucket — ten failed logins from anyone would
+lock out the whole service for 15 minutes. `TRUST_PROXY_HOPS` closes that:
+
+| Value | Meaning |
+|-------|---------|
+| unset / `0` | Trust nothing; use the TCP peer address. Correct for the dev stack and any deployment reached directly. |
+| `n` | `n` reverse proxies you operate sit in front. The client IP is read `n` entries from the **right** of `X-Forwarded-For`. |
+
+Reading from the right matters. `X-Forwarded-For` is append-only, so entries a
+caller sends arrive on the left and only the rightmost `n` were written by
+infrastructure you control. Trusting the leftmost entry instead lets any caller
+name its own bucket — dodging its own limit, or spending someone else's.
+
+`docker-compose.prod.yml` sets `TRUST_PROXY_HOPS=1` literally rather than through
+`${...}`, because Compose interpolates from the project `.env` and a value copied
+from `.env.example` would otherwise silently override it. Add a hop for each extra
+proxy you place in front, editing the compose file where the topology is declared.
+
+To verify a deployment buckets on real client addresses:
+
+```bash
+# 1. Nothing but the tunnel may reach the backend. From another machine:
+curl -sS --max-time 5 http://<host>:4005/api/v1/auth/login   # must fail to connect
+curl -sS --max-time 5 http://<host>:5435                     # must fail to connect
+
+# 2. Through the tunnel, exhaust the auth limiter from one client.
+for i in $(seq 1 11); do
+  curl -s -o /dev/null -w '%{http_code}\n' -X POST https://<tunnel-host>/api/v1/auth/login \
+    -H 'Content-Type: application/json' -d '{"email":"nobody@example.com","password":"wrong"}'
+done
+# Expect 401s, then 429 once the window is spent.
+
+# 3. A second client (different network, e.g. phone on cellular) must still get
+#    401 rather than 429 — separate buckets.
+
+# 4. A forged header must not create a new bucket. From the already-limited
+#    client, still 429:
+curl -s -o /dev/null -w '%{http_code}\n' -X POST https://<tunnel-host>/api/v1/auth/login \
+  -H 'X-Forwarded-For: 203.0.113.7' \
+  -H 'Content-Type: application/json' -d '{"email":"nobody@example.com","password":"wrong"}'
+```
+
+If step 3 returns 429, the hop count is too low; if step 4 returns 401, it is too
+high. Note that `RATE_LIMIT_DISABLED=true` skips the limiter entirely, so unset it
+before testing.
+
 ### Environment Rules
 1. **Frontend prefix**: Any environment variable that must be readable on the browser-side of Next.js must be prefixed with `NEXT_PUBLIC_`.
 2. **Production injection**: Production should not depend on a checked-in `.env` file. Inject settings through your hosting platform configuration instead (e.g. Vercel, AWS Secrets Manager).

--- a/docs/ZH-TW/DEVELOPMENT.md
+++ b/docs/ZH-TW/DEVELOPMENT.md
@@ -82,6 +82,55 @@ Docker Compose 會將容器內部連接埠映射至主機的外部連接埠，�
 NEXT_PUBLIC_API_URL=http://localhost:4005
 ```
 
+### 正式環境入口拓撲與代理信任
+
+`docker-compose.prod.yml` 的所有主機連接埠都綁定在 `127.0.0.1`，因此文件記載的本機
+正式流程（`http://localhost:3005`）仍可運作，而外部網路唯一的入口是 Cloudflare
+Tunnel。`cloudflared` 是透過 compose 網路連到 `frontend:3000` 與 `backend:4000`，
+完全不經過已發布的主機連接埠。
+
+速率限制以來源 IP 分桶，因此必須知道呼叫端的真實位址。經過 tunnel 時，實際連線位址
+永遠是 `cloudflared` 容器，等於所有外部使用者共用同一個桶 —— 任何人 10 次登入失敗就
+會讓全服務被鎖 15 分鐘。`TRUST_PROXY_HOPS` 用來解決這件事：
+
+| 值 | 意義 |
+|----|------|
+| 未設定 / `0` | 不信任任何代理，直接採用 TCP 連線位址。開發堆疊與任何直連部署皆適用。 |
+| `n` | 前方有 `n` 層自行維運的反向代理，來源 IP 取 `X-Forwarded-For` 由**右**數來第 `n` 段。 |
+
+「由右數」是關鍵。`X-Forwarded-For` 只會被附加，呼叫端自行帶入的內容一定落在左側，
+只有最右邊 `n` 段是我們掌控的基礎設施寫入的。若改採最左段，任何呼叫端都能自選限流
+桶 —— 迴避自己的額度，或去消耗別人的。
+
+`docker-compose.prod.yml` 是直接寫死 `TRUST_PROXY_HOPS=1` 而非使用 `${...}`：Compose
+會讀取專案 `.env` 進行插值，若沿用 `.env.example` 的值會靜默覆寫此預設。前方每多一層
+代理就加一，並直接修改宣告該拓撲的 compose 檔。
+
+驗證部署確實以真實來源 IP 分桶：
+
+```bash
+# 1. 除 tunnel 外不應有其他途徑觸及 backend。在另一台機器上執行：
+curl -sS --max-time 5 http://<host>:4005/api/v1/auth/login   # 必須連線失敗
+curl -sS --max-time 5 http://<host>:5435                     # 必須連線失敗
+
+# 2. 經 tunnel 以單一用戶端耗盡 auth 限流額度。
+for i in $(seq 1 11); do
+  curl -s -o /dev/null -w '%{http_code}\n' -X POST https://<tunnel-host>/api/v1/auth/login \
+    -H 'Content-Type: application/json' -d '{"email":"nobody@example.com","password":"wrong"}'
+done
+# 預期先出現 401，額度用盡後轉為 429。
+
+# 3. 第二個用戶端（不同網路，例如手機行動網路）應仍取得 401 而非 429，代表分桶獨立。
+
+# 4. 偽造標頭不得建立新的桶。以已被限流的用戶端執行，應仍為 429：
+curl -s -o /dev/null -w '%{http_code}\n' -X POST https://<tunnel-host>/api/v1/auth/login \
+  -H 'X-Forwarded-For: 203.0.113.7' \
+  -H 'Content-Type: application/json' -d '{"email":"nobody@example.com","password":"wrong"}'
+```
+
+若步驟 3 回傳 429，表示 hop 數設得太低；若步驟 4 回傳 401，表示設得太高。另外
+`RATE_LIMIT_DISABLED=true` 會整個跳過限流，測試前請先取消該設定。
+
 ### 環境變數規則
 1. **前端前綴**：任何需要在 Next.js 瀏覽器端讀取的環境變數，都必須加上 `NEXT_PUBLIC_` 前綴。
 2. **生產環境注入**：生產環境不應該依賴已提交的 `.env` 檔案，請改為透過雲端託管平台（例如 Vercel、AWS Secrets Manager）的設定來注入環境變數。


### PR DESCRIPTION
## 變更描述 (Description)

正式部署下所有外部流量經 `cloudflared` 進入 backend。在 `TRUST_PROXY=false`（目前預設）之下，`getClientIp()` 取到的一律是 tunnel 容器的位址，等於所有外部使用者共用同一個限流桶：auth limiter 預設 15 分鐘 10 次，任一批 10 次登入嘗試即可讓全服務被限流 15 分鐘。

但**單純把 `TRUST_PROXY` 改為 `true` 會換來另一個問題**。`X-Forwarded-For` 只會被附加，Cloudflare 會把真實來源附加在用戶端自帶內容之後：

```
用戶端送出:  X-Forwarded-For: 203.0.113.7
backend 收到: X-Forwarded-For: 203.0.113.7, <真實來源 IP>
```

取「第一段」拿到的正是 `203.0.113.7` —— 用戶端可控的值。任何人都能藉此自選限流桶，迴避自己的額度或去消耗別人的。issue #413 驗收標準明確要求排除這條路徑。

### 作法一：以層數取代布林開關

新增 `TRUST_PROXY_HOPS`，宣告前方有幾層**自行維運**的代理，來源 IP 取 `X-Forwarded-For` 由**右**數來第 n 段：

| 值 | 行為 |
|---|---|
| 未設定 / `0` | 不信任任何代理，採用實際 TCP 連線位址 |
| `n` | 取由右數來第 n 段 |

右側是各層代理自己寫入的，左側是用戶端可控的，用層數即可分辨。用戶端往鏈上前綴任何內容都只是加長不受信任的左側，無法把索引移到自己能控制的值上。鏈長不足 n 段時（代表請求並非由預期路徑進來）回退至實際連線位址，而非退而求其次採用最左段。

舊的布林 `TRUST_PROXY=true` 仍相容，視為 1 層 —— 既有環境不會靜默失效，同時也不再讀取可偽造的那一端。

### 作法二：收斂正式環境入口

`docker-compose.prod.yml` 的所有主機連接埠改綁 `127.0.0.1`：

```diff
-      - "4005:4000"     # backend
+      - "127.0.0.1:4005:4000"
-      - "5435:5432"     # db
+      - "127.0.0.1:5435:5432"
-      - "3005:3000"     # frontend
+      - "127.0.0.1:3005:3000"
```

`cloudflared` 是透過 compose 網路連到 `frontend:3000` 與 `backend:4000`，完全不經過已發布的主機連接埠，因此不受影響；而文件記載的本機正式流程（瀏覽器連 `localhost:3005` / `localhost:4005`）維持可用。外部網路則無法再直接觸及 backend 與 db。這正是 issue #413 候選方案中的第一項。

`TRUST_PROXY_HOPS=1` **直接寫死而非 `${TRUST_PROXY_HOPS:-1}`**：Compose 會讀取專案 `.env` 進行插值，沿用 `.env.example` 的值會靜默覆寫此預設 —— issue #413 已記錄過這個陷阱（實測 `${TRUST_PROXY:-true}` 被 `.env.example` 的 `false` 蓋掉）。正式 compose 不再傳入 `TRUST_PROXY`，該變數在正式環境完全失效，陷阱消失。

`docker-compose.release.yml` 則是直接發布連接埠、前方無代理的拓撲，因此預設 `TRUST_PROXY_HOPS: ${TRUST_PROXY_HOPS:-0}` 並開放給自行架設代理的部署者調整。

### 文件

`.env.example`、`README.md`、`README.zh-TW.md`、`docs/DEVELOPMENT.md`、`docs/ZH-TW/DEVELOPMENT.md` 同步更新；DEVELOPMENT 新增「正式環境入口拓撲與代理信任」一節，含可執行的驗證步驟。release bundle 的 `near-chat.env.example` 亦加入此變數。

本 PR 為 `docs/reports/deep-research-report.md` 中列為 P0 的第三項。

## 相關的 Issue (Related Issue)

Closes #413

## 變更類型 (Type of Change)
- [x] `fix`: 修復 Bug
- [x] `docs`: 修改文件
- [x] `test`: 新增或修正測試案例
- [x] `ci`: CI 設定變更（release bundle 的 env 範本）

## 驗證與測試計畫 (Verification & Test Plan)

### 本地測試 (Local Tests)
- [x] 後端型別檢查 (`pnpm exec tsc --noEmit`)
- [x] 後端 Linter 檢查 (`pnpm exec eslint src`)
- [x] 單元測試（443 passed）
- [x] 整合測試（33 passed，含 ephemeral db-test）
- [x] E2E 測試（73 passed）

### 新增測試

`backend/tests/e2e/rateLimitBucketing.e2e.test.ts` —— 既有測試都以合成 Context 驅動 `getClientIp`，無法證明實際連線位址在執行期真的取得到，而那正是不信任代理時的唯一依據。新測試讓請求真的走 TCP 經過 `@hono/node-server`（與正式環境同一個 adapter），涵蓋：

- 未信任代理時回退至實際連線位址，且 `X-Forwarded-For` 完全不影響分桶
- 信任 1 層時，不同用戶端分屬不同桶（tunnel 的失效模式）
- 用戶端前綴鏈上內容無法脫離自己的桶
- 鏈長不足宣告層數時回退至連線位址

`clientIp.test.ts` 與 `securityMiddleware.test.ts` 一併改寫，原本的 `uses only the first hop of a forwarded chain` 正是本 PR 要移除的行為。

### 手動測試 (Manual Verification)

**1. 對照驗證** —— 把 `forwarded[forwarded.length - hops]` 暫時改回 `forwarded[0]` 後重跑，6 項測試失敗，其中包含兩項偽造情境，確認測試確實在測新行為：

```
(fail) does not let a caller escape its bucket by prepending to the chain
(fail) falls back to the peer address for a request that skipped the proxy
(fail) reads one hop back from the right when one proxy is trusted
(fail) ignores entries a client prepends to the chain
(fail) skips the declared number of hops
(fail) falls back to the socket when the chain is shorter than the trusted hops
```

**2. loopback 綁定語意** —— 以拋棄式容器實測，確認「本機可連、外部連不到」確實成立：

| 綁定 | 經 `127.0.0.1` | 經 LAN IP |
|---|---|---|
| `127.0.0.1:18099:80` | `200` | 連線被拒 |
| `18099:80`（對照） | — | `200` |

**3. Compose 解析結果** —— `docker compose -f docker-compose.prod.yml config` 在專案 `.env`（內含 `TRUST_PROXY=false`）存在的情況下解析為：

```yaml
TRUST_PROXY_HOPS: "1"
host_ip: 127.0.0.1   # 4005 / 5435 / 3005 三者皆是
```

確認 `.env` 不再能靜默覆寫正式環境的設定。三個 compose 檔均通過 `docker compose config`，`release-stack.yml` 亦通過 YAML 解析並確認 heredoc 產出正確。

**4. 前端連線路徑未受影響** —— `frontend/src/lib/api.ts` 在 port 為 `3005` 時回退至 `hostname:4005`，瀏覽器位於主機上時可正常連到 loopback 綁定的 4005，故文件記載的本機正式流程 REST 與 Socket.IO 皆維持正常。

**5. 經 tunnel 的實際驗證步驟**已寫入 `docs/DEVELOPMENT.md` 與 ZH-TW 版本（耗盡單一用戶端額度 → 確認第二用戶端不受影響 → 確認偽造標頭無法換桶），並說明 hop 數過低／過高各自的症狀。

## 資料庫變更 (Database Changes)
* 此變更是否包含資料庫 Schema 修改？ **否**

## API 與 WebSocket 協定一致性 (API & WebSocket Contract Check)
* 此變更是否涉及 API 路由或 WebSocket 事件的資料結構變更？ **否**
* 限流的 `429` / `TOO_MANY_REQUESTS` 回應形狀不變，僅分桶依據改變。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6mD6HGYtTphyzsAW1DFmL
