### PR TITLE
refactor(backend): 將 composition root 拆分為 bootstrap 工廠

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -10,7 +10,8 @@ This directory contains the Bun + Hono TypeScript API server for the chat applic
 
 | File | Description |
 |------|-------------|
-| [src/index.ts](src/index.ts) | Composition Root: Instantiates database pool, repositories, services, Hono routes, Socket.IO handlers, and launches the HTTP server |
+| [src/index.ts](src/index.ts) | Composition Root: calls the `src/bootstrap/` factories in dependency order and launches the HTTP server. Holds wiring only — no construction logic of its own |
+| [src/bootstrap/](src/bootstrap/) | One factory per assembly stage: `config`, `repositories`, `services`, `httpApp`, `realtime`, `jobs`, `start` |
 | [src/models/db.ts](src/models/db.ts) | Exports the shared `pg.Pool` instance initialized from the `DATABASE_URL` environment variable |
 | [migrations/](migrations/) | PostgreSQL migration files written in raw SQL managed by `node-pg-migrate` |
 | [package.json](package.json) | NPM scripts (`pnpm run dev` for `bun --watch`, `pnpm run test`) and dependencies |

--- a/backend/src/CLAUDE.md
+++ b/backend/src/CLAUDE.md
@@ -10,6 +10,7 @@ This directory contains the TypeScript source code for the backend service built
 
 | Directory | Layer & Role | Code Standards & Guidelines |
 |-----------|--------------|----------------------------|
+| [bootstrap/](bootstrap/) | **Assembly Layer** | One factory per stage of startup — `config`, `repositories`, `services`, `httpApp`, `realtime`, `jobs`, `start` — called in dependency order by [index.ts](index.ts). Wiring only: no business rules, no SQL, no route handlers. Services are built before Socket.IO exists, so they receive a `getIo` accessor rather than the server itself; see the comment in `bootstrap/services.ts` before changing that order. |
 | [routes/](routes/) | **Routing Layer** | Defines Hono HTTP endpoints, mounts validation middleware via `zValidator`, extracts auth context (`c.get('user')`), and delegates to the Service layer. Also holds the Zod schemas validating each route's payloads (e.g. `userSchemas.ts`, `roomSchemas.ts`, `folderSchemas.ts`, `messageSchemas.ts`). |
 | [services/](services/) | **Business Logic Layer** | Domain orchestration and permission checking. Throws `AppError` subclasses. |
 | [models/](models/) | **Data Access Layer** | Executes raw SQL statements, and holds the shared `pg.Pool` in `db.ts`. Repositories must conform to corresponding interfaces (e.g., `IRoomRepository.ts`) to allow mock testing. |
@@ -20,7 +21,7 @@ This directory contains the TypeScript source code for the backend service built
 ## AI Agent Guidelines
 
 ### 1. Interface-Driven Design
-- Repositories utilize interface declarations (e.g., `IMessageRepository`) which are instantiated in the composition root [index.ts](index.ts).
+- Repositories utilize interface declarations (e.g., `IMessageRepository`) which are instantiated in [bootstrap/repositories.ts](bootstrap/repositories.ts) and handed to services by [bootstrap/services.ts](bootstrap/services.ts).
 - This structure enables unit tests to inject mocked repositories via Bun test, checking services in isolation. Always write unit tests by mocking interfaces.
 
 ### 2. JWT & Socket Authorization

--- a/backend/src/bootstrap/config.ts
+++ b/backend/src/bootstrap/config.ts
@@ -1,0 +1,34 @@
+const DEFAULT_CORS_ORIGINS = [
+  'http://localhost:3000',
+  'http://localhost:3005',
+  'http://localhost:5173',
+];
+
+export interface AppConfig {
+  /**
+   * Left as `string | number` because that is what `process.env.PORT || 4000`
+   * has always produced, and `server.listen` accepts both. Coercing it here
+   * would change what a non-numeric `PORT` does — today it reaches `listen` as
+   * a string, which Node treats as a pipe path — and this refactor is meant to
+   * move code, not alter startup behaviour.
+   */
+  port: string | number;
+  corsOrigins: string[];
+}
+
+/**
+ * The environment this process was started with, read once.
+ *
+ * Deliberately narrow: only the values the composition root needs to wire
+ * things together. Everything else still reads `process.env` where it is used.
+ * Pulling those in — with a schema, fail-fast validation and coercion — is its
+ * own piece of work, and folding it in here would bury a behavioural change
+ * (startup that now refuses to boot on bad input) inside a structural refactor.
+ */
+export const createConfig = (env: NodeJS.ProcessEnv = process.env): AppConfig => ({
+  port: env.PORT || 4000,
+  corsOrigins: (env.CORS_ORIGINS ?? DEFAULT_CORS_ORIGINS.join(','))
+    .split(',')
+    .map((origin) => origin.trim())
+    .filter(Boolean),
+});

--- a/backend/src/bootstrap/httpApp.ts
+++ b/backend/src/bootstrap/httpApp.ts
@@ -1,0 +1,88 @@
+import { Hono } from 'hono';
+import { cors } from 'hono/cors';
+import path from 'path';
+import type { AppConfig } from './config';
+import type { Services } from './services';
+import { errorHandler } from '../middlewares/errorHandler';
+import { authMiddleware } from '../middlewares/authMiddleware';
+import { makeAuthRateLimiter, makeGlobalRateLimiter, securityHeaders } from '../middlewares/securityMiddleware';
+import { makeAuthRoutes } from '../routes/authRoutes';
+import { makeUserRoutes } from '../routes/userRoutes';
+import { makeRoomRoutes } from '../routes/roomRoutes';
+import { makeMessageRoutes } from '../routes/messageRoutes';
+import { makeFolderRoutes } from '../routes/folderRoutes';
+import { makeAttachmentRoutes } from '../routes/attachmentRoutes';
+import { makeFriendRoutes, makeBlockRoutes, makeFriendRequestRoutes } from '../routes/friendRoutes';
+import { AVATARS_UPLOAD_DIR, ensureUploadDirectories } from '../utils/uploads';
+import { avatarContentType } from '../utils/avatarUpload';
+
+export interface CreateHttpAppDeps {
+  services: Services;
+  config: AppConfig;
+}
+
+/**
+ * The Hono application: middleware, static uploads and every API route.
+ *
+ * Middleware order is load-bearing and preserved as it was — security headers
+ * and CORS wrap everything, the global limiter covers `/api/*`, and the auth
+ * limiter is mounted on `/api/v1/auth/*` ahead of the auth routes themselves.
+ */
+export const createHttpApp = ({ services, config }: CreateHttpAppDeps): Hono => {
+  const honoApp = new Hono();
+
+  honoApp.use('*', securityHeaders);
+  honoApp.use(
+    '*',
+    cors({
+      origin: (origin) => (config.corsOrigins.includes(origin) ? origin : null),
+      credentials: true,
+    }),
+  );
+
+  honoApp.use('/api/*', makeGlobalRateLimiter());
+
+  // Fired and not awaited, as before: the directories are only needed by the
+  // time an upload or a read of one arrives, not to serve the first request.
+  void ensureUploadDirectories();
+
+  honoApp.get('/uploads/avatars/*', async (c) => {
+    const reqPath = c.req.path.replace('/uploads/avatars/', '');
+    const fileName = path.basename(reqPath);
+    const filePath = path.join(AVATARS_UPLOAD_DIR, fileName);
+    const file = Bun.file(filePath);
+    if (await file.exists()) {
+      return new Response(file, {
+        status: 200,
+        headers: {
+          'Content-Type': avatarContentType(fileName),
+          'Cache-Control': 'public, max-age=604800, immutable',
+          'Cross-Origin-Resource-Policy': 'cross-origin',
+        },
+      });
+    }
+    return c.notFound();
+  });
+
+  honoApp.use('/api/v1/auth/*', makeAuthRateLimiter());
+  honoApp.route('/api/v1/auth', makeAuthRoutes(services.user));
+  honoApp.route('/api/v1/users', makeUserRoutes(services.user));
+
+  // Room and message routes share one auth-guarded sub-app so `authMiddleware`
+  // is applied once for both.
+  const roomApi = new Hono();
+  roomApi.use('*', authMiddleware);
+  roomApi.route('/', makeRoomRoutes(services.room));
+  roomApi.route('/', makeMessageRoutes(services.message));
+  honoApp.route('/api/v1/rooms', roomApi);
+
+  honoApp.route('/api/v1/folders', makeFolderRoutes(services.folder));
+  honoApp.route('/api/v1/attachments', makeAttachmentRoutes(services.attachment));
+  honoApp.route('/api/v1/friends', makeFriendRoutes(services.friend));
+  honoApp.route('/api/v1/friend-requests', makeFriendRequestRoutes(services.friend));
+  honoApp.route('/api/v1/blocks', makeBlockRoutes(services.friend));
+
+  honoApp.onError(errorHandler);
+
+  return honoApp;
+};

--- a/backend/src/bootstrap/jobs.ts
+++ b/backend/src/bootstrap/jobs.ts
@@ -1,0 +1,18 @@
+import type { Repositories } from './repositories';
+import type { Services } from './services';
+import { startInactivityJob } from '../utils/inactivityJob';
+
+export interface StartJobsDeps {
+  repositories: Repositories;
+  services: Services;
+}
+
+/**
+ * Background timers.
+ *
+ * Started only when this process is the entrypoint — importing the app (as the
+ * E2E suite does) must not leave a live interval behind holding the runner open.
+ */
+export const startJobs = ({ repositories, services }: StartJobsDeps): void => {
+  startInactivityJob(repositories.users, services.user);
+};

--- a/backend/src/bootstrap/realtime.ts
+++ b/backend/src/bootstrap/realtime.ts
@@ -1,0 +1,53 @@
+import { createServer, type Server as HttpServer } from 'node:http';
+import { getRequestListener } from '@hono/node-server';
+import { Server } from 'socket.io';
+import type { Hono } from 'hono';
+import type { ClientToServerEvents, ServerToClientEvents } from '@shared/types';
+import type { AppConfig } from './config';
+import type { Repositories } from './repositories';
+import type { Services } from './services';
+import type { ChatServer } from '../realtime/authSocket';
+import { attachSocketAuth } from '../realtime/authSocket';
+import { attachSockets } from '../realtime/socketServer';
+
+/**
+ * The `node:http` server that fronts the Hono app.
+ *
+ * Socket.IO needs a real Node server to attach its upgrade handling to, which
+ * is why Hono is adapted through `getRequestListener` rather than served
+ * directly.
+ */
+export const createHttpServer = (honoApp: Hono): HttpServer =>
+  createServer(getRequestListener(honoApp.fetch));
+
+export interface CreateRealtimeDeps {
+  httpServer: HttpServer;
+  config: AppConfig;
+  services: Services;
+  repositories: Repositories;
+}
+
+/**
+ * The Socket.IO server, sharing a port with the REST API, with auth and event
+ * handlers attached.
+ */
+export const createRealtime = ({
+  httpServer,
+  config,
+  services,
+  repositories,
+}: CreateRealtimeDeps): ChatServer => {
+  const io = new Server<ClientToServerEvents, ServerToClientEvents>(httpServer, {
+    cors: { origin: config.corsOrigins, credentials: true },
+  }) as ChatServer;
+
+  attachSocketAuth(io);
+  attachSockets(io, {
+    messageService: services.message,
+    messageRepository: repositories.messages,
+    roomMemberRepository: repositories.roomMembers,
+    friendRepository: repositories.friends,
+  });
+
+  return io;
+};

--- a/backend/src/bootstrap/repositories.ts
+++ b/backend/src/bootstrap/repositories.ts
@@ -1,0 +1,42 @@
+import type sql from '../models/db';
+import { UserRepository } from '../models/userRepository';
+import { EmergencyContactRepository } from '../models/emergencyContactRepository';
+import { RoomRepository } from '../models/roomRepository';
+import { RoomMemberRepository } from '../models/roomMemberRepository';
+import { MessageRepository } from '../models/messageRepository';
+import { FolderRepository } from '../models/folderRepository';
+import { AttachmentRepository } from '../models/attachmentRepository';
+import { RefreshTokenRepository } from '../models/refreshTokenRepository';
+import { makeFriendRepository } from '../models/friendRepository';
+
+export type Db = typeof sql;
+
+export interface Repositories {
+  users: UserRepository;
+  emergencyContacts: EmergencyContactRepository;
+  rooms: RoomRepository;
+  roomMembers: RoomMemberRepository;
+  messages: MessageRepository;
+  folders: FolderRepository;
+  attachments: AttachmentRepository;
+  refreshTokens: RefreshTokenRepository;
+  friends: ReturnType<typeof makeFriendRepository>;
+}
+
+/**
+ * Every repository, bound to one database handle.
+ *
+ * Repositories are stateless over the handle, so construction order carries no
+ * meaning here — unlike the services, which reference one another.
+ */
+export const createRepositories = (db: Db): Repositories => ({
+  users: new UserRepository(db),
+  emergencyContacts: new EmergencyContactRepository(db),
+  rooms: new RoomRepository(db),
+  roomMembers: new RoomMemberRepository(db),
+  messages: new MessageRepository(db),
+  folders: new FolderRepository(db),
+  attachments: new AttachmentRepository(db),
+  refreshTokens: new RefreshTokenRepository(db),
+  friends: makeFriendRepository(db),
+});

--- a/backend/src/bootstrap/services.ts
+++ b/backend/src/bootstrap/services.ts
@@ -1,0 +1,145 @@
+import type { ServerToClientEvents } from '@shared/types';
+import type { ChatServer } from '../realtime/authSocket';
+import type { Repositories } from './repositories';
+import { signToken, generateRefreshToken, hashToken } from '../utils/jwt';
+import { makeUserService } from '../services/userService';
+import { makeRoomService } from '../services/roomService';
+import { makeMessageService } from '../services/messageService';
+import { makeFolderService } from '../services/folderService';
+import { makeAttachmentService } from '../services/attachmentService';
+import { makeFriendService } from '../services/friendService';
+
+export interface Services {
+  user: ReturnType<typeof makeUserService>;
+  room: ReturnType<typeof makeRoomService>;
+  message: ReturnType<typeof makeMessageService>;
+  folder: ReturnType<typeof makeFolderService>;
+  attachment: ReturnType<typeof makeAttachmentService>;
+  friend: ReturnType<typeof makeFriendService>;
+}
+
+export interface CreateServicesDeps {
+  repositories: Repositories;
+  /**
+   * Resolves the Socket.IO server at emit time rather than at construction.
+   *
+   * The wiring is genuinely circular: services need to emit through `io`, `io`
+   * is built on the HTTP server, the HTTP server serves the Hono app, and the
+   * routes on that app need the services. Previously every one of these lived
+   * in one module scope, so the emit callbacks simply closed over an `io` that
+   * was assigned further down the file. Splitting the wiring across modules
+   * removes that shared scope, and this accessor is what replaces it.
+   *
+   * Nothing here emits during construction, so by the time any of these
+   * callbacks run — on an HTTP request, a socket event or the inactivity timer
+   * — `io` exists.
+   */
+  getIo: () => ChatServer;
+}
+
+/**
+ * Every service, wired to its repositories and to the realtime server.
+ *
+ * Construction order matters: `userService`'s emergency callback calls
+ * `roomService` and `messageService`, and `friendService` is handed three of
+ * `roomService`'s methods. Those references resolve when the callbacks fire,
+ * not while this function runs, which is what lets `userService` be built
+ * first — exactly as it was when this lived in `index.ts`.
+ */
+export const createServices = ({ repositories, getIo }: CreateServicesDeps): Services => {
+  const userService = makeUserService(
+    repositories.users,
+    repositories.emergencyContacts,
+    repositories.refreshTokens,
+    { signToken, generateRefreshToken, hashToken },
+    async (contactId, payload) => {
+      let room = await repositories.rooms.findPrivateRoomByMembers(payload.userId, contactId);
+      if (!room) {
+        try {
+          const result = await roomService.createPrivate(payload.userId, contactId, true);
+          room = result.room;
+        } catch (err) {
+          console.error('Failed to auto-create private room for emergency contact:', err);
+        }
+      }
+
+      if (room) {
+        try {
+          const message = await messageService.sendMessage(payload.userId, room.roomId, payload.message);
+          getIo().to(`room_${room.roomId}`).emit('new_message', message);
+        } catch (err) {
+          console.error('Failed to auto-send emergency message:', err);
+          getIo().to(`user_${contactId}`).emit('emergency_alert', payload);
+        }
+      } else {
+        getIo().to(`user_${contactId}`).emit('emergency_alert', payload);
+      }
+    },
+    repositories.friends,
+    async (userId, data) => {
+      try {
+        const rooms = await repositories.rooms.findByMember(userId);
+        for (const room of rooms) {
+          getIo().to(`room_${room.roomId}`).emit('room_update', {
+            type: 'USER_UPDATED',
+            roomId: room.roomId,
+            data: { userId, ...data },
+          });
+        }
+      } catch (err) {
+        console.error('Failed to broadcast user update:', err);
+      }
+    },
+  );
+
+  const roomService = makeRoomService(
+    repositories.rooms,
+    repositories.roomMembers,
+    (roomId, eventName, payload) => {
+      if (eventName === 'room_update') {
+        const p = payload as { type: string; data: unknown };
+        getIo().to(`room_${roomId}`).emit('room_update', { ...p, roomId });
+      } else {
+        getIo().to(`room_${roomId}`).emit(eventName as keyof ServerToClientEvents, payload as never);
+      }
+    },
+    repositories.friends,
+    repositories.users,
+    repositories.messages,
+    (userId, eventName, payload) => {
+      getIo().to(`user_${userId}`).emit(eventName as keyof ServerToClientEvents, payload as never);
+    },
+  );
+
+  const messageService = makeMessageService(
+    repositories.messages,
+    repositories.rooms,
+    repositories.roomMembers,
+  );
+
+  const folderService = makeFolderService(repositories.folders, repositories.roomMembers);
+
+  const attachmentService = makeAttachmentService(repositories.attachments);
+
+  const friendService = makeFriendService(
+    repositories.friends,
+    (userId, eventName, payload) => {
+      getIo().to(`user_${userId}`).emit(eventName as keyof ServerToClientEvents, payload as never);
+    },
+    {
+      markPrivateReadOnly: roomService.markPrivateReadOnly,
+      createPrivate: (userA: string, userB: string, bypassFriendCheck?: boolean) =>
+        roomService.createPrivate(userA, userB, bypassFriendCheck),
+      reopenPrivateRoom: roomService.reopenPrivateRoom,
+    },
+  );
+
+  return {
+    user: userService,
+    room: roomService,
+    message: messageService,
+    folder: folderService,
+    attachment: attachmentService,
+    friend: friendService,
+  };
+};

--- a/backend/src/bootstrap/start.ts
+++ b/backend/src/bootstrap/start.ts
@@ -1,0 +1,38 @@
+import path from 'path';
+import type { Server as HttpServer } from 'node:http';
+import type { AppConfig } from './config';
+
+/**
+ * The running version, for the startup log line only.
+ *
+ * The workspace root manifest is the source of truth; the backend's own is the
+ * fallback for when the process runs with the package as its working directory.
+ * Both lookups stay best-effort — a missing or unreadable manifest must not stop
+ * the server from booting.
+ */
+const resolveVersion = async (): Promise<string> => {
+  try {
+    return (await Bun.file(path.join(process.cwd(), '../package.json')).json()).version;
+  } catch {
+    try {
+      return (await Bun.file(path.join(process.cwd(), 'package.json')).json()).version;
+    } catch {
+      return '1.0.0';
+    }
+  }
+};
+
+export interface StartServerDeps {
+  httpServer: HttpServer;
+  config: AppConfig;
+}
+
+export const startServer = async ({ httpServer, config }: StartServerDeps): Promise<void> => {
+  const version = await resolveVersion();
+
+  httpServer.listen(config.port as number, '0.0.0.0', () =>
+    console.log(
+      `Backend server (v${version}) successfully listening on port ${config.port} (0.0.0.0)`,
+    ),
+  );
+};

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,223 +1,50 @@
-import { Hono } from "hono";
-import { cors } from "hono/cors";
-import { getRequestListener } from "@hono/node-server";
-import { createServer } from "node:http";
-import path from "path";
-import { Server } from "socket.io";
-import pool from "./models/db";
-import { signToken, generateRefreshToken, hashToken } from "./utils/jwt";
-import { RefreshTokenRepository } from "./models/refreshTokenRepository";
-import { errorHandler } from "./middlewares/errorHandler";
-import { authMiddleware } from "./middlewares/authMiddleware";
-import { makeAuthRateLimiter, makeGlobalRateLimiter, securityHeaders } from "./middlewares/securityMiddleware";
-import { UserRepository } from "./models/userRepository";
-import { EmergencyContactRepository } from "./models/emergencyContactRepository";
-import { RoomRepository } from "./models/roomRepository";
-import { RoomMemberRepository } from "./models/roomMemberRepository";
-import { MessageRepository } from "./models/messageRepository";
-import { FolderRepository } from "./models/folderRepository";
-import { AttachmentRepository } from "./models/attachmentRepository";
-import { makeAttachmentService } from "./services/attachmentService";
-import { makeAttachmentRoutes } from "./routes/attachmentRoutes";
-import { makeFriendRepository } from "./models/friendRepository";
-import { makeUserService } from "./services/userService";
-import { makeRoomService } from "./services/roomService";
-import { makeMessageService } from "./services/messageService";
-import { makeFolderService } from "./services/folderService";
-import { makeFriendService } from "./services/friendService";
-import { startInactivityJob } from "./utils/inactivityJob";
-import { makeAuthRoutes } from "./routes/authRoutes";
-import { makeUserRoutes } from "./routes/userRoutes";
-import { makeRoomRoutes } from "./routes/roomRoutes";
-import { makeMessageRoutes } from "./routes/messageRoutes";
-import { makeFolderRoutes } from "./routes/folderRoutes";
-import { makeFriendRoutes, makeBlockRoutes, makeFriendRequestRoutes } from "./routes/friendRoutes";
-import { attachSocketAuth } from "./realtime/authSocket";
-import { attachSockets } from "./realtime/socketServer";
-import { AVATARS_UPLOAD_DIR, ensureUploadDirectories } from "./utils/uploads";
-import { avatarContentType } from "./utils/avatarUpload";
-import type { ClientToServerEvents, ServerToClientEvents } from "../../shared/types";
+import db from "./models/db";
+import { createConfig } from "./bootstrap/config";
+import { createRepositories } from "./bootstrap/repositories";
+import { createServices } from "./bootstrap/services";
+import { createHttpApp } from "./bootstrap/httpApp";
+import { createHttpServer, createRealtime } from "./bootstrap/realtime";
+import { startJobs } from "./bootstrap/jobs";
+import { startServer } from "./bootstrap/start";
+import type { ChatServer } from "./realtime/authSocket";
 
-const honoApp = new Hono();
+/**
+ * Composition root.
+ *
+ * Assembly runs in dependency order — config, repositories, services, HTTP app,
+ * HTTP server, Socket.IO — with one knot: the services emit through Socket.IO,
+ * but Socket.IO cannot exist until there is an HTTP server, which serves the
+ * routes that those same services back. `getIo` is what unties it; the reasoning
+ * is in `bootstrap/services.ts`.
+ */
+const config = createConfig();
+const repositories = createRepositories(db);
 
-const DEFAULT_CORS_ORIGINS = ['http://localhost:3000', 'http://localhost:3005', 'http://localhost:5173'];
-const allowedOrigins = (process.env.CORS_ORIGINS ?? DEFAULT_CORS_ORIGINS.join(','))
-  .split(',')
-  .map((origin) => origin.trim())
-  .filter(Boolean);
-
-// Security Headers & CORS
-honoApp.use('*', securityHeaders);
-honoApp.use('*', cors({
-  origin: (origin) => (allowedOrigins.includes(origin) ? origin : null),
-  credentials: true,
-}));
-
-// Global Rate Limiter for API
-honoApp.use('/api/*', makeGlobalRateLimiter());
-
-// Static uploads serving
-void ensureUploadDirectories();
-honoApp.get('/uploads/avatars/*', async (c) => {
-  const reqPath = c.req.path.replace('/uploads/avatars/', '');
-  const fileName = path.basename(reqPath);
-  const filePath = path.join(AVATARS_UPLOAD_DIR, fileName);
-  const file = Bun.file(filePath);
-  if (await file.exists()) {
-    return new Response(file, {
-      status: 200,
-      headers: {
-        'Content-Type': avatarContentType(fileName),
-        'Cache-Control': 'public, max-age=604800, immutable',
-        'Cross-Origin-Resource-Policy': 'cross-origin',
-      },
-    });
+let pendingIo: ChatServer | undefined;
+const getIo = (): ChatServer => {
+  if (!pendingIo) {
+    throw new Error("Socket.IO server used before it was created");
   }
-  return c.notFound();
-});
+  return pendingIo;
+};
 
-const userRepo = new UserRepository(pool);
-const emergencyContactRepo = new EmergencyContactRepository(pool);
-const roomRepo = new RoomRepository(pool);
-const roomMemberRepo = new RoomMemberRepository(pool);
-const messageRepo = new MessageRepository(pool);
-const folderRepo = new FolderRepository(pool);
-const attachmentRepo = new AttachmentRepository(pool);
-const friendRepo = makeFriendRepository(pool);
-const refreshTokenRepo = new RefreshTokenRepository(pool);
+const services = createServices({ repositories, getIo });
+const honoApp = createHttpApp({ services, config });
+const server = createHttpServer(honoApp);
 
-const userService = makeUserService(
-  userRepo,
-  emergencyContactRepo,
-  refreshTokenRepo,
-  { signToken, generateRefreshToken, hashToken },
-  async (contactId, payload) => {
-    let room = await roomRepo.findPrivateRoomByMembers(payload.userId, contactId);
-    if (!room) {
-      try {
-        const result = await roomService.createPrivate(payload.userId, contactId, true);
-        room = result.room;
-      } catch (err) {
-        console.error('Failed to auto-create private room for emergency contact:', err);
-      }
-    }
+pendingIo = createRealtime({ httpServer: server, config, services, repositories });
 
-    if (room) {
-      try {
-        const message = await messageService.sendMessage(payload.userId, room.roomId, payload.message);
-        io.to(`room_${room.roomId}`).emit('new_message', message);
-      } catch (err) {
-        console.error('Failed to auto-send emergency message:', err);
-        io.to(`user_${contactId}`).emit('emergency_alert', payload);
-      }
-    } else {
-      io.to(`user_${contactId}`).emit('emergency_alert', payload);
-    }
-  },
-  friendRepo,
-  async (userId, data) => {
-    try {
-      const rooms = await roomRepo.findByMember(userId);
-      for (const room of rooms) {
-        io.to(`room_${room.roomId}`).emit('room_update', {
-          type: 'USER_UPDATED',
-          roomId: room.roomId,
-          data: { userId, ...data },
-        });
-      }
-    } catch (err) {
-      console.error('Failed to broadcast user update:', err);
-    }
-  }
-);
+// Re-bound as a definitely-assigned const so the export keeps the type it always
+// had; `pendingIo` is optional only to express the window before assignment.
+const io: ChatServer = pendingIo;
 
-const roomService = makeRoomService(
-  roomRepo,
-  roomMemberRepo,
-  (roomId, eventName, payload) => {
-    if (eventName === 'room_update') {
-      const p = payload as { type: string; data: unknown };
-      io.to(`room_${roomId}`).emit('room_update', { ...p, roomId });
-    } else {
-      io.to(`room_${roomId}`).emit(eventName as keyof ServerToClientEvents, payload as never);
-    }
-  },
-  friendRepo,
-  userRepo,
-  messageRepo,
-  (userId, eventName, payload) => {
-    io.to(`user_${userId}`).emit(eventName as keyof ServerToClientEvents, payload as never);
-  },
-);
-
-const messageService = makeMessageService(messageRepo, roomRepo, roomMemberRepo);
-const folderService = makeFolderService(folderRepo, roomMemberRepo);
-const attachmentService = makeAttachmentService(attachmentRepo);
-
-const friendService = makeFriendService(friendRepo, (userId, eventName, payload) => {
-  io.to(`user_${userId}`).emit(eventName as keyof ServerToClientEvents, payload as never);
-}, {
-  markPrivateReadOnly: roomService.markPrivateReadOnly,
-  createPrivate: (userA: string, userB: string, bypassFriendCheck?: boolean) => roomService.createPrivate(userA, userB, bypassFriendCheck),
-  reopenPrivateRoom: roomService.reopenPrivateRoom,
-});
-
-// Attach Hono API Routes
-honoApp.use('/api/v1/auth/*', makeAuthRateLimiter());
-honoApp.route('/api/v1/auth', makeAuthRoutes(userService));
-honoApp.route('/api/v1/users', makeUserRoutes(userService));
-
-const roomApi = new Hono();
-roomApi.use('*', authMiddleware);
-roomApi.route('/', makeRoomRoutes(roomService));
-roomApi.route('/', makeMessageRoutes(messageService));
-honoApp.route('/api/v1/rooms', roomApi);
-
-honoApp.route('/api/v1/folders', makeFolderRoutes(folderService));
-honoApp.route('/api/v1/attachments', makeAttachmentRoutes(attachmentService));
-honoApp.route('/api/v1/friends', makeFriendRoutes(friendService));
-honoApp.route('/api/v1/friend-requests', makeFriendRequestRoutes(friendService));
-honoApp.route('/api/v1/blocks', makeBlockRoutes(friendService));
-
-honoApp.onError(errorHandler);
-
-const requestListener = getRequestListener(honoApp.fetch);
-const server = createServer(requestListener);
+// The Node HTTP server under a second name, kept because the E2E suite hands
+// `app` to supertest.
 const app = server;
 
-const io = new Server<ClientToServerEvents, ServerToClientEvents>(server, {
-  cors: { origin: allowedOrigins, credentials: true },
-});
-
-const PORT = process.env.PORT || 4000;
-
-attachSocketAuth(io);
-attachSockets(io, {
-  messageService,
-  messageRepository: messageRepo,
-  roomMemberRepository: roomMemberRepo,
-  friendRepository: friendRepo
-});
-
 if (require.main === module) {
-  startInactivityJob(userRepo, userService);
-
-  (async () => {
-    let version = "1.0.0";
-    try {
-      const rootPkg = await Bun.file(path.join(process.cwd(), "../package.json")).json();
-      version = rootPkg.version;
-    } catch {
-      try {
-        const localPkg = await Bun.file(path.join(process.cwd(), "package.json")).json();
-        version = localPkg.version;
-      } catch {}
-    }
-
-    server.listen(PORT as number, "0.0.0.0", () =>
-      console.log(`Backend server (v${version}) successfully listening on port ${PORT} (0.0.0.0)`),
-    );
-  })();
+  startJobs({ repositories, services });
+  void startServer({ httpServer: server, config });
 }
 
 export { app, honoApp, server, io };


### PR DESCRIPTION
## 變更描述 (Description)

`index.ts` 目前同時負責建立所有 repositories 與 services、掛載 Hono 路由與 middleware、建立 Node HTTP server 與 Socket.IO server、啟動排程、讀取版本號並 listen —— 223 行裡把 runtime adapter 與業務流程協調混在一起，不只是 composition root。

拆為 `src/bootstrap/` 下每個組裝階段一個工廠，`index.ts` 縮為 50 行的純接線：

| 檔案 | 職責 | 行數 |
|---|---|---:|
| `bootstrap/config.ts` | 讀取 `PORT` 與 `CORS_ORIGINS` | 34 |
| `bootstrap/repositories.ts` | 9 個 repository，綁定同一個 db handle | 42 |
| `bootstrap/services.ts` | 6 個 service 與其事件 callback 接線 | 145 |
| `bootstrap/httpApp.ts` | middleware、靜態上傳路由、全部 API 路由 | 88 |
| `bootstrap/realtime.ts` | `node:http` server 與 Socket.IO server | 53 |
| `bootstrap/jobs.ts` | 背景排程 | 18 |
| `bootstrap/start.ts` | 版本解析與 listen | 38 |
| `index.ts` | 依相依順序呼叫上列工廠 | 50 |

### 組裝順序的循環

這是拆分中唯一有實質難度的地方。services 需要透過 `io` 發事件；`io` 建立在 HTTP server 之上；HTTP server 服務的路由又需要 services。原本所有東西都在同一個 module scope，callback 直接閉包到檔案下方才賦值的 `io`，循環被隱含地化解掉了。

拆檔後沒有共用 scope，改為傳入 `getIo` 存取器，在**發送當下**而非建構當下解析：

```ts
let pendingIo: ChatServer | undefined;
const getIo = (): ChatServer => { ... };

const services = createServices({ repositories, getIo });
const honoApp  = createHttpApp({ services, config });
const server   = createHttpServer(honoApp);
pendingIo      = createRealtime({ httpServer: server, config, services, repositories });
```

建構期間不會有任何發送，callback 一律在 HTTP 請求、socket 事件或排程觸發時才執行，因此 `io` 必然已存在。`bootstrap/services.ts` 與 `backend/src/CLAUDE.md` 都留了說明，避免後人「順手」改成建構期注入而踩到循環。

> 這個存取器是**最小限度**的解法，不是報告中的 `RealtimePublisher`。callback 的簽章與內容維持與原本逐字相同；把它換成 typed 的 transport port 是另一項 P1，獨立處理才看得清楚。

### 刻意不做的行為改變

本 PR 是純結構調整，以下都維持原樣：

- middleware 與路由掛載順序（順序具語意，逐條比對過）
- `ensureUploadDirectories()` 仍是 fire-and-forget，未加 `await`
- `require.main === module` 守衛，以及匯出 `{ app, honoApp, server, io }`
- **`PORT` 保留 `string | number`**。`process.env.PORT || 4000` 一直是這個型別，`server.listen` 兩者皆收。改成 `Number(...) || 4000` 會讓非數字的 `PORT` 從「被當成 pipe path」變成「靜默回退 4000」—— 那是行為變更，不該埋在重構裡。已於 `config.ts` 註記，屬 typed config module 那項 P1 的範圍。
- `io` 匯出型別維持既有的具體型別（未因內部改用 `let` 而變成 `| undefined`）。

## 相關的 Issue (Related Issue)

本項出自 `docs/reports/deep-research-report.md` 的 P1 清單（「拆分 `index.ts` composition root」），無對應 issue。

## 變更類型 (Type of Change)
- [x] `refactor`: 重構代碼
- [x] `docs`: 修改文件（`backend/CLAUDE.md`、`backend/src/CLAUDE.md` 的組裝層說明）

## 驗證與測試計畫 (Verification & Test Plan)

### 本地測試 (Local Tests)
- [x] 後端型別檢查 (`tsc --noEmit`)
- [x] 後端 Linter 檢查 (`eslint src`)
- [x] 單元測試（436 passed）
- [x] 整合測試（33 passed，含 ephemeral db-test）
- [x] E2E 測試（68 passed）

合計 537 項，與重構前的 `main` 基準完全一致 —— 本 PR 不新增也不刪減任何測試，測試套件本身就是「行為未變」的契約。E2E 直接 `import { app } from 'src/index'`，因此整條組裝鏈都被覆蓋；其中 `emergencyAlert.e2e.test.ts` 正好走過最麻煩的那條路徑（userService callback → roomService / messageService → io）。

### 手動測試 (Manual Verification)

測試全部以 `import` 方式載入模組，因此 **`require.main === module` 分支不在覆蓋範圍內** —— 若 `startJobs` 或 `startServer` 被拆壞，測試不會發現。故實際啟動伺服器驗證：

```
DB INIT: env=unknown target=localhost:5436/ntnu_test
Backend server (v2.1.0) successfully listening on port 4099 (0.0.0.0)
```

啟動日誌格式與版本解析（由 workspace root manifest 取得 `2.1.0`）皆與原本相同。各層探測：

| 探測 | 結果 | 驗證了什麼 |
|---|---|---|
| `GET /uploads/avatars/nope.png` | `404` | 靜態上傳路由 |
| `POST /api/v1/auth/login`（空 body） | `400` | auth 路由 ＋ rate limiter ＋ errorHandler |
| `GET /api/v1/users/me`（無 token） | `401` | `authMiddleware` |
| `GET /socket.io/?EIO=4&transport=polling` | `200` | Socket.IO 與 REST 共用同一個 server |

另：`bun test` 三個 tier 均正常結束未 hang，代表 `require.main` 守衛仍有效攔下 `startInactivityJob`，匯入模組不會留下 interval。

## 資料庫變更 (Database Changes)
* 此變更是否包含資料庫 Schema 修改？ **否**

## API 與 WebSocket 協定一致性 (API & WebSocket Contract Check)
* 此變更是否涉及 API 路由或 WebSocket 事件的資料結構變更？ **否**
* 路由路徑、middleware 順序與 Socket.IO 事件皆逐條保持不變。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6mD6HGYtTphyzsAW1DFmL
