### PR TITLE
fix: 移除 Emergency alert 的非持久化 fallback 路徑 (#535)

### DIFF
--- a/backend/src/bootstrap/services.ts
+++ b/backend/src/bootstrap/services.ts
@@ -8,6 +8,7 @@ import { makeMessageService } from '../services/messageService';
 import { makeFolderService } from '../services/folderService';
 import { makeAttachmentService } from '../services/attachmentService';
 import { makeFriendService } from '../services/friendService';
+import { makeEmergencyNotifier } from '../services/emergencyNotifier';
 
 export interface Services {
   user: ReturnType<typeof makeUserService>;
@@ -52,29 +53,27 @@ export const createServices = ({ repositories, getIo }: CreateServicesDeps): Ser
     repositories.emergencyContacts,
     repositories.refreshTokens,
     { signToken, generateRefreshToken, hashToken },
-    async (contactId, payload) => {
-      let room = await repositories.rooms.findPrivateRoomByMembers(payload.userId, contactId);
-      if (!room) {
-        try {
-          const result = await roomService.createPrivate(payload.userId, contactId, true);
-          room = result.room;
-        } catch (err) {
-          console.error('Failed to auto-create private room for emergency contact:', err);
-        }
-      }
-
-      if (room) {
-        try {
-          const message = await messageService.sendMessage(payload.userId, room.roomId, payload.message);
-          getIo().to(`room_${room.roomId}`).emit('new_message', message);
-        } catch (err) {
-          console.error('Failed to auto-send emergency message:', err);
-          getIo().to(`user_${contactId}`).emit('emergency_alert', payload);
-        }
-      } else {
-        getIo().to(`user_${contactId}`).emit('emergency_alert', payload);
-      }
-    },
+    // The delivery rules live in `makeEmergencyNotifier`, not here — bootstrap
+    // wires, it does not decide. Every service reference below is reached
+    // through a closure so that `roomService` and `messageService`, declared
+    // further down, are resolved when an alert fires rather than now.
+    makeEmergencyNotifier({
+      userRepo: repositories.users,
+      socialRepo: repositories.friends,
+      roomService: {
+        createPrivate: (creatorId, targetUserId, bypassFriendCheck) =>
+          roomService.createPrivate(creatorId, targetUserId, bypassFriendCheck),
+      },
+      messageService: {
+        sendMessage: (userId, roomId, content) => messageService.sendMessage(userId, roomId, content),
+      },
+      emitNewMessage: (roomId, message) => {
+        getIo().to(`room_${roomId}`).emit('new_message', message);
+      },
+      notifyRoomJoined: (userId, roomId) => {
+        getIo().to(`user_${userId}`).emit('room_update', { type: 'ROOM_JOINED', roomId, data: {} });
+      },
+    }),
     repositories.friends,
     async (userId, data) => {
       try {

--- a/backend/src/models/IEmergencyContactRepository.ts
+++ b/backend/src/models/IEmergencyContactRepository.ts
@@ -15,4 +15,5 @@ export interface IEmergencyContactRepository {
   upsert(userId: string, contactId: string, message: string): Promise<{ contact: EmergencyContact, isUpdate: boolean }>;
   delete(userId: string, contactId: string): Promise<void>;
   recordAlertIfNew(userId: string, lastActivity: Date): Promise<boolean>;
+  releaseAlert(userId: string, lastActivity: Date): Promise<void>;
 }

--- a/backend/src/models/emergencyContactRepository.ts
+++ b/backend/src/models/emergencyContactRepository.ts
@@ -92,20 +92,29 @@ export class EmergencyContactRepository implements IEmergencyContactRepository {
   }
 
   async recordAlertIfNew(userId: string, lastActivity: Date): Promise<boolean> {
-    const existingRes = await this.sql<{ exists: number }[]>`
-      SELECT 1 as exists
-      FROM emergency_alert_logs
-      WHERE user_id = ${userId} AND last_activity_at = ${lastActivity}
-    `;
-
-    if (existingRes.length > 0) {
-      return false;
-    }
-
-    await this.sql`
+    // Claimed in one statement. The previous SELECT-then-INSERT let a second
+    // concurrent run pass the existence check and then fail on the
+    // (user_id, last_activity_at) primary key with a unique violation, which
+    // nothing handled.
+    const rows = await this.sql<{ claimed: number }[]>`
       INSERT INTO emergency_alert_logs (user_id, last_activity_at)
       VALUES (${userId}, ${lastActivity})
+      ON CONFLICT (user_id, last_activity_at) DO NOTHING
+      RETURNING 1 as claimed
     `;
-    return true;
+    return rows.length > 0;
+  }
+
+  /**
+   * Hands the claim back so a later run can retry this `lastActivity` window.
+   *
+   * Only called when nothing durable reached a contact. Once even one alert is
+   * persisted the claim must stand, or the retry would write a duplicate.
+   */
+  async releaseAlert(userId: string, lastActivity: Date): Promise<void> {
+    await this.sql`
+      DELETE FROM emergency_alert_logs
+      WHERE user_id = ${userId} AND last_activity_at = ${lastActivity}
+    `;
   }
 }

--- a/backend/src/services/emergencyNotifier.ts
+++ b/backend/src/services/emergencyNotifier.ts
@@ -1,0 +1,111 @@
+import type { MessageWithSender } from '@shared/types';
+import { AppError } from '../utils/AppError';
+
+export interface EmergencyAlertPayload {
+  userId: string;
+  message: string;
+}
+
+export type EmergencyDeliveryFailureCode =
+  | 'CONTACT_UNAVAILABLE'
+  | 'CONTACT_BLOCKED'
+  | 'ROOM_UNAVAILABLE'
+  | 'PERSIST_FAILED'
+  | 'DELIVERY_ERROR';
+
+/**
+ * The result of trying to reach one emergency contact.
+ *
+ * `retryable` is what decides whether the caller gives back the dedupe marker
+ * for this `lastActivity` window. A blocked or deleted contact will never
+ * succeed, so retrying it every hour is pure noise; a database outage will.
+ */
+export type EmergencyDeliveryOutcome =
+  | { delivered: true }
+  | { delivered: false; retryable: boolean; code: EmergencyDeliveryFailureCode };
+
+export interface EmergencyNotifierDeps {
+  userRepo: { findById(userId: string): Promise<{ userId: string } | null> };
+  socialRepo: { isBlocked(userA: string, userB: string): Promise<boolean> };
+  roomService: {
+    createPrivate(
+      creatorId: string,
+      targetUserId: string,
+      bypassFriendCheck?: boolean,
+    ): Promise<{ room: { roomId: string } }>;
+  };
+  messageService: {
+    sendMessage(userId: string, roomId: string, content: string): Promise<MessageWithSender>;
+  };
+  emitNewMessage: (roomId: string, message: MessageWithSender) => void;
+  notifyRoomJoined: (userId: string, roomId: string) => void;
+}
+
+/**
+ * A 4xx `AppError` describes a rule the caller broke, so repeating the same
+ * call cannot produce a different answer. Anything else — a dropped
+ * connection, a constraint the code did not anticipate — may.
+ */
+const isPermanentFailure = (err: unknown): boolean =>
+  err instanceof AppError && err.statusCode >= 400 && err.statusCode < 500;
+
+/**
+ * Delivers an emergency alert as a durable chat message, and only then as a
+ * realtime signal.
+ *
+ * The previous implementation lived inline in `bootstrap/services.ts` and used
+ * a transient `emergency_alert` socket event as the *fallback* for a failed
+ * persist: precisely when no durable record existed, an offline contact was
+ * sent a fire-and-forget event it could never receive, and nothing recorded
+ * that the attempt had happened. There is no fallback here. Either the message
+ * row exists and the contact can read it on their next sync, or the caller is
+ * told the alert did not go out.
+ */
+export const makeEmergencyNotifier = (deps: EmergencyNotifierDeps) =>
+  async (contactId: string, payload: EmergencyAlertPayload): Promise<EmergencyDeliveryOutcome> => {
+    const contact = await deps.userRepo.findById(contactId);
+    if (!contact) {
+      return { delivered: false, retryable: false, code: 'CONTACT_UNAVAILABLE' };
+    }
+
+    // `createPrivate` below is called with `bypassFriendCheck`, which skips the
+    // block check and reopens a read-only room. Without this guard an alert
+    // would re-grant write access to someone who blocked the sender.
+    if (await deps.socialRepo.isBlocked(payload.userId, contactId)) {
+      return { delivered: false, retryable: false, code: 'CONTACT_BLOCKED' };
+    }
+
+    let roomId: string;
+    try {
+      const { room } = await deps.roomService.createPrivate(payload.userId, contactId, true);
+      roomId = room.roomId;
+    } catch (err) {
+      console.error(`Emergency alert could not resolve a room for contact ${contactId}:`, err);
+      return { delivered: false, retryable: !isPermanentFailure(err), code: 'ROOM_UNAVAILABLE' };
+    }
+
+    let message: MessageWithSender;
+    try {
+      message = await deps.messageService.sendMessage(payload.userId, roomId, payload.message);
+    } catch (err) {
+      console.error(`Emergency alert could not be persisted for contact ${contactId}:`, err);
+      return { delivered: false, retryable: !isPermanentFailure(err), code: 'PERSIST_FAILED' };
+    }
+
+    // The durable record exists from here on, so a realtime failure must not
+    // downgrade the outcome: reporting failure would hand the dedupe marker
+    // back and the next run would persist a second copy of the same alert.
+    try {
+      deps.emitNewMessage(roomId, message);
+      // The room may have just been created, in which case the contact's client
+      // learns about it from `createPrivate`'s ROOM_JOINED — which fires before
+      // this message exists, so the client subscribes too late to see the emit
+      // above. Repeating it now makes the client refresh once more, with the
+      // message already written.
+      deps.notifyRoomJoined(contactId, roomId);
+    } catch (err) {
+      console.error(`Emergency alert persisted but realtime fan-out failed for contact ${contactId}:`, err);
+    }
+
+    return { delivered: true };
+  };

--- a/backend/src/services/userService.ts
+++ b/backend/src/services/userService.ts
@@ -27,6 +27,7 @@ import {
 import { getRefreshTokenTtlMs } from '../utils/refreshTokenTtl';
 
 import type { IRefreshTokenRepository } from '../models/IRefreshTokenRepository';
+import type { EmergencyDeliveryOutcome } from './emergencyNotifier';
 
 interface JwtHelper {
   signToken(payload: JwtPayload): Promise<string>;
@@ -34,9 +35,13 @@ interface JwtHelper {
   hashToken(token: string): string;
 }
 
-interface EmergencyAlertResult {
+export interface EmergencyAlertResult {
   alerted: boolean;
+  /** Contacts whose alert was durably written. */
   recipients: string[];
+  /** Contacts the alert did not reach. Omitted when every contact was reached. */
+  failedRecipients?: string[];
+  /** Why nothing was alerted. Only set when `alerted` is false. */
   reason?: string;
 }
 
@@ -78,33 +83,84 @@ export const makeUserService = (
   emergencyContactRepo: IEmergencyContactRepository,
   refreshTokenRepo: IRefreshTokenRepository,
   jwt: JwtHelper,
-  notifyEmergencyContact?: (contactId: string, payload: { userId: string; message: string }) => void | Promise<void>,
+  /**
+   * Delivers one alert. Reports an {@link EmergencyDeliveryOutcome} so this
+   * service can tell a durable write apart from a failure; returning nothing
+   * means delivered. A throw is treated as a retryable failure.
+   */
+  notifyEmergencyContact?: (
+    contactId: string,
+    payload: { userId: string; message: string },
+  ) => void | EmergencyDeliveryOutcome | Promise<void | EmergencyDeliveryOutcome>,
   friendRepo?: { getFriends(userId: string): Promise<FriendResponse[]> },
   onUserUpdated?: (userId: string, data: { name?: string; avatarUrl?: string }) => void | Promise<void>,
   avatarStore: AvatarStore = defaultAvatarStore,
 ) => {
-  const notifyContacts = async (userId: string, fallbackMessage: string): Promise<EmergencyAlertResult> => {
+  const notifyContacts = async (
+    userId: string,
+    fallbackMessage: string,
+  ): Promise<{ outcome: EmergencyAlertResult; releaseMarker: boolean }> => {
     const user = await repo.findById(userId);
     if (!user) throw new NotFoundError('user', userId);
 
     const contacts = await emergencyContactRepo.findByUserId(userId);
     if (contacts.length === 0) {
-      return { alerted: false, recipients: [], reason: 'NO_CONTACTS' };
+      // Nothing was attempted, so the dedupe marker must not be spent — the
+      // user may add a contact before the next run reaches this same window.
+      return {
+        outcome: { alerted: false, recipients: [], reason: 'NO_CONTACTS' },
+        releaseMarker: true,
+      };
     }
 
     const recipients: string[] = [];
+    const failedRecipients: string[] = [];
+    let hasRetryableFailure = false;
+
     for (const contact of contacts) {
       const msg = contact.message || fallbackMessage;
-      if (notifyEmergencyContact) {
-        await notifyEmergencyContact(contact.contactId, {
-          userId,
-          message: msg,
-        });
+
+      let outcome: EmergencyDeliveryOutcome | undefined;
+      try {
+        // `void` is `undefined` at runtime. A notifier that returns nothing —
+        // the injected test stubs, and any caller predating the outcome
+        // contract — counts as delivered.
+        const returned = notifyEmergencyContact
+          ? await notifyEmergencyContact(contact.contactId, { userId, message: msg })
+          : undefined;
+        outcome = returned as EmergencyDeliveryOutcome | undefined;
+      } catch (err) {
+        console.error(`Emergency alert delivery threw for contact ${contact.contactId}:`, err);
+        outcome = { delivered: false, retryable: true, code: 'DELIVERY_ERROR' };
       }
-      recipients.push(contact.contactId);
+
+      if (!outcome || outcome.delivered) {
+        recipients.push(contact.contactId);
+        continue;
+      }
+
+      console.error(
+        `Emergency alert for user ${userId} did not reach contact ${contact.contactId}: ${outcome.code}`,
+      );
+      failedRecipients.push(contact.contactId);
+      hasRetryableFailure = hasRetryableFailure || outcome.retryable;
     }
 
-    return { alerted: true, recipients };
+    if (recipients.length === 0) {
+      return {
+        outcome: { alerted: false, recipients: [], failedRecipients, reason: 'DELIVERY_FAILED' },
+        // A contact that can never succeed (blocked, deleted) must not put this
+        // window back on the queue for every future run.
+        releaseMarker: hasRetryableFailure,
+      };
+    }
+
+    return {
+      outcome: failedRecipients.length > 0
+        ? { alerted: true, recipients, failedRecipients }
+        : { alerted: true, recipients },
+      releaseMarker: false,
+    };
   };
 
   const issueRefreshToken = async (userId: string): Promise<string> => {
@@ -336,7 +392,22 @@ export const makeUserService = (
         return { alerted: false, recipients: [], reason: 'ALREADY_ALERTED' };
       }
 
-      return notifyContacts(userId, 'User has exceeded their inactivity warning threshold');
+      const { outcome, releaseMarker } = await notifyContacts(
+        userId,
+        'User has exceeded their inactivity warning threshold',
+      );
+
+      if (releaseMarker) {
+        // Best effort: a failed release must not mask the delivery result the
+        // caller is waiting on. Losing it only costs one retry opportunity.
+        try {
+          await emergencyContactRepo.releaseAlert(userId, user.lastActivity);
+        } catch (err) {
+          console.error(`Failed to release emergency alert marker for user ${userId}:`, err);
+        }
+      }
+
+      return outcome;
     },
 
 

--- a/backend/src/utils/inactivityJob.ts
+++ b/backend/src/utils/inactivityJob.ts
@@ -20,7 +20,12 @@ export function startInactivityJob(
             await userRepo.update(user.userId, { lastActivity: now });
             continue;
           }
-          await userService.checkInactivity(user.userId, now);
+          const result = await userService.checkInactivity(user.userId, now);
+          if (result?.failedRecipients?.length) {
+            console.error(
+              `Emergency alert for user ${user.userId} did not reach contacts: ${result.failedRecipients.join(', ')}`,
+            );
+          }
         } catch (err) {
           console.error(`Error checking inactivity for user ${user.userId}:`, err);
         }

--- a/backend/tests/e2e/socket/emergencyAlert.e2e.test.ts
+++ b/backend/tests/e2e/socket/emergencyAlert.e2e.test.ts
@@ -124,4 +124,153 @@ describe('Emergency alert Socket.IO E2E', () => {
     expect(received.senderId).toBe(userRes.body.user.userId);
     expect(received.roomId).toBe(privateRoomId);
   });
+
+  /**
+   * Registers two users, makes them friends, opens their private room and
+   * configures the first as an inactive user alerting the second.
+   */
+  const setUpAlertPair = async (suffix: string, message = 'Please check on me') => {
+    const userRes = await request(app).post('/api/v1/auth/register').send({
+      name: 'Alert User',
+      email: `alert-user-${suffix}@example.com`,
+      password: 'Password123!',
+    });
+    const contactRes = await request(app).post('/api/v1/auth/register').send({
+      name: 'Contact User',
+      email: `contact-user-${suffix}@example.com`,
+      password: 'Password123!',
+    });
+
+    await request(app)
+      .post('/api/v1/friend-requests')
+      .set('Authorization', `Bearer ${userRes.body.token}`)
+      .send({ target_user_id: contactRes.body.user.userId });
+    await request(app)
+      .patch(`/api/v1/friend-requests/${userRes.body.user.userId}`)
+      .set('Authorization', `Bearer ${contactRes.body.token}`)
+      .send({ status: 'accepted' });
+
+    const roomRes = await request(app)
+      .post('/api/v1/rooms')
+      .set('Authorization', `Bearer ${userRes.body.token}`)
+      .send({ type: 'private', targetUserId: contactRes.body.user.userId });
+    expect([200, 201]).toContain(roomRes.status);
+
+    await request(app)
+      .post('/api/v1/users/me/emergency-contacts')
+      .set('Authorization', `Bearer ${userRes.body.token}`)
+      .send({ contactId: contactRes.body.user.userId, message });
+
+    await request(app)
+      .patch('/api/v1/users/me/settings')
+      .set('Authorization', `Bearer ${userRes.body.token}`)
+      .send({ warningEnabled: true, warningDays: 1 });
+
+    return {
+      user: userRes.body.user,
+      userToken: userRes.body.token as string,
+      contact: contactRes.body.user,
+      contactToken: contactRes.body.token as string,
+      roomId: roomRes.body.roomId as string,
+    };
+  };
+
+  const triggerAlert = (token: string) =>
+    request(app)
+      .post('/api/v1/users/me/emergency-alert/check-inactivity')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ now: new Date(Date.now() + 5 * 24 * 60 * 60 * 1000).toISOString() });
+
+  const listMessages = (token: string, roomId: string) =>
+    request(app).get(`/api/v1/rooms/${roomId}/messages`).set('Authorization', `Bearer ${token}`);
+
+  it('leaves the alert readable through normal history for a contact that was offline', async () => {
+    const ctx = await setUpAlertPair('offline', 'Offline contact alert');
+
+    // No socket is connected for the contact at any point during the trigger.
+    const triggerRes = await triggerAlert(ctx.userToken);
+    expect(triggerRes.status).toBe(200);
+    expect(triggerRes.body.alerted).toBe(true);
+    expect(triggerRes.body.recipients).toEqual([ctx.contact.userId]);
+    expect(triggerRes.body.failedRecipients).toBeUndefined();
+
+    // The contact "reconnects" and reads the room through the ordinary path.
+    const history = await listMessages(ctx.contactToken, ctx.roomId);
+    expect(history.status).toBe(200);
+    const contents = (history.body as any[]).map((m) => m.content);
+    expect(contents).toContain('Offline contact alert');
+  });
+
+  it('reports an undeliverable alert instead of emitting a transient event', async () => {
+    const ctx = await setUpAlertPair('blocked', 'Blocked contact alert');
+
+    // Blocking marks the shared private room read-only, so the durable write
+    // cannot succeed. This used to fall back to a fire-and-forget
+    // `emergency_alert` event that nothing recorded.
+    await request(app)
+      .post('/api/v1/blocks')
+      .set('Authorization', `Bearer ${ctx.contactToken}`)
+      .send({ targetUserId: ctx.user.userId });
+
+    const contactSocket = await connectClient(ctx.contactToken);
+    contactSocket.emit('join_room', { roomId: ctx.roomId });
+    await new Promise((res) => setTimeout(res, 100));
+
+    const events: string[] = [];
+    contactSocket.onAny((event: string) => events.push(event));
+
+    const triggerRes = await triggerAlert(ctx.userToken);
+    expect(triggerRes.status).toBe(200);
+    expect(triggerRes.body.alerted).toBe(false);
+    expect(triggerRes.body.reason).toBe('DELIVERY_FAILED');
+    expect(triggerRes.body.failedRecipients).toEqual([ctx.contact.userId]);
+
+    await new Promise((res) => setTimeout(res, 300));
+    expect(events).not.toContain('emergency_alert');
+    expect(events).not.toContain('new_message');
+
+    const history = await listMessages(ctx.contactToken, ctx.roomId);
+    const contents = (history.body as any[]).map((m) => m.content);
+    expect(contents).not.toContain('Blocked contact alert');
+  });
+
+  it('stores exactly one alert when the same window is checked twice', async () => {
+    const ctx = await setUpAlertPair('duplicate', 'Duplicate guard alert');
+
+    const first = await triggerAlert(ctx.userToken);
+    expect(first.body.alerted).toBe(true);
+
+    const second = await triggerAlert(ctx.userToken);
+    expect(second.body).toEqual({ alerted: false, recipients: [], reason: 'ALREADY_ALERTED' });
+
+    const history = await listMessages(ctx.contactToken, ctx.roomId);
+    const matching = (history.body as any[]).filter((m) => m.content === 'Duplicate guard alert');
+    expect(matching).toHaveLength(1);
+  });
+
+  it('retries a window in which nothing was ever attempted', async () => {
+    const ctx = await setUpAlertPair('retry', 'Retry alert');
+
+    await request(app)
+      .delete(`/api/v1/users/me/emergency-contacts/${ctx.contact.userId}`)
+      .set('Authorization', `Bearer ${ctx.userToken}`);
+
+    const noContacts = await triggerAlert(ctx.userToken);
+    expect(noContacts.body).toEqual({ alerted: false, recipients: [], reason: 'NO_CONTACTS' });
+
+    // The dedupe marker must have been given back: the user has now configured
+    // a contact and the same inactivity window has to be alertable.
+    await request(app)
+      .post('/api/v1/users/me/emergency-contacts')
+      .set('Authorization', `Bearer ${ctx.userToken}`)
+      .send({ contactId: ctx.contact.userId, message: 'Retry alert' });
+
+    const retried = await triggerAlert(ctx.userToken);
+    expect(retried.body.alerted).toBe(true);
+    expect(retried.body.recipients).toEqual([ctx.contact.userId]);
+
+    const history = await listMessages(ctx.contactToken, ctx.roomId);
+    const matching = (history.body as any[]).filter((m) => m.content === 'Retry alert');
+    expect(matching).toHaveLength(1);
+  });
 });

--- a/backend/tests/e2e/socket/emergencyAlert.e2e.test.ts
+++ b/backend/tests/e2e/socket/emergencyAlert.e2e.test.ts
@@ -29,6 +29,10 @@ describe('Emergency alert Socket.IO E2E', () => {
   beforeEach(async () => {
     clients.forEach((socket) => socket.disconnect());
     clients = [];
+    // Disconnecting makes the server broadcast an offline status, which reads
+    // `friendships`. `resetDb` truncates it, and TRUNCATE needs a lock that
+    // conflicts with that read — starting it immediately deadlocks the pair.
+    await new Promise((res) => setTimeout(res, 150));
     await resetDb();
   });
 
@@ -129,7 +133,11 @@ describe('Emergency alert Socket.IO E2E', () => {
    * Registers two users, makes them friends, opens their private room and
    * configures the first as an inactive user alerting the second.
    */
-  const setUpAlertPair = async (suffix: string, message = 'Please check on me') => {
+  const setUpAlertPair = async (
+    suffix: string,
+    message = 'Please check on me',
+    opts: { blockBeforeConfiguring?: boolean } = {},
+  ) => {
     const userRes = await request(app).post('/api/v1/auth/register').send({
       name: 'Alert User',
       email: `alert-user-${suffix}@example.com`,
@@ -155,6 +163,17 @@ describe('Emergency alert Socket.IO E2E', () => {
       .set('Authorization', `Bearer ${userRes.body.token}`)
       .send({ type: 'private', targetUserId: contactRes.body.user.userId });
     expect([200, 201]).toContain(roomRes.status);
+
+    // `friendRepository.blockUser` deletes the emergency_contacts rows in both
+    // directions, so blocking after configuration would simply leave the user
+    // with no contacts. Blocking first is the reachable ordering: adding an
+    // emergency contact does not check blocks.
+    if (opts.blockBeforeConfiguring) {
+      await request(app)
+        .post('/api/v1/blocks')
+        .set('Authorization', `Bearer ${contactRes.body.token}`)
+        .send({ targetUserId: userRes.body.user.userId });
+    }
 
     await request(app)
       .post('/api/v1/users/me/emergency-contacts')
@@ -202,15 +221,14 @@ describe('Emergency alert Socket.IO E2E', () => {
   });
 
   it('reports an undeliverable alert instead of emitting a transient event', async () => {
-    const ctx = await setUpAlertPair('blocked', 'Blocked contact alert');
-
-    // Blocking marks the shared private room read-only, so the durable write
-    // cannot succeed. This used to fall back to a fire-and-forget
+    // The contact has blocked the user, who then configured them as an
+    // emergency contact anyway — `upsertEmergencyContact` does not check
+    // blocks. The alert must not be delivered, and must not silently reopen the
+    // read-only room. This used to fall back to a fire-and-forget
     // `emergency_alert` event that nothing recorded.
-    await request(app)
-      .post('/api/v1/blocks')
-      .set('Authorization', `Bearer ${ctx.contactToken}`)
-      .send({ targetUserId: ctx.user.userId });
+    const ctx = await setUpAlertPair('blocked', 'Blocked contact alert', {
+      blockBeforeConfiguring: true,
+    });
 
     const contactSocket = await connectClient(ctx.contactToken);
     contactSocket.emit('join_room', { roomId: ctx.roomId });

--- a/backend/tests/unit/services/emergencyNotifier.test.ts
+++ b/backend/tests/unit/services/emergencyNotifier.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, mock } from 'bun:test';
+
+import { makeEmergencyNotifier } from '../../../src/services/emergencyNotifier';
+import { ForbiddenError } from '../../../src/utils/AppError';
+
+describe('emergencyNotifier', () => {
+  let userRepo: any;
+  let socialRepo: any;
+  let roomService: any;
+  let messageService: any;
+  let emitNewMessage: any;
+  let notifyRoomJoined: any;
+  let notify: ReturnType<typeof makeEmergencyNotifier>;
+
+  const payload = { userId: 'u1', message: 'Please check on me' };
+  const persistedMessage = { messageId: 'm1', roomId: 'r1', senderId: 'u1' } as any;
+
+  beforeEach(() => {
+    userRepo = { findById: mock().mockResolvedValue({ userId: 'c1' }) };
+    socialRepo = { isBlocked: mock().mockResolvedValue(false) };
+    roomService = { createPrivate: mock().mockResolvedValue({ room: { roomId: 'r1' } }) };
+    messageService = { sendMessage: mock().mockResolvedValue(persistedMessage) };
+    emitNewMessage = mock();
+    notifyRoomJoined = mock();
+
+    notify = makeEmergencyNotifier({
+      userRepo,
+      socialRepo,
+      roomService,
+      messageService,
+      emitNewMessage,
+      notifyRoomJoined,
+    });
+  });
+
+  it('persists the alert before emitting anything', async () => {
+    const order: string[] = [];
+    messageService.sendMessage.mockImplementation(async () => {
+      order.push('persist');
+      return persistedMessage;
+    });
+    emitNewMessage.mockImplementation(() => order.push('emit'));
+
+    const outcome = await notify('c1', payload);
+
+    expect(outcome).toEqual({ delivered: true });
+    expect(order).toEqual(['persist', 'emit']);
+    expect(messageService.sendMessage).toHaveBeenCalledWith('u1', 'r1', 'Please check on me');
+    expect(emitNewMessage).toHaveBeenCalledWith('r1', persistedMessage);
+  });
+
+  it('emits no realtime signal at all when the durable write fails', async () => {
+    messageService.sendMessage.mockRejectedValue(new Error('database is down'));
+
+    const outcome = await notify('c1', payload);
+
+    expect(outcome).toEqual({ delivered: false, retryable: true, code: 'PERSIST_FAILED' });
+    expect(emitNewMessage).not.toHaveBeenCalled();
+    expect(notifyRoomJoined).not.toHaveBeenCalled();
+  });
+
+  it('reports room creation failure instead of swallowing it', async () => {
+    roomService.createPrivate.mockRejectedValue(new Error('connection reset'));
+
+    const outcome = await notify('c1', payload);
+
+    expect(outcome).toEqual({ delivered: false, retryable: true, code: 'ROOM_UNAVAILABLE' });
+    expect(messageService.sendMessage).not.toHaveBeenCalled();
+    expect(emitNewMessage).not.toHaveBeenCalled();
+  });
+
+  it('classifies a 4xx rejection as permanent so it is not retried forever', async () => {
+    messageService.sendMessage.mockRejectedValue(new ForbiddenError('Muted members cannot send messages'));
+
+    const outcome = await notify('c1', payload);
+
+    expect(outcome).toEqual({ delivered: false, retryable: false, code: 'PERSIST_FAILED' });
+  });
+
+  it('refuses to deliver to a contact who blocked the sender, and never reopens the room', async () => {
+    socialRepo.isBlocked.mockResolvedValue(true);
+
+    const outcome = await notify('c1', payload);
+
+    expect(outcome).toEqual({ delivered: false, retryable: false, code: 'CONTACT_BLOCKED' });
+    expect(roomService.createPrivate).not.toHaveBeenCalled();
+    expect(messageService.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('treats a soft-deleted contact as a permanent skip', async () => {
+    userRepo.findById.mockResolvedValue(null);
+
+    const outcome = await notify('c1', payload);
+
+    expect(outcome).toEqual({ delivered: false, retryable: false, code: 'CONTACT_UNAVAILABLE' });
+    expect(socialRepo.isBlocked).not.toHaveBeenCalled();
+    expect(roomService.createPrivate).not.toHaveBeenCalled();
+  });
+
+  it('stays delivered when the realtime fan-out throws after a successful write', async () => {
+    emitNewMessage.mockImplementation(() => {
+      throw new Error('socket server not ready');
+    });
+
+    const outcome = await notify('c1', payload);
+
+    // Reporting failure here would hand back the dedupe marker and the next run
+    // would persist a second copy of an alert that was already stored.
+    expect(outcome).toEqual({ delivered: true });
+  });
+
+  it('re-announces the room to the contact after the message exists', async () => {
+    await notify('c1', payload);
+
+    expect(notifyRoomJoined).toHaveBeenCalledWith('c1', 'r1');
+    expect(roomService.createPrivate).toHaveBeenCalledWith('u1', 'c1', true);
+  });
+});

--- a/backend/tests/unit/services/userService.test.ts
+++ b/backend/tests/unit/services/userService.test.ts
@@ -53,6 +53,7 @@ describe('userService', () => {
       upsert: mock(),
       delete: mock(),
       recordAlertIfNew: mock(),
+      releaseAlert: mock().mockResolvedValue(undefined),
     };
     mockRefreshTokenRepo = {
       create: mock(),
@@ -496,6 +497,114 @@ describe('userService', () => {
         userId: 'u1',
         message: 'inactive',
       });
+    });
+
+    const contactsFor = (...contactIds: string[]) =>
+      contactIds.map((contactId) => ({
+        userId: 'u1',
+        contactId,
+        message: 'inactive',
+        createdAt: new Date(),
+      }));
+
+    it('reports DELIVERY_FAILED and gives the marker back when no alert was stored', async () => {
+      mockRepo.findById.mockResolvedValue(inactiveUser);
+      emergencyContactRepo.recordAlertIfNew.mockResolvedValue(true);
+      emergencyContactRepo.findByUserId.mockResolvedValue(contactsFor('u2'));
+      notifyEmergencyContact.mockResolvedValue({
+        delivered: false,
+        retryable: true,
+        code: 'PERSIST_FAILED',
+      });
+
+      const result = await userService.checkInactivity('u1', new Date('2026-01-04T00:00:00.000Z'));
+
+      expect(result).toEqual({
+        alerted: false,
+        recipients: [],
+        failedRecipients: ['u2'],
+        reason: 'DELIVERY_FAILED',
+      });
+      expect(emergencyContactRepo.releaseAlert).toHaveBeenCalledWith('u1', inactiveUser.lastActivity);
+    });
+
+    it('treats a thrown notifier as a retryable failure', async () => {
+      mockRepo.findById.mockResolvedValue(inactiveUser);
+      emergencyContactRepo.recordAlertIfNew.mockResolvedValue(true);
+      emergencyContactRepo.findByUserId.mockResolvedValue(contactsFor('u2'));
+      notifyEmergencyContact.mockRejectedValue(new Error('database is down'));
+
+      const result = await userService.checkInactivity('u1', new Date('2026-01-04T00:00:00.000Z'));
+
+      expect(result.alerted).toBe(false);
+      expect(result.failedRecipients).toEqual(['u2']);
+      expect(emergencyContactRepo.releaseAlert).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps the marker when every failure is permanent, so it is not retried forever', async () => {
+      mockRepo.findById.mockResolvedValue(inactiveUser);
+      emergencyContactRepo.recordAlertIfNew.mockResolvedValue(true);
+      emergencyContactRepo.findByUserId.mockResolvedValue(contactsFor('u2'));
+      notifyEmergencyContact.mockResolvedValue({
+        delivered: false,
+        retryable: false,
+        code: 'CONTACT_BLOCKED',
+      });
+
+      const result = await userService.checkInactivity('u1', new Date('2026-01-04T00:00:00.000Z'));
+
+      expect(result.reason).toBe('DELIVERY_FAILED');
+      expect(emergencyContactRepo.releaseAlert).not.toHaveBeenCalled();
+    });
+
+    it('keeps the marker on partial delivery and names the contacts that were missed', async () => {
+      mockRepo.findById.mockResolvedValue(inactiveUser);
+      emergencyContactRepo.recordAlertIfNew.mockResolvedValue(true);
+      emergencyContactRepo.findByUserId.mockResolvedValue(contactsFor('u2', 'u3'));
+      notifyEmergencyContact.mockImplementation(async (contactId: string) =>
+        contactId === 'u2'
+          ? { delivered: true }
+          : { delivered: false, retryable: true, code: 'PERSIST_FAILED' },
+      );
+
+      const result = await userService.checkInactivity('u1', new Date('2026-01-04T00:00:00.000Z'));
+
+      expect(result).toEqual({
+        alerted: true,
+        recipients: ['u2'],
+        failedRecipients: ['u3'],
+      });
+      // Retrying would write a second alert for u2, which already has one.
+      expect(emergencyContactRepo.releaseAlert).not.toHaveBeenCalled();
+    });
+
+    it('gives the marker back when the user has no contacts to alert', async () => {
+      mockRepo.findById.mockResolvedValue(inactiveUser);
+      emergencyContactRepo.recordAlertIfNew.mockResolvedValue(true);
+      emergencyContactRepo.findByUserId.mockResolvedValue([]);
+
+      const result = await userService.checkInactivity('u1', new Date('2026-01-04T00:00:00.000Z'));
+
+      expect(result).toEqual({ alerted: false, recipients: [], reason: 'NO_CONTACTS' });
+      // Otherwise adding a contact later could never alert for this window.
+      expect(emergencyContactRepo.releaseAlert).toHaveBeenCalledWith('u1', inactiveUser.lastActivity);
+    });
+
+    it('still returns the delivery result when releasing the marker fails', async () => {
+      mockRepo.findById.mockResolvedValue(inactiveUser);
+      emergencyContactRepo.recordAlertIfNew.mockResolvedValue(true);
+      emergencyContactRepo.findByUserId.mockResolvedValue(contactsFor('u2'));
+      notifyEmergencyContact.mockResolvedValue({
+        delivered: false,
+        retryable: true,
+        code: 'PERSIST_FAILED',
+      });
+      emergencyContactRepo.releaseAlert.mockRejectedValue(new Error('database is down'));
+
+      const result = await userService.checkInactivity('u1', new Date('2026-01-04T00:00:00.000Z'));
+
+      expect(result.reason).toBe('DELIVERY_FAILED');
+      expect(result.failedRecipients).toEqual(['u2']);
     });
 
     it('does not alert below the inactivity threshold', async () => {

--- a/docs/ZH-TW/api-documentation.md
+++ b/docs/ZH-TW/api-documentation.md
@@ -67,7 +67,6 @@
 | | `room_update` | 連線需驗證 | 房間設定變更、成員變動或被剔除之通知。詳見 [room_update 子類型](#room_update-子類型)。 |
 | | `friend_request` | 連線需驗證 | 好友請求狀態變更的即時通知（已送出、已接受、已拒絕） |
 | | `user_status` | 連線需驗證 | 好友的上線 / 下線狀態變更 |
-| | `emergency_alert` | 連線需驗證 | 收到緊急聯絡人發送之警報通知 |
 | | `error` | 連線需驗證 | 事件處理失敗之錯誤回報 |
 
 ---
@@ -1385,7 +1384,23 @@ NEXT_PUBLIC_API_URL=http://localhost:4005
   }
   ```
 - **回應**:
-  - `200 OK`: 檢查完成。
+  - `200 OK`: 檢查完成，回應內容說明實際送達狀況。
+- **回應欄位**:
+  | 欄位 | 型別 | 說明 |
+  | :--- | :--- | :--- |
+  | `alerted` | 布林值 | 至少有一位聯絡人取得已持久化的警報時為 `true` |
+  | `recipients` | 字串陣列 | 警報已寫入資料庫的聯絡人 |
+  | `failedRecipients` | 字串陣列 | 警報未送達的聯絡人；全部送達時不會出現此欄位 |
+  | `reason` | 字串 | 未發出警報的原因，僅在 `alerted` 為 `false` 時出現：`WARNING_DISABLED`、`INVALID_THRESHOLD`、`BELOW_THRESHOLD`、`ALREADY_ALERTED`、`NO_CONTACTS`、`DELIVERY_FAILED` |
+- **回應範例**:
+  ```json
+  {
+    "alerted": true,
+    "recipients": ["d3b07384-d113-4956-a5cc-4847841c2c31"],
+    "failedRecipients": ["9f8e7d6c-5b4a-4321-8765-1a2b3c4d5e6f"]
+  }
+  ```
+- **送達語意**: 警報一律以私聊房間中的一般聊天訊息形式送出，因此離線的聯絡人重新連線後可透過既有的歷史訊息與 `new_message` 路徑取得，不需特殊處理。系統不再提供瞬時的警報事件：列於 `failedRecipients` 的聯絡人代表**完全未收到**任何通知。
 
 ---
 
@@ -1420,7 +1435,6 @@ NEXT_PUBLIC_API_URL=http://localhost:4005
 | `room_update` | `{ type: string, roomId: string, data: unknown }` | 房間或成員狀態變更。`type` 欄位決定子類型，詳見 [`room_update` 子類型](#room_update-子類型)。 |
 | `friend_request` | `{ requesterId: string, addresseeId: string, status: 'pending' \| 'accepted' \| 'rejected', createdAt: string }` | 好友請求狀態變更通知。**收件方**（新邀請）與**發送方**（被接受／拒絕）都會收到此事件。客戶端收到後不論 `status` 為何，皆應重新拉取好友與待確認請求列表。 |
 | `user_status` | `{ userId: string, status: 'online' \| 'offline' }` | 好友的上線 / 下線狀態更新。於好友連線或斷線時推送。 |
-| `emergency_alert` | `{ userId: string, message: string }` | 收到緊急聯絡人的警報通知 |
 | `error` | `ApiError` | 事件處理失敗的錯誤回報 |
 
 ---

--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -67,7 +67,6 @@ This document defines the RESTful API and Socket.IO real-time communication inte
 | | `room_update` | Yes (On connection) | Room settings changes, member changes, or kick notifications. See [room_update subtypes](#room_update-subtypes). |
 | | `friend_request` | Yes (On connection) | Real-time notification for friend request status changes (sent, accepted, rejected) |
 | | `user_status` | Yes (On connection) | Online/offline presence change of a friend |
-| | `emergency_alert` | Yes (On connection) | Receive emergency alert notification from contact |
 | | `error` | Yes (On connection) | Error report for failed event processing |
 
 ---
@@ -1385,7 +1384,23 @@ All errors return the following JSON structure:
   }
   ```
 - **Response**:
-  - `200 OK`: Check completed.
+  - `200 OK`: Check completed. The body reports what was actually delivered.
+- **Response Fields**:
+  | Field | Type | Description |
+  | :--- | :--- | :--- |
+  | `alerted` | Boolean | `true` when at least one contact received a durably stored alert |
+  | `recipients` | String[] | Contacts whose alert was written to the database |
+  | `failedRecipients` | String[] | Contacts the alert did not reach. Omitted when every contact was reached |
+  | `reason` | String | Why nothing was alerted. Only present when `alerted` is `false`: `WARNING_DISABLED`, `INVALID_THRESHOLD`, `BELOW_THRESHOLD`, `ALREADY_ALERTED`, `NO_CONTACTS`, `DELIVERY_FAILED` |
+- **Response Example**:
+  ```json
+  {
+    "alerted": true,
+    "recipients": ["d3b07384-d113-4956-a5cc-4847841c2c31"],
+    "failedRecipients": ["9f8e7d6c-5b4a-4321-8765-1a2b3c4d5e6f"]
+  }
+  ```
+- **Delivery Semantics**: An alert is delivered as a regular chat message in the private room shared with the contact, so an offline contact receives it through the normal history and `new_message` paths on reconnect. There is no separate transient alert event: a contact listed in `failedRecipients` was **not** notified by any channel.
 
 ---
 
@@ -1420,7 +1435,6 @@ All errors return the following JSON structure:
 | `room_update` | `{ type: string, roomId: string, data: unknown }` | Room or membership state change. `type` determines the subtype. See [`room_update` Subtypes](#room_update-subtypes). |
 | `friend_request` | `{ requesterId: string, addresseeId: string, status: 'pending' \| 'accepted' \| 'rejected', createdAt: string }` | Friend request status change notification. Delivered to **both** the addressee (new request) and the requester (accepted / rejected). The client should refresh friend and pending-request lists upon receiving this event regardless of `status`. |
 | `user_status` | `{ userId: string, status: 'online' \| 'offline' }` | Presence update for a friend. Delivered when a friend connects or disconnects. |
-| `emergency_alert` | `{ userId: string, message: string }` | Receive emergency alert from contact |
 | `error` | `ApiError` | Error report for failed event processing |
 
 ---

--- a/frontend/src/context/ChatContext.tsx
+++ b/frontend/src/context/ChatContext.tsx
@@ -77,7 +77,6 @@ import {
 import {
   createChatSocket,
   joinRoom,
-  onEmergencyAlert,
   onFriendRequest,
   onMessageRecalled,
   onMessageUpdated,
@@ -1237,9 +1236,6 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
         }
       }
     });
-    const cleanupEmergencyAlert = onEmergencyAlert(socket, (payload) => {
-      window.alert(`[EMERGENCY ALERT]\nFrom User: ${payload.userId}\nMessage: ${payload.message}`);
-    });
     const cleanupUserStatus = onUserStatus(socket, ({ userId, status }) => {
       setFriends((prev) =>
         prev.map((friend) =>
@@ -1371,7 +1367,6 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
       cleanupTyping();
       cleanupError();
       cleanupFriendRequest();
-      cleanupEmergencyAlert();
       cleanupUserStatus();
       cleanupRoomUpdate();
       socket.off("connect", joinKnownRooms);

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -100,6 +100,7 @@ type UploadAttachmentResponse = Attachment;
 type EmergencyAlertResult = {
   alerted: boolean;
   recipients: string[];
+  failedRecipients?: string[];
   reason?: string;
 };
 

--- a/frontend/src/lib/socket.ts
+++ b/frontend/src/lib/socket.ts
@@ -75,14 +75,6 @@ export const onReadUpdate = (
   return () => socket.off('read_update', handler);
 };
 
-export const onEmergencyAlert = (
-  socket: ChatSocket,
-  handler: ServerToClientEvents['emergency_alert'],
-): (() => void) => {
-  socket.on('emergency_alert', handler);
-  return () => socket.off('emergency_alert', handler);
-};
-
 export const onSocketError = (
   socket: ChatSocket,
   handler: ServerToClientEvents['error'],

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -208,7 +208,6 @@ export interface ServerToClientEvents {
   read_update:      (payload: { roomId: string; userId: string; messageId: string }) => void;
   room_update:      (payload: { type: string; roomId: string; data: any }) => void;
   friend_request:   (payload: FriendRequest) => void;
-  emergency_alert:  (payload: { userId: string; message: string }) => void;
   error:            (payload: ApiError) => void;
   user_status:      (payload: { userId: string; status: 'online' | 'offline' }) => void;
 }


### PR DESCRIPTION
## 變更描述 (Description)

Emergency alert 的瞬時 `emergency_alert` 事件，原本正是「持久化失敗時的 fallback」。也就是說，**正好在 durable 紀錄不存在的那個情況下**，系統送出一個 fire-and-forget 事件：離線的緊急聯絡人什麼都收不到，系統也沒有留下任何曾經嘗試通知的紀錄。房間建立失敗走的是同一條路，只被 `console.error` 吞掉。

本 PR 移除這條 fallback 路徑。警報改為「先持久化，成功後才發即時訊號」，失敗則明確回報給呼叫端。

### 根因 (Root Cause)

本次逐條讀原始碼確認：

1. `backend/src/bootstrap/services.ts:72`（送出失敗）與 `:75`（房間不存在）是兩個 ghost emit，都送往 `user_{contactId}` 個人頻道，都沒有任何 durable 紀錄。
2. `services.ts:61-64` 把房間建立錯誤吞進 `console.error`，`room` 保持 `undefined`，控制流落到 `:74-76` 的 ghost emit。
3. `userService.ts:95-107` 無條件把每個 `contactId` 推進 `recipients` 並回傳 `alerted: true`。真正原因不是回呼型別，而是**注入的 notifier 自己把錯誤吞掉了**（`services.ts:62,71`）——若它會拋出，`:99` 的 `await` 本來就會傳播。因此修法是「契約上要求 notifier 回報結果」加上「防禦性的 per-contact try/catch」。
4. `emergencyContactRepository.ts:94-110` 的 `recordAlertIfNew` 是 SELECT-then-INSERT，且在任何送出嘗試**之前**就寫下標記。後果是完全失敗的警報永遠無法重試；並存的兩次執行則會讓落後者的 INSERT 撞上 `(user_id, last_activity_at)` 主鍵，拋出未被處理的 unique violation。
5. `recordAlertIfNew` 在 `findByUserId` 之前執行，因此**沒有設定聯絡人的使用者會白白燒掉標記**，之後即使新增聯絡人也再也不會對該時間窗發出警報。
6. 私聊房間若已存在但為 `isReadonly`（解除好友或封鎖所致），`services.ts:56-57` 會短路使用該房間，`messageService.ts:71-73` 隨即拋出 `ForbiddenError`，於是又落入 ghost emit。

### 變更內容 (What changed and why)

- **新增 `backend/src/services/emergencyNotifier.ts`**：送達規則從 composition root 移入 service 層（`src/CLAUDE.md` 明訂 bootstrap 只做 wiring、不放商業規則）。這同時讓「資料庫寫入失敗」與「房間建立失敗」變成可用 mock 驗證的單元測試，不再只能靠 e2e。
- **不再有 fallback**：先 `createPrivate`（沿用既有的 find / reopen / create 邏輯），再 `sendMessage`，成功後才對房間頻道 `room_{roomId}` 發 `new_message`——與 `socketServer.ts:70` 的一般送訊路徑完全相同。
- **即時層失敗不得降級結果**：durable 紀錄寫入後，emit 失敗只記錄日誌。若在此回報失敗，標記會被歸還，下一輪就會寫入第二份相同警報。
- **封鎖防護**：`createPrivate(..., true)` 會跳過封鎖檢查並把 read-only 房間重新開啟。若不擋，一則警報就會把寫入權限還給封鎖對方的人，且 `blocks` 紀錄還在、唯一的實際約束（`is_readonly`）卻消失了。因此 notifier 先查 `isBlocked`，視為**永久性**失敗並跳過。
- **軟刪除聯絡人**：`emergency_contacts` 的 JOIN 未過濾 `deleted_at`，而 `room_members` 在軟刪除後仍存在，因此警報會被誤報為「已送達」給一個墓碑帳號。改以 `userRepo.findById`（本身已過濾 `deleted_at IS NULL`）判定，視為永久性失敗。
- **`recordAlertIfNew` 改為單一原子語句**（`ON CONFLICT DO NOTHING RETURNING`）。
- **新增 `releaseAlert`**：當沒有任何聯絡人取得 durable 紀錄時歸還標記，讓該時間窗可以重試；只要有一位成功就保留標記，避免重試寫出重複警報。永久性失敗（封鎖、已刪除）不歸還，以免每小時無效重試。
- **`checkInactivity` 回應擴充** `failedRecipients`，`reason` 維持只在 `alerted` 為 false 時出現。`inactivityJob` 對未送達的聯絡人輸出錯誤日誌，排程路徑不再靜默。
- **移除已成死碼的 `emergency_alert` 事件**：`shared/types.ts`、`frontend/src/lib/socket.ts`、`ChatContext.tsx` 的 `window.alert` 監聽，以及中英文 API 文件。同時補上 check-inactivity 的回應欄位與送達語意說明。

### 需要 reviewer 判斷的行為變更

- **重新開啟 read-only 私聊房間**：因解除好友而 read-only 的房間，現在會因為一則緊急警報而重新開啟，等同永久恢復雙方的寫入權限，而關閉它的可能正是該聯絡人。對「dead man's switch」而言這是合理的，但這是**政策變更**而非單純修 bug，故在此明列。封鎖情境已依上述擋下。
- **已知殘留缺口**：標記的粒度是 `(user_id, last_activity_at)`，因此「一位成功、另一位暫時性失敗」時，失敗的那位不會被自動重試（會出現在 `failedRecipients` 並寫入日誌）。要完整解決需將主鍵改為 `(user_id, contact_id, last_activity_at)`，但既有資料沒有誠實的 backfill 方式，且會改動 `IEmergencyContactRepository` 與 `ALREADY_ALERTED` 的早期返回位置，故另開 issue 處理較適當。

## 相關的 Issue (Related Issue)

Closes #535

## 變更類型 (Type of Change)

- [ ] `feat`: 新增功能 (Feature)
- [x] `fix`: 修復 Bug
- [ ] `refactor`: 重構代碼
- [x] `docs`: 修改文件
- [ ] `test`: 新增或修正測試案例
- [ ] `chore`: 建置流程或輔助工具變更
- [ ] `perf`: 效能優化
- [ ] `ci`: CI 設定變更

## 驗證與測試計畫 (Verification & Test Plan)

### 本地測試 (Local Tests)

本 PR 的開發環境**沒有可用的 Docker daemon**，需要資料庫的測試改由 CI 執行並已通過。

本機實際執行並通過：

- [x] 後端型別檢查（`bunx tsc --noEmit`，涵蓋 `src/**` 與 `tests/**`）— 通過
- [x] 前端型別檢查（`bunx tsc --noEmit`）— 通過
- [x] 後端 Linter（`bunx eslint src`）— 通過
- [x] 前端 Linter（`bunx eslint`）— 通過
- [x] 後端單元測試（`bun test tests/unit`）— **464 pass / 0 fail**（修改前基準為 450，新增 14 項）
- [x] 前端測試（`bunx vitest run`）— 30 pass / 0 fail

CI（`database / database-tests`）執行並通過：

- [x] 整合測試 — 33 pass / 0 fail
- [x] E2E — **77 pass / 0 fail**（13 個檔案）

### CI 首次執行抓到的兩個問題（已修正）

本機無法執行資料庫層測試，以下兩點是 CI 才發現的，均為本 PR 新增測試自身的問題：

1. **封鎖情境的前置順序寫反了**。`friendRepository.blockUser:177-181` 會雙向刪除 `emergency_contacts`，因此「先設定聯絡人再封鎖」只會得到 `NO_CONTACTS`。可達的順序相反：`upsertEmergencyContact` 不檢查封鎖，使用者可以把已封鎖自己的人加為緊急聯絡人。測試已改為此順序——這同時佐證 notifier 的封鎖防護擋的是真實路徑。
2. **TRUNCATE 與斷線廣播死結**。中斷連線會觸發離線狀態廣播並讀取 `friendships`，而 `resetDb` 要 TRUNCATE 同一批資料表，兩者鎖衝突。此檔案原本只有一個 socket 測試、後面沒有其他測試，因此不會踩到；新增測試後才顯現。已在 `beforeEach` 中先讓斷線處理結束再 truncate，重跑後 Postgres log 中已無 `deadlock detected`。

### 新增測試

`backend/tests/unit/services/emergencyNotifier.test.ts`（新檔，8 項，可在無 Docker 環境執行）：
- 持久化先於任何 emit（以呼叫順序斷言）
- 資料庫寫入失敗時完全不發出即時訊號
- 房間建立失敗被回報而非吞掉
- 4xx 錯誤歸類為永久性、不再重試
- 封鎖對象不送達且不重新開啟房間
- 軟刪除聯絡人視為永久性跳過
- 寫入成功後即時層拋錯仍維持 delivered
- 訊息寫入後重新對聯絡人廣播 ROOM_JOINED

`backend/tests/unit/services/userService.test.ts`（新增 6 項）：`DELIVERY_FAILED` 並歸還標記、notifier 拋出視為可重試、永久性失敗保留標記、部分送達保留標記並列出未送達者、`NO_CONTACTS` 歸還標記、歸還失敗不影響回傳結果。

`backend/tests/e2e/socket/emergencyAlert.e2e.test.ts`（新增 4 項）：離線聯絡人可透過既有歷史訊息路徑取得警報、無法送達時明確回報且不發出任何瞬時事件、同一時間窗重複檢查只存一份警報、未曾嘗試過的時間窗可重試。

### 手動測試 (Manual Verification)

未進行；本次變更沒有 UI 產出，前端僅移除一個已無來源的事件監聽（原本是 `window.alert`）。

## 資料庫變更 (Database Changes)

* 此變更是否包含資料庫 Schema 修改？ **否**
* 若為是，請寫明 Migration 檔案名稱：`N/A`
* 是否已確認遷移與 [docs/database-design.md](../docs/database-design.md) 設計一致？ **N/A**（僅變更 `emergency_alert_logs` 的存取語句，未更動結構）

## API 與 WebSocket 協定一致性 (API & WebSocket Contract Check)

* 此變更是否涉及 API 路由或 WebSocket 事件的資料結構變更？ **是**
* 是否已確認與 [docs/api-documentation.md](../docs/api-documentation.md) 規範完全一致？ **是**

具體變更：移除 Server-to-Client 事件 `emergency_alert`（已無任何來源）；`POST /users/me/emergency-alert/check-inactivity` 回應新增 `failedRecipients` 與 `DELIVERY_FAILED` 原因碼。中英文兩份文件均已同步更新。

## Advisor 重點意見

實作前經 architect sub-agent（opus）審查計畫，主要修正了三點：

1. **原分析有一處錯誤**：我原本認為並存執行會造成重複警報。實際上主鍵已阻止重複，真正的缺陷是**未被處理的 unique violation**。`ON CONFLICT DO NOTHING` 仍是正確修法，但理由不同。
2. **notifier 應抽成 service**（採納）：留在 composition root 會讓「寫入失敗」「房間建立失敗」兩條路徑只能靠 e2e 驗證，而本環境沒有 Docker；抽出後即可用單元測試涵蓋。
3. **`createPrivate(..., true)` 會默默破壞封鎖**（採納，advisor 視為 blocker）：已加上 `isBlocked` 前置檢查。

另建議簡化回傳詞彙：捨棄 `PARTIAL_DELIVERY_FAILURE`，改由 `failedRecipients` 表達部分失敗，`reason` 只描述「完全未發出警報」的原因，維持 `alerted === false` 才有 `reason` 的既有不變式（已採納）。

---

Generated with Claude Code (https://claude.com/claude-code)