### PR TITLE
chore(deps): 移除未使用的 config、dotenv 與 dotenv-expand

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -25,9 +25,6 @@
   "dependencies": {
     "@hono/node-server": "^2.0.11",
     "@hono/zod-validator": "^0.9.0",
-    "config": "^4.4.2",
-    "dotenv": "^17.4.2",
-    "dotenv-expand": "^13.0.0",
     "hono": "^4.12.34",
     "hono-rate-limiter": "^0.5.3",
     "node-pg-migrate": "^9.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,15 +25,6 @@ importers:
       '@hono/zod-validator':
         specifier: ^0.9.0
         version: 0.9.0(hono@4.12.34)(zod@4.4.3)
-      config:
-        specifier: ^4.4.2
-        version: 4.4.2
-      dotenv:
-        specifier: ^17.4.2
-        version: 17.4.2
-      dotenv-expand:
-        specifier: ^13.0.0
-        version: 13.0.0
       hono:
         specifier: ^4.12.34
         version: 4.12.34
@@ -1479,10 +1470,6 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
-  config@4.4.2:
-    resolution: {integrity: sha512-5HJD7TX70gOG2dAd72eDjDeSTYn6D8nOiKgysQQS8mRUo9X1wDtlzb1JlmIWkP+sM9zKRVdYJxmj+qmCsYu6DQ==}
-    engines: {node: '>= 20.0.0'}
-
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
@@ -1583,14 +1570,6 @@ packages:
 
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
-
-  dotenv-expand@13.0.0:
-    resolution: {integrity: sha512-aBfBS8eYIeXmpHI9ThIlA7/WLq+SLt18iXUZhb52rW89QLKQFoIpPG1bPeewoPZsTyjSSO3T7234FBVUM1V2rA==}
-    engines: {node: '>=12'}
-
-  dotenv@17.4.2:
-    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
-    engines: {node: '>=12'}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -4419,10 +4398,6 @@ snapshots:
 
   concat-map@0.0.1: {}
 
-  config@4.4.2:
-    dependencies:
-      json5: 2.2.3
-
   convert-source-map@2.0.0: {}
 
   cookie-signature@1.2.2: {}
@@ -4520,12 +4495,6 @@ snapshots:
       esutils: 2.0.3
 
   dom-accessibility-api@0.5.16: {}
-
-  dotenv-expand@13.0.0:
-    dependencies:
-      dotenv: 17.4.2
-
-  dotenv@17.4.2: {}
 
   dunder-proto@1.0.1:
     dependencies:


### PR DESCRIPTION
## 變更描述 (Description)

後端 `package.json` 宣告了 `config`、`dotenv` 與 `dotenv-expand`，但原始碼與測試皆**無任何引用**。環境變數目前一律直接讀取 `process.env`，而 Bun 本身就會載入 `.env` 檔案，因此這三個都是死相依。

```diff
   "dependencies": {
     "@hono/node-server": "^2.0.11",
     "@hono/zod-validator": "^0.9.0",
-    "config": "^4.4.2",
-    "dotenv": "^17.4.2",
-    "dotenv-expand": "^13.0.0",
     "hono": "^4.12.34",
```

純刪除，不動任何一行程式碼。

本項為報告中「建立 typed config module，移除確認未使用的 config/dotenv packages」這條 P1 的**前半**，可獨立交付。後半 —— 以 zod 集中目前散落在 10 個檔案的 `process.env` 解析，並改為設定錯誤即 fail-fast —— 另行處理，因為那會帶入啟動行為變更，不適合和單純的相依清理混在同一個 PR。

## 相關的 Issue (Related Issue)

出自 `docs/reports/deep-research-report.md` 的 P1 清單，無對應 issue。

## 變更類型 (Type of Change)
- [x] `chore`: 建置流程或輔助工具變更

## 驗證與測試計畫 (Verification & Test Plan)

### 本地測試 (Local Tests)
- [x] 後端型別檢查 (`tsc --noEmit`)
- [x] 後端 Linter 檢查 (`eslint src`)
- [x] 單元測試（450 passed）
- [x] 整合測試（33 passed，含 ephemeral db-test）
- [x] E2E 測試（73 passed）

合計 556 項，與 `main` 基準一致。

### 手動測試 (Manual Verification)

報告特別提醒過「不要以純文字搜尋作為唯一刪除依據」，因此逐項排除了 grep 掃不到的載入途徑：

| 檢查 | 結果 |
|---|---|
| `config` 套件的 `config/` 目錄慣例（它靠目錄載入，不一定出現在 import 中） | repo 內無 `config/` 或 `backend/config/` 目錄 |
| `NODE_CONFIG` / `NODE_CONFIG_DIR` / `SUPPRESS_NO_CONFIG_WARNING` 等環境變數 | 全域搜尋無命中 |
| Dockerfile、`bunfig.toml` preload、`tests/preload.ts`、compose、CI workflow 的 `-r dotenv/config` 預載 | 皆無 |
| `depcheck` 獨立確認 | 未使用的 dependencies 恰為 `['config', 'dotenv', 'dotenv-expand']`，未使用的 devDependencies 為空 |

> `depcheck` 另報了 `bun:test`、`bun`、`@shared/types` 為「缺少的相依」，屬誤判 —— 前兩者是 Bun 內建模組，後者是 TypeScript path alias。

**lockfile 差異**確認只移除了這三個套件本身及其項目，未波及其他解析結果；`pnpm-workspace.yaml` 的 CVE `overrides` 也沒有任何一條是靠這三者才可達（唯一的 transitive `json5` 仍經由 babel 存在）。已確認未產生巢狀 lockfile（改用 `pnpm --filter near-chat-backend remove` 從根目錄執行）。

**實際啟動驗證** —— 這是唯一能抓到「隱性依賴 dotenv 載入環境變數」的檢查，測試套件本身不會發現：

```
DB INIT: env=unknown target=localhost:5436/ntnu_test
Backend server (v2.1.0) successfully listening on port 4098 (0.0.0.0)
```

`GET /api/v1/users/me`（無 token）回 `401`、Socket.IO handshake 回 `200`，代表 `DATABASE_URL`、`JWT_SECRET`、`PORT`、`CORS_ORIGINS` 在沒有 dotenv 的情況下仍正常讀取。

## 資料庫變更 (Database Changes)
* 此變更是否包含資料庫 Schema 修改？ **否**

## API 與 WebSocket 協定一致性 (API & WebSocket Contract Check)
* 此變更是否涉及 API 路由或 WebSocket 事件的資料結構變更？ **否**

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6mD6HGYtTphyzsAW1DFmL
