### PR TITLE
feat: 建立訊息變更序號與冪等鍵的資料模型 (#530)

### DIFF
--- a/backend/migrations/2026080900000_message_change_sequences.sql
+++ b/backend/migrations/2026080900000_message_change_sequences.sql
@@ -1,0 +1,224 @@
+--- Up migration
+-- Message Sequence / Change Sequence / revision / idempotency key, plus the
+-- sequence-based Join Boundary and Read Position on room_members.
+--
+-- Sequences are allocated from a counter row inside the writing transaction and
+-- deliberately NOT from a PostgreSQL sequence: nextval() is not transactional, so
+-- a transaction that draws a lower number may commit after one that drew a higher
+-- number. A reader whose cursor has already advanced past the higher number would
+-- then skip the lower one permanently, and silently. Locking a counter row makes
+-- allocation order equal commit order, and a rollback releases the number again.
+
+CREATE TABLE message_sequence_counter (
+  counter_id  BOOLEAN PRIMARY KEY DEFAULT true CHECK (counter_id),
+  current_seq BIGINT  NOT NULL DEFAULT 0
+);
+
+INSERT INTO message_sequence_counter (counter_id, current_seq) VALUES (true, 0);
+
+-- Self-materialising so that a TRUNCATE in the test helpers cannot leave the
+-- allocator without a row to lock.
+CREATE FUNCTION next_message_seq() RETURNS BIGINT
+LANGUAGE sql VOLATILE AS $$
+  INSERT INTO message_sequence_counter AS c (counter_id, current_seq)
+  VALUES (true, 1)
+  ON CONFLICT (counter_id) DO UPDATE SET current_seq = c.current_seq + 1
+  RETURNING c.current_seq;
+$$;
+
+ALTER TABLE messages
+  ADD COLUMN message_seq       BIGINT,
+  ADD COLUMN change_seq        BIGINT,
+  ADD COLUMN revision          INTEGER NOT NULL DEFAULT 1,
+  ADD COLUMN client_command_id UUID;
+
+-- Backfill in the existing keyset order, not physical order, so that existing
+-- conversations keep the order they are currently paginated in.
+WITH ordered AS (
+  SELECT message_id, ROW_NUMBER() OVER (ORDER BY sent_at, message_id) AS rn
+  FROM messages
+)
+UPDATE messages m
+SET message_seq = ordered.rn,
+    change_seq  = ordered.rn
+FROM ordered
+WHERE m.message_id = ordered.message_id;
+
+UPDATE message_sequence_counter
+SET current_seq = COALESCE((SELECT MAX(change_seq) FROM messages), 0);
+
+ALTER TABLE messages
+  ALTER COLUMN message_seq SET NOT NULL,
+  ALTER COLUMN change_seq  SET NOT NULL;
+
+-- A change number is drawn once and belongs to exactly one change; a create
+-- number belongs to exactly one message. Both catch an allocator fault at the
+-- first bad write rather than at sync time.
+ALTER TABLE messages
+  ADD CONSTRAINT messages_message_seq_key UNIQUE (message_seq),
+  ADD CONSTRAINT messages_change_seq_key  UNIQUE (change_seq);
+
+-- One command identifier per sender yields at most one message.
+CREATE UNIQUE INDEX messages_sender_command_id_key
+  ON messages (sender_id, client_command_id)
+  WHERE client_command_id IS NOT NULL;
+
+CREATE FUNCTION messages_assign_create_seq() RETURNS TRIGGER
+LANGUAGE plpgsql AS $$
+BEGIN
+  IF NEW.message_seq IS NULL THEN
+    NEW.message_seq := next_message_seq();
+  END IF;
+  -- A create is itself the first change, so both numbers come from the same
+  -- allocation: a single cursor over change_seq then sees creates and edits
+  -- as one gapless stream.
+  NEW.change_seq := NEW.message_seq;
+  NEW.revision   := 1;
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_messages_assign_create_seq
+  BEFORE INSERT ON messages
+  FOR EACH ROW EXECUTE FUNCTION messages_assign_create_seq();
+
+CREATE FUNCTION messages_advance_change_seq() RETURNS TRIGGER
+LANGUAGE plpgsql AS $$
+BEGIN
+  NEW.message_seq := OLD.message_seq;  -- creation order never moves
+  NEW.change_seq  := next_message_seq();
+  NEW.revision    := OLD.revision + 1;
+  RETURN NEW;
+END;
+$$;
+
+-- Restricted to the columns that are a Message Change. reply_to_id is set NULL
+-- by a foreign key when a replied-to message is hard-deleted; that must not
+-- burn a change number or push a no-op revision to synced clients.
+CREATE TRIGGER trg_messages_advance_change_seq
+  BEFORE UPDATE ON messages
+  FOR EACH ROW
+  WHEN (OLD.content IS DISTINCT FROM NEW.content
+     OR OLD.is_recalled IS DISTINCT FROM NEW.is_recalled)
+  EXECUTE FUNCTION messages_advance_change_seq();
+
+ALTER TABLE room_members
+  ADD COLUMN join_seq      BIGINT NOT NULL DEFAULT 0,
+  ADD COLUMN last_read_seq BIGINT NOT NULL DEFAULT 0;
+
+UPDATE room_members rm
+SET join_seq = COALESCE((
+      SELECT MAX(m.message_seq)
+      FROM messages m
+      WHERE m.room_id = rm.room_id
+        AND m.sent_at <= rm.join_time
+    ), 0),
+    last_read_seq = COALESCE((
+      SELECT m.message_seq
+      FROM messages m
+      WHERE m.message_id = rm.last_read_id
+    ), 0);
+
+CREATE INDEX idx_messages_room_seq   ON messages (room_id, message_seq DESC);
+CREATE INDEX idx_messages_change_seq ON messages (change_seq);
+DROP INDEX IF EXISTS idx_messages_pagination;
+
+-- Column list changes, so the view has to be dropped rather than replaced.
+DROP VIEW IF EXISTS room_last_message_view;
+CREATE VIEW room_last_message_view AS
+SELECT DISTINCT ON (m.room_id)
+  m.room_id,
+  m.message_id,
+  m.sender_id,
+  m.content,
+  m.sent_at,
+  m.message_seq
+FROM messages m
+ORDER BY m.room_id, m.message_seq DESC;
+
+CREATE OR REPLACE VIEW message_with_sender_view AS
+SELECT
+  m.message_id,
+  m.room_id,
+  m.sender_id,
+  m.content,
+  m.reply_to_id,
+  m.is_recalled,
+  m.sent_at,
+  u.user_id AS sender_user_id,
+  u.name AS sender_name,
+  u.avatar_url AS sender_avatar_url,
+  u.deleted_at AS sender_deleted_at,
+  -- Appended: CREATE OR REPLACE VIEW can only add columns at the end.
+  m.message_seq,
+  m.change_seq,
+  m.revision,
+  m.client_command_id
+FROM messages m
+LEFT JOIN users u ON u.user_id = m.sender_id;
+
+--- Down migration
+
+DROP VIEW IF EXISTS message_with_sender_view;
+DROP VIEW IF EXISTS room_last_message_view;
+
+CREATE VIEW message_with_sender_view AS
+SELECT
+  m.message_id,
+  m.room_id,
+  m.sender_id,
+  m.content,
+  m.reply_to_id,
+  m.is_recalled,
+  m.sent_at,
+  u.user_id AS sender_user_id,
+  u.name AS sender_name,
+  u.avatar_url AS sender_avatar_url,
+  u.deleted_at AS sender_deleted_at
+FROM messages m
+LEFT JOIN users u ON u.user_id = m.sender_id;
+
+CREATE VIEW room_last_message_view AS
+SELECT
+  m.room_id,
+  m.message_id,
+  m.sender_id,
+  m.content,
+  m.sent_at
+FROM messages m
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM messages newer
+  WHERE newer.room_id = m.room_id
+    AND (
+      newer.sent_at > m.sent_at
+      OR (newer.sent_at = m.sent_at AND newer.message_id > m.message_id)
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_messages_pagination ON messages (room_id, sent_at DESC, message_id DESC);
+DROP INDEX IF EXISTS idx_messages_change_seq;
+DROP INDEX IF EXISTS idx_messages_room_seq;
+
+ALTER TABLE room_members
+  DROP COLUMN IF EXISTS last_read_seq,
+  DROP COLUMN IF EXISTS join_seq;
+
+DROP TRIGGER IF EXISTS trg_messages_advance_change_seq ON messages;
+DROP TRIGGER IF EXISTS trg_messages_assign_create_seq ON messages;
+DROP FUNCTION IF EXISTS messages_advance_change_seq();
+DROP FUNCTION IF EXISTS messages_assign_create_seq();
+
+DROP INDEX IF EXISTS messages_sender_command_id_key;
+ALTER TABLE messages
+  DROP CONSTRAINT IF EXISTS messages_change_seq_key,
+  DROP CONSTRAINT IF EXISTS messages_message_seq_key;
+
+ALTER TABLE messages
+  DROP COLUMN IF EXISTS client_command_id,
+  DROP COLUMN IF EXISTS revision,
+  DROP COLUMN IF EXISTS change_seq,
+  DROP COLUMN IF EXISTS message_seq;
+
+DROP FUNCTION IF EXISTS next_message_seq();
+DROP TABLE IF EXISTS message_sequence_counter;

--- a/backend/src/models/IMessageRepository.ts
+++ b/backend/src/models/IMessageRepository.ts
@@ -2,8 +2,9 @@ import type { Message, MessageWithSender } from '@shared/types';
 
 export interface IMessageRepository {
   findById(messageId: string): Promise<Message | null>;
-  findByRoom(roomId: string, opts: { beforeId?: string; limit: number; after?: Date }): Promise<MessageWithSender[]>;
-  create(data: Pick<Message, 'roomId' | 'senderId' | 'content' | 'replyToId'> & { mentions?: string[], attachmentIds?: string[] }): Promise<MessageWithSender>;
+  findByRoom(roomId: string, opts: { beforeId?: string; limit: number; afterSeq?: number }): Promise<MessageWithSender[]>;
+  findBySenderCommandId(senderId: string, clientCommandId: string): Promise<MessageWithSender | null>;
+  create(data: Pick<Message, 'roomId' | 'senderId' | 'content' | 'replyToId'> & { mentions?: string[], attachmentIds?: string[], clientCommandId?: string }): Promise<MessageWithSender>;
   markRecalled(messageId: string): Promise<MessageWithSender>;
   update(messageId: string, content: string, mentions?: string[]): Promise<MessageWithSender>;
 }

--- a/backend/src/models/messageRepository.ts
+++ b/backend/src/models/messageRepository.ts
@@ -4,6 +4,15 @@ import type { Attachment, Message, MessageWithSender } from '@shared/types';
 import type { IMessageRepository } from './IMessageRepository';
 import { ValidationError } from '../utils/AppError';
 
+const PG_UNIQUE_VIOLATION = '23505';
+
+/** Bun's SQL driver reports the SQLSTATE in `errno`; node-pg reports it in `code`. */
+function isUniqueViolation(err: unknown): boolean {
+  if (typeof err !== 'object' || err === null) return false;
+  const { code, errno } = err as { code?: unknown; errno?: unknown };
+  return code === PG_UNIQUE_VIOLATION || errno === PG_UNIQUE_VIOLATION;
+}
+
 export interface MessageRow {
   message_id: string;
   room_id: string;
@@ -12,6 +21,9 @@ export interface MessageRow {
   reply_to_id?: string | null;
   is_recalled: boolean;
   sent_at: Date;
+  message_seq?: string | number | null;
+  change_seq?: string | number | null;
+  revision?: number | null;
 }
 
 export interface MessageWithSenderRow {
@@ -22,6 +34,10 @@ export interface MessageWithSenderRow {
   reply_to_id?: string | null;
   is_recalled: boolean;
   sent_at: Date;
+  message_seq?: string | number | null;
+  change_seq?: string | number | null;
+  revision?: number | null;
+  client_command_id?: string | null;
   sender_user_id?: string | null;
   sender_name?: string | null;
   sender_avatar_url?: string | null;
@@ -54,6 +70,11 @@ function mapRowToAttachment(row: AttachmentRow): Attachment {
   };
 }
 
+/** BIGINT columns arrive as strings on some drivers; sequences stay well inside Number range. */
+function toSeq(value: string | number | null | undefined): number | undefined {
+  return value === null || value === undefined ? undefined : Number(value);
+}
+
 function mapRowToMessage(row: MessageRow | MessageWithSenderRow): Message {
   return {
     messageId: row.message_id,
@@ -63,6 +84,9 @@ function mapRowToMessage(row: MessageRow | MessageWithSenderRow): Message {
     replyToId: row.reply_to_id ?? undefined,
     isRecalled: row.is_recalled,
     sentAt: row.sent_at,
+    messageSeq: toSeq(row.message_seq),
+    changeSeq: toSeq(row.change_seq),
+    revision: row.revision ?? undefined,
   };
 }
 
@@ -157,25 +181,31 @@ export class MessageRepository implements IMessageRepository {
     return rows.length === 0 ? null : mapRowToMessage(rows[0]);
   }
 
-  async findByRoom(roomId: string, opts: { beforeId?: string; limit: number; after?: Date }): Promise<MessageWithSender[]> {
+  /**
+   * Paginates on message_seq. Creation order is fixed at insert and never moves,
+   * so an edited message keeps its place in the thread. `afterSeq` is the caller's
+   * Join Boundary: messages at or below it predate the membership.
+   */
+  async findByRoom(roomId: string, opts: { beforeId?: string; limit: number; afterSeq?: number }): Promise<MessageWithSender[]> {
     const limit = Math.max(1, opts.limit);
+    const afterSeq = opts.afterSeq ?? null;
 
     if (opts.beforeId) {
-      const cursorRows = await this.sql<MessageRow[]>`
-        SELECT sent_at, message_id, room_id, sender_id, content, is_recalled FROM messages WHERE message_id = ${opts.beforeId} AND room_id = ${roomId}
+      const cursorRows = await this.sql<{ message_seq: string | number }[]>`
+        SELECT message_seq FROM messages WHERE message_id = ${opts.beforeId} AND room_id = ${roomId}
       `;
       if (cursorRows.length === 0) {
         throw new ValidationError('Cursor message not found in this room');
       }
-      const cursor = cursorRows[0];
+      const cursorSeq = Number(cursorRows[0].message_seq);
 
       const rows = await this.sql<{ message_id: string }[]>`
         SELECT message_id
         FROM messages
         WHERE room_id = ${roomId}
-          AND (${opts.after ?? null}::timestamptz IS NULL OR sent_at >= ${opts.after ?? null})
-          AND (sent_at, message_id) < (${cursor.sent_at}, ${cursor.message_id})
-        ORDER BY sent_at DESC, message_id DESC
+          AND (${afterSeq}::bigint IS NULL OR message_seq > ${afterSeq})
+          AND message_seq < ${cursorSeq}
+        ORDER BY message_seq DESC
         LIMIT ${limit}
       `;
       return this.fetchMessageWithSenderByIds(rows.map((row) => row.message_id));
@@ -185,58 +215,95 @@ export class MessageRepository implements IMessageRepository {
       SELECT message_id
       FROM messages
       WHERE room_id = ${roomId}
-        AND (${opts.after ?? null}::timestamptz IS NULL OR sent_at >= ${opts.after ?? null})
-      ORDER BY sent_at DESC, message_id DESC
+        AND (${afterSeq}::bigint IS NULL OR message_seq > ${afterSeq})
+      ORDER BY message_seq DESC
       LIMIT ${limit}
     `;
     return this.fetchMessageWithSenderByIds(rows.map((row) => row.message_id));
   }
 
-  async create(data: Pick<Message, 'roomId' | 'senderId' | 'content' | 'replyToId'> & { mentions?: string[], attachmentIds?: string[] }): Promise<MessageWithSender> {
+  /** Returns the message a previous attempt at the same command already created, if any. */
+  async findBySenderCommandId(senderId: string, clientCommandId: string): Promise<MessageWithSender | null> {
+    const rows = await this.sql<{ message_id: string }[]>`
+      SELECT message_id
+      FROM messages
+      WHERE sender_id = ${senderId} AND client_command_id = ${clientCommandId}
+    `;
+    if (rows.length === 0) return null;
+    const [message] = await this.fetchMessageWithSenderByIds([rows[0].message_id]);
+    return message ?? null;
+  }
+
+  async create(data: Pick<Message, 'roomId' | 'senderId' | 'content' | 'replyToId'> & { mentions?: string[], attachmentIds?: string[], clientCommandId?: string }): Promise<MessageWithSender> {
     let createdMessageId: string = '';
 
-    await this.sql.begin(async (tx) => {
-      const rows = await tx<{ message_id: string }[]>`
-        INSERT INTO messages (room_id, sender_id, content, reply_to_id)
-        VALUES (${data.roomId}, ${data.senderId}, ${data.content}, ${data.replyToId ?? null})
-        RETURNING message_id
-      `;
-      createdMessageId = rows[0].message_id;
+    // Resolve a replay before opening the transaction, so a repeat of a command
+    // that already succeeded never draws a sequence number it would not use.
+    if (data.clientCommandId && data.senderId) {
+      const replayed = await this.findBySenderCommandId(data.senderId, data.clientCommandId);
+      if (replayed) return replayed;
+    }
 
-      if (data.mentions && data.mentions.length > 0) {
-        for (const userId of data.mentions) {
+    try {
+      await this.sql.begin(async (tx) => {
+        const rows = await tx<{ message_id: string }[]>`
+          INSERT INTO messages (room_id, sender_id, content, reply_to_id, client_command_id)
+          VALUES (${data.roomId}, ${data.senderId}, ${data.content}, ${data.replyToId ?? null}, ${data.clientCommandId ?? null})
+          RETURNING message_id
+        `;
+        createdMessageId = rows[0].message_id;
+
+        if (data.mentions && data.mentions.length > 0) {
+          // One statement: every mention insert would otherwise sit inside the
+          // globally serialised allocation window opened by this transaction.
+          const pgMentionIds = `{${data.mentions.join(',')}}`;
           await tx`
             INSERT INTO message_mentions (message_id, user_id)
-            VALUES (${createdMessageId}, ${userId})
+            SELECT ${createdMessageId}, user_id
+            FROM UNNEST(${pgMentionIds}::uuid[]) AS user_id
           `;
         }
-      }
 
-      if (data.attachmentIds && data.attachmentIds.length > 0) {
-        const pgAttIds = `{${data.attachmentIds.join(',')}}`;
-        const updatedAtts = await tx<{ attachment_id: string }[]>`
-          UPDATE attachments SET message_id = ${createdMessageId}
-          WHERE attachment_id = ANY(${pgAttIds}::uuid[]) AND message_id IS NULL
-          RETURNING attachment_id
-        `;
-        if (updatedAtts.length !== new Set(data.attachmentIds).size) {
-          throw new ValidationError('Attachments must exist and must not already belong to a message');
+        if (data.attachmentIds && data.attachmentIds.length > 0) {
+          const pgAttIds = `{${data.attachmentIds.join(',')}}`;
+          const updatedAtts = await tx<{ attachment_id: string }[]>`
+            UPDATE attachments SET message_id = ${createdMessageId}
+            WHERE attachment_id = ANY(${pgAttIds}::uuid[]) AND message_id IS NULL
+            RETURNING attachment_id
+          `;
+          if (updatedAtts.length !== new Set(data.attachmentIds).size) {
+            throw new ValidationError('Attachments must exist and must not already belong to a message');
+          }
         }
+      });
+    } catch (err) {
+      // Two concurrent attempts at the same command: the unique index rejects the
+      // loser, which then reports the winner's message rather than an error.
+      if (data.clientCommandId && data.senderId && isUniqueViolation(err)) {
+        const winner = await this.findBySenderCommandId(data.senderId, data.clientCommandId);
+        if (winner) return winner;
       }
-    });
+      throw err;
+    }
 
     const [message] = await this.fetchMessageWithSenderByIds([createdMessageId]);
     return message;
   }
 
   async markRecalled(messageId: string): Promise<MessageWithSender> {
+    // Guarded so a repeated recall is a no-op rather than a fresh revision
+    // pushed to every synced client.
     const rows = await this.sql<{ message_id: string }[]>`
       UPDATE messages
       SET is_recalled = true
-      WHERE message_id = ${messageId}
+      WHERE message_id = ${messageId} AND is_recalled = false
       RETURNING message_id
     `;
-    if (rows.length === 0) throw new Error('Message not found');
+    if (rows.length === 0) {
+      const [existing] = await this.fetchMessageWithSenderByIds([messageId]);
+      if (!existing) throw new Error('Message not found');
+      return existing;
+    }
     const [message] = await this.fetchMessageWithSenderByIds([messageId]);
     return message;
   }
@@ -256,12 +323,12 @@ export class MessageRepository implements IMessageRepository {
       await tx`DELETE FROM message_mentions WHERE message_id = ${messageId}`;
 
       if (mentions && mentions.length > 0) {
-        for (const userId of mentions) {
-          await tx`
-            INSERT INTO message_mentions (message_id, user_id)
-            VALUES (${messageId}, ${userId})
-          `;
-        }
+        const pgMentionIds = `{${mentions.join(',')}}`;
+        await tx`
+          INSERT INTO message_mentions (message_id, user_id)
+          SELECT ${messageId}, user_id
+          FROM UNNEST(${pgMentionIds}::uuid[]) AS user_id
+        `;
       }
     });
 

--- a/backend/src/models/roomMemberRepository.ts
+++ b/backend/src/models/roomMemberRepository.ts
@@ -11,6 +11,8 @@ export interface RoomMemberRow {
   is_muted: boolean;
   last_read_id?: string | null;
   join_time: Date;
+  join_seq?: string | number | null;
+  last_read_seq?: string | number | null;
 }
 
 function mapRowToRoomMember(row: RoomMemberRow): RoomMember {
@@ -22,6 +24,8 @@ function mapRowToRoomMember(row: RoomMemberRow): RoomMember {
     isMuted: row.is_muted,
     lastReadId: row.last_read_id ?? undefined,
     joinTime: row.join_time,
+    joinSeq: row.join_seq === null || row.join_seq === undefined ? undefined : Number(row.join_seq),
+    lastReadSeq: row.last_read_seq === null || row.last_read_seq === undefined ? undefined : Number(row.last_read_seq),
   };
 }
 
@@ -43,9 +47,16 @@ export class RoomMemberRepository implements IRoomMemberRepository {
   }
 
   async add(data: Pick<RoomMember, 'roomId' | 'userId' | 'role'>): Promise<RoomMember> {
+    // The Join Boundary is the room's newest message at the moment of joining, so
+    // a room that does not publish history can exclude everything before it.
     const rows = await this.sql<RoomMemberRow[]>`
-      INSERT INTO room_members (room_id, user_id, role)
-      VALUES (${data.roomId}, ${data.userId}, ${data.role})
+      INSERT INTO room_members (room_id, user_id, role, join_seq)
+      VALUES (
+        ${data.roomId},
+        ${data.userId},
+        ${data.role},
+        COALESCE((SELECT MAX(message_seq) FROM messages WHERE room_id = ${data.roomId}), 0)
+      )
       RETURNING *
     `;
     return mapRowToRoomMember(rows[0]);
@@ -59,14 +70,28 @@ export class RoomMemberRepository implements IRoomMemberRepository {
     const roleVal = data.role !== undefined ? data.role : this.sql`role`;
     const nickVal = data.nickname !== undefined ? data.nickname : this.sql`nickname`;
     const muteVal = data.isMuted !== undefined ? data.isMuted : this.sql`is_muted`;
-    const readVal = data.lastReadId !== undefined ? data.lastReadId : this.sql`last_read_id`;
+
+    // The Read Position only moves forward: a late-arriving or replayed request
+    // carrying an older message must not reopen messages the user has read.
+    // last_read_id is kept as a denormalised companion and advances in lockstep.
+    const readSeqVal = data.lastReadId !== undefined
+      ? this.sql`GREATEST(room_members.last_read_seq, COALESCE((SELECT message_seq FROM messages WHERE message_id = ${data.lastReadId}), 0))`
+      : this.sql`last_read_seq`;
+    const readIdVal = data.lastReadId !== undefined
+      ? this.sql`CASE
+            WHEN COALESCE((SELECT message_seq FROM messages WHERE message_id = ${data.lastReadId}), 0) > room_members.last_read_seq
+            THEN ${data.lastReadId}::uuid
+            ELSE room_members.last_read_id
+          END`
+      : this.sql`last_read_id`;
 
     const rows = await this.sql<RoomMemberRow[]>`
       UPDATE room_members SET
         role = ${roleVal},
         nickname = ${nickVal},
         is_muted = ${muteVal},
-        last_read_id = ${readVal}
+        last_read_seq = ${readSeqVal},
+        last_read_id = ${readIdVal}
       WHERE room_id = ${roomId} AND user_id = ${userId}
       RETURNING *
     `;

--- a/backend/src/models/roomRepository.ts
+++ b/backend/src/models/roomRepository.ts
@@ -64,11 +64,13 @@ function mapRowToRoomSummary(row: RoomRow & {
 export interface MemberRoomRow extends RoomRow {
   join_time: Date;
   last_read_id?: string | null;
-  last_read_sent_at?: Date | null;
+  join_seq?: string | number | null;
+  last_read_seq?: string | number | null;
   latest_message_id?: string | null;
   latest_sender_id?: string | null;
   latest_content?: string | null;
   latest_sent_at?: Date | null;
+  latest_message_seq?: string | number | null;
   role: string;
 }
 
@@ -113,14 +115,15 @@ export class RoomRepository implements IRoomRepository {
         rm.join_time,
         rm.last_read_id,
         rm.role,
-        last_read.sent_at AS last_read_sent_at,
+        rm.join_seq,
+        rm.last_read_seq,
         latest.message_id AS latest_message_id,
         latest.sender_id AS latest_sender_id,
         latest.content AS latest_content,
-        latest.sent_at AS latest_sent_at
+        latest.sent_at AS latest_sent_at,
+        latest.message_seq AS latest_message_seq
       FROM chat_rooms cr
       JOIN room_members rm ON rm.room_id = cr.room_id
-      LEFT JOIN messages last_read ON last_read.message_id = rm.last_read_id
       LEFT JOIN room_last_message_view latest ON latest.room_id = cr.room_id
       WHERE rm.user_id = ${userId}
     `;
@@ -135,19 +138,18 @@ export class RoomRepository implements IRoomRepository {
     const [unreadRows, privateRoomMemberRows] = await Promise.all([
       this.sql<{ room_id: string; unread_count: number }[]>`
         WITH filtered_unread_messages AS (
-          SELECT 
+          SELECT
             m.room_id,
             ROW_NUMBER() OVER (
-              PARTITION BY m.room_id 
-              ORDER BY m.sent_at DESC
+              PARTITION BY m.room_id
+              ORDER BY m.message_seq DESC
             ) as rn
           FROM messages m
           JOIN chat_rooms cr ON cr.room_id = m.room_id
           JOIN room_members rm ON rm.room_id = m.room_id AND rm.user_id = ${userId}
-          LEFT JOIN messages last_read ON last_read.message_id = rm.last_read_id
           WHERE m.room_id = ANY(${pgRoomIds}::uuid[])
-            AND (last_read.sent_at IS NULL OR m.sent_at > last_read.sent_at)
-            AND (cr.view_history = true OR m.sent_at >= rm.join_time)
+            AND m.message_seq > rm.last_read_seq
+            AND (cr.view_history = true OR m.message_seq > rm.join_seq)
         )
         SELECT room_id, COUNT(*)::int AS unread_count
         FROM filtered_unread_messages
@@ -174,8 +176,10 @@ export class RoomRepository implements IRoomRepository {
     }
 
     const summaries = roomRows.map((room) => {
+      const latestSeq = Number(room.latest_message_seq ?? 0);
+      const joinSeq = Number(room.join_seq ?? 0);
       const latestVisible =
-        room.latest_sent_at && (room.view_history || room.latest_sent_at >= room.join_time)
+        room.latest_sent_at && (room.view_history || latestSeq > joinSeq)
           ? {
               messageId: room.latest_message_id ?? null,
               senderId: room.latest_sender_id ?? null,

--- a/backend/src/services/messageService.ts
+++ b/backend/src/services/messageService.ts
@@ -133,7 +133,7 @@ export const makeMessageService = (
       return messageRepo.findByRoom(parsed.data.roomId, {
         beforeId: parsed.data.beforeId,
         limit: parsed.data.limit,
-        after: room.viewHistory ? undefined : member.joinTime,
+        afterSeq: room.viewHistory ? undefined : member.joinSeq,
       });
     },
 

--- a/backend/tests/e2e/routes/message.e2e.test.ts
+++ b/backend/tests/e2e/routes/message.e2e.test.ts
@@ -96,8 +96,17 @@ describe('Message E2E', () => {
     const newUserId = newUserRes.body.user.userId;
     const memberRole = 'member';
     const joinTime = '2026-01-02T00:00:00.000Z';
+    // The Join Boundary is a sequence, so it is pinned to the room's newest
+    // message at join time — the same value RoomMemberRepository.add derives.
     await testPool`
-      INSERT INTO room_members (room_id, user_id, role, join_time) VALUES (${hiddenRoomId}, ${newUserId}, ${memberRole}, ${joinTime})
+      INSERT INTO room_members (room_id, user_id, role, join_time, join_seq)
+      VALUES (
+        ${hiddenRoomId},
+        ${newUserId},
+        ${memberRole},
+        ${joinTime},
+        COALESCE((SELECT MAX(message_seq) FROM messages WHERE room_id = ${hiddenRoomId}), 0)
+      )
     `;
 
     const afterContent = 'after join';

--- a/backend/tests/helpers/resetDb.ts
+++ b/backend/tests/helpers/resetDb.ts
@@ -2,6 +2,6 @@ import { testPool } from './testPool';
 
 export async function resetDb(): Promise<void> {
   await testPool`
-    TRUNCATE users, chat_rooms, messages, room_members, emergency_contacts, friendships, blocks, folders, folder_rooms, attachments RESTART IDENTITY CASCADE
+    TRUNCATE users, chat_rooms, messages, room_members, emergency_contacts, friendships, blocks, folders, folder_rooms, attachments, message_sequence_counter RESTART IDENTITY CASCADE
   `;
 }

--- a/backend/tests/integration/repositories/messageSequences.int.test.ts
+++ b/backend/tests/integration/repositories/messageSequences.int.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, beforeEach } from 'bun:test';
+import { MessageRepository } from '../../../src/models/messageRepository';
+import { RoomMemberRepository } from '../../../src/models/roomMemberRepository';
+import { testPool } from '../../helpers/testPool';
+import { resetDb } from '../../helpers/resetDb';
+
+describe('Message sequences (pg)', () => {
+  const repo = new MessageRepository(testPool);
+  const memberRepo = new RoomMemberRepository(testPool);
+
+  let roomId: string;
+  let senderId: string;
+
+  beforeEach(async () => {
+    await resetDb();
+    const userRes = await testPool`
+      INSERT INTO users (name, email, password_hash) VALUES ('Alice', 'alice@test.com', 'hash') RETURNING user_id
+    `;
+    senderId = userRes[0].user_id;
+    const roomRes = await testPool`
+      INSERT INTO chat_rooms (type, name, require_approval, view_history)
+      VALUES ('group', 'Seq Room', false, true) RETURNING room_id
+    `;
+    roomId = roomRes[0].room_id;
+  });
+
+  async function send(content: string, clientCommandId?: string) {
+    return repo.create({ roomId, senderId, content, ...(clientCommandId ? { clientCommandId } : {}) });
+  }
+
+  it('assigns message_seq, change_seq and revision on creation', async () => {
+    const first = await send('one');
+    const second = await send('two');
+
+    expect(first.revision).toBe(1);
+    // A create is its own first change, so both numbers come from one allocation.
+    expect(first.changeSeq).toBe(first.messageSeq!);
+    expect(second.messageSeq!).toBeGreaterThan(first.messageSeq!);
+  });
+
+  it('keeps message_seq fixed while change_seq and revision advance on edit and recall', async () => {
+    const created = await send('original');
+    const createdSeq = created.messageSeq!;
+
+    const edited = await repo.update(created.messageId, 'edited');
+    expect(edited.messageSeq).toBe(createdSeq);
+    expect(edited.revision).toBe(2);
+    expect(edited.changeSeq!).toBeGreaterThan(created.changeSeq!);
+
+    const recalled = await repo.markRecalled(created.messageId);
+    expect(recalled.messageSeq).toBe(createdSeq);
+    expect(recalled.revision).toBe(3);
+    expect(recalled.changeSeq!).toBeGreaterThan(edited.changeSeq!);
+  });
+
+  it('does not burn a revision when a recall is repeated', async () => {
+    const created = await send('to recall');
+    const first = await repo.markRecalled(created.messageId);
+    const second = await repo.markRecalled(created.messageId);
+
+    expect(second.isRecalled).toBe(true);
+    expect(second.revision).toBe(first.revision);
+    expect(second.changeSeq).toBe(first.changeSeq);
+  });
+
+  it('allocates gapless, commit-ordered sequences under concurrent writes', async () => {
+    const WRITERS = 8;
+
+    // A reader running alongside the writers. If a transaction that drew a higher
+    // number could become visible before one that drew a lower number, some
+    // snapshot would show a hole below its own maximum.
+    let reading = true;
+    const snapshots: number[][] = [];
+    const reader = (async () => {
+      while (reading) {
+        const rows = await testPool<{ change_seq: string }[]>`
+          SELECT change_seq FROM messages ORDER BY change_seq
+        `;
+        snapshots.push(rows.map((row) => Number(row.change_seq)));
+      }
+    })();
+
+    await Promise.all(
+      Array.from({ length: WRITERS }, (_unused, index) => send(`concurrent ${index}`)),
+    );
+    reading = false;
+    await reader;
+
+    const finalRows = await testPool<{ change_seq: string }[]>`
+      SELECT change_seq FROM messages ORDER BY change_seq
+    `;
+    const finalSeqs = finalRows.map((row) => Number(row.change_seq));
+    expect(finalSeqs).toEqual(Array.from({ length: WRITERS }, (_unused, i) => i + 1));
+
+    expect(snapshots.length).toBeGreaterThan(0);
+    for (const snapshot of snapshots) {
+      // Every committed set must be a contiguous prefix: no reader can ever see
+      // a change number while a smaller one is still missing.
+      expect(snapshot).toEqual(Array.from({ length: snapshot.length }, (_unused, i) => i + 1));
+    }
+  });
+
+  it('releases the sequence number when a write rolls back', async () => {
+    const first = await send('kept');
+
+    await expect(
+      repo.create({
+        roomId,
+        senderId,
+        content: 'rolled back',
+        attachmentIds: ['00000000-0000-0000-0000-000000000000'],
+      }),
+    ).rejects.toThrow();
+
+    const next = await send('after rollback');
+    // Contiguous with the first message: the abandoned transaction left no hole.
+    expect(next.messageSeq).toBe(first.messageSeq! + 1);
+  });
+
+  it('returns the original message when a command identifier is replayed', async () => {
+    const commandId = '11111111-1111-4111-a111-111111111111';
+    const first = await send('sent once', commandId);
+    const replay = await send('sent once', commandId);
+
+    expect(replay.messageId).toBe(first.messageId);
+    expect(replay.messageSeq).toBe(first.messageSeq);
+
+    const countRows = await testPool<{ count: string }[]>`
+      SELECT COUNT(*)::int AS count FROM messages WHERE room_id = ${roomId}
+    `;
+    expect(Number(countRows[0].count)).toBe(1);
+  });
+
+  it('collapses concurrent replays of one command identifier to a single message', async () => {
+    const commandId = '22222222-2222-4222-a222-222222222222';
+    const results = await Promise.all([
+      send('racing', commandId),
+      send('racing', commandId),
+      send('racing', commandId),
+    ]);
+
+    const distinctIds = new Set(results.map((message) => message.messageId));
+    expect(distinctIds.size).toBe(1);
+
+    const countRows = await testPool<{ count: string }[]>`
+      SELECT COUNT(*)::int AS count FROM messages WHERE room_id = ${roomId}
+    `;
+    expect(Number(countRows[0].count)).toBe(1);
+  });
+
+  it('lets a different sender reuse the same command identifier', async () => {
+    const commandId = '33333333-3333-4333-a333-333333333333';
+    const otherRes = await testPool`
+      INSERT INTO users (name, email, password_hash) VALUES ('Bob', 'bob@test.com', 'hash') RETURNING user_id
+    `;
+    const otherSenderId = otherRes[0].user_id;
+
+    const mine = await send('mine', commandId);
+    const theirs = await repo.create({ roomId, senderId: otherSenderId, content: 'theirs', clientCommandId: commandId });
+
+    expect(theirs.messageId).not.toBe(mine.messageId);
+  });
+
+  it('records the Join Boundary as the room\'s newest message when a member joins', async () => {
+    const existing = await send('before the new member');
+
+    const joinerRes = await testPool`
+      INSERT INTO users (name, email, password_hash) VALUES ('Carol', 'carol@test.com', 'hash') RETURNING user_id
+    `;
+    const member = await memberRepo.add({ roomId, userId: joinerRes[0].user_id, role: 'member' });
+
+    expect(member.joinSeq).toBe(existing.messageSeq!);
+  });
+
+  it('moves the Read Position forward only', async () => {
+    const first = await send('first');
+    const second = await send('second');
+
+    const joinerRes = await testPool`
+      INSERT INTO users (name, email, password_hash) VALUES ('Dave', 'dave@test.com', 'hash') RETURNING user_id
+    `;
+    const userId = joinerRes[0].user_id;
+    await memberRepo.add({ roomId, userId, role: 'member' });
+
+    const advanced = await memberRepo.update(roomId, userId, { lastReadId: second.messageId });
+    expect(advanced.lastReadSeq).toBe(second.messageSeq!);
+
+    // A late or replayed request carrying an older message must not reopen it.
+    const rewound = await memberRepo.update(roomId, userId, { lastReadId: first.messageId });
+    expect(rewound.lastReadSeq).toBe(second.messageSeq!);
+    expect(rewound.lastReadId).toBe(second.messageId);
+  });
+});

--- a/backend/tests/integration/repositories/roomRepository.int.test.ts
+++ b/backend/tests/integration/repositories/roomRepository.int.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect, beforeEach, afterAll } from 'bun:test';
 import { RoomRepository } from '../../../src/models/roomRepository';
+import { RoomMemberRepository } from '../../../src/models/roomMemberRepository';
 import { testPool } from '../../helpers/testPool';
 import { resetDb } from '../../helpers/resetDb';
 
 describe('RoomRepository (pg)', () => {
   const repo = new RoomRepository(testPool);
+  const memberRepo = new RoomMemberRepository(testPool);
 
   beforeEach(async () => {
     await resetDb();
@@ -121,10 +123,8 @@ describe('RoomRepository (pg)', () => {
     expect(rooms).toHaveLength(1);
     expect(rooms[0].unreadCount).toBe(1);
 
-    // 2. Alice updates last_read_id to Bob's message (unread count should be 0)
-    await testPool`
-      UPDATE room_members SET last_read_id = ${msg1Id} WHERE room_id = ${room.roomId} AND user_id = ${aliceId}
-    `;
+    // 2. Alice advances her Read Position to Bob's message (unread count should be 0)
+    await memberRepo.update(room.roomId, aliceId, { lastReadId: msg1Id });
     rooms = await repo.findByMember(aliceId);
     expect(rooms[0].unreadCount).toBe(0);
 
@@ -135,9 +135,7 @@ describe('RoomRepository (pg)', () => {
     `;
     const msg2Id = msg2Res[0].message_id;
 
-    await testPool`
-      UPDATE room_members SET last_read_id = ${msg2Id} WHERE room_id = ${room.roomId} AND user_id = ${aliceId}
-    `;
+    await memberRepo.update(room.roomId, aliceId, { lastReadId: msg2Id });
     rooms = await repo.findByMember(aliceId);
     expect(rooms[0].unreadCount).toBe(0);
   });

--- a/backend/tests/integration/schema.test.ts
+++ b/backend/tests/integration/schema.test.ts
@@ -113,6 +113,62 @@ describe('Database Schema & Constraints', () => {
     });
   });
 
+  describe('messages table constraints', () => {
+    let userId: string;
+    let roomId: string;
+
+    beforeEach(async () => {
+      const userRes = await testPool`
+        INSERT INTO users (name, email, password_hash) VALUES ('Alice', 'alice@test.com', 'hash') RETURNING user_id
+      `;
+      userId = userRes[0].user_id;
+      const roomRes = await testPool`
+        INSERT INTO chat_rooms (type) VALUES ('group') RETURNING room_id
+      `;
+      roomId = roomRes[0].room_id;
+    });
+
+    it('should reject a second message reusing one sender\'s command identifier', async () => {
+      const commandId = '44444444-4444-4444-a444-444444444444';
+      const first = 'first attempt';
+      const second = 'retry';
+      await testPool`
+        INSERT INTO messages (room_id, sender_id, content, client_command_id)
+        VALUES (${roomId}, ${userId}, ${first}, ${commandId})
+      `;
+
+      let error: unknown = null;
+      try {
+        await testPool`
+          INSERT INTO messages (room_id, sender_id, content, client_command_id)
+          VALUES (${roomId}, ${userId}, ${second}, ${commandId})
+        `;
+      } catch (err) {
+        error = err;
+      }
+      expect(error).not.toBeNull();
+      expect(String(error)).toMatch(/unique constraint/i);
+    });
+
+    it('should allow many messages without a command identifier', async () => {
+      const content = 'no command id';
+      await testPool`
+        INSERT INTO messages (room_id, sender_id, content) VALUES (${roomId}, ${userId}, ${content})
+      `;
+      await testPool`
+        INSERT INTO messages (room_id, sender_id, content) VALUES (${roomId}, ${userId}, ${content})
+      `;
+
+      const rows = await testPool`
+        SELECT message_seq, change_seq, revision FROM messages WHERE room_id = ${roomId} ORDER BY message_seq
+      `;
+      expect(rows).toHaveLength(2);
+      expect(rows[0].revision).toBe(1);
+      expect(Number(rows[1].message_seq)).toBe(Number(rows[0].message_seq) + 1);
+      expect(Number(rows[0].change_seq)).toBe(Number(rows[0].message_seq));
+    });
+  });
+
   describe('Foreign Key Constraints and Cascades', () => {
     let userId: string;
     let roomId: string;

--- a/backend/tests/unit/services/messageService.test.ts
+++ b/backend/tests/unit/services/messageService.test.ts
@@ -33,6 +33,7 @@ describe('messageService', () => {
     role: 'member',
     isMuted: false,
     joinTime: new Date('2026-01-01T00:00:00.000Z'),
+    joinSeq: 42,
   };
 
   const message: Message = {
@@ -275,7 +276,7 @@ describe('messageService', () => {
     });
   });
 
-  it('listForRoom applies join time when room history is hidden', async () => {
+  it('listForRoom applies the Join Boundary when room history is hidden', async () => {
     const hiddenHistoryRoom = { ...room, viewHistory: false };
     roomRepo.findById.mockResolvedValue(hiddenHistoryRoom);
     roomMemberRepo.findMember.mockResolvedValue(member);
@@ -286,7 +287,7 @@ describe('messageService', () => {
     expect(messageRepo.findByRoom).toHaveBeenCalledWith('room-1', {
       beforeId: undefined,
       limit: 50,
-      after: member.joinTime,
+      afterSeq: member.joinSeq,
     });
   });
 

--- a/docs/ZH-TW/api-documentation.md
+++ b/docs/ZH-TW/api-documentation.md
@@ -328,6 +328,8 @@ NEXT_PUBLIC_API_URL=http://localhost:4005
   | `isMuted` | 布林值 | 是否已被靜音 |
   | `lastReadId` | UUID \| null | 最後已讀的訊息唯一識別碼 |
   | `joinTime` | 字串 | 加入時間（時間格式） |
+  | `joinSeq` | 數字 | Join Boundary：`messageSeq` 小於或等於此值的訊息皆早於此成員加入 |
+  | `lastReadSeq` | 數字 | Read Position，以 `messageSeq` 表達，且只能向前移動 |
 - **範例**:
   ```json
   {
@@ -352,6 +354,9 @@ NEXT_PUBLIC_API_URL=http://localhost:4005
   | `replyToId` | UUID \| null | 被引用的父訊息唯一識別碼 |
   | `isRecalled` | 布林值 | 訊息是否已被收回 |
   | `sentAt` | 字串 | 發送時間（時間格式） |
+  | `messageSeq` | 數字 | 建立順序，建立後固定不變，用於排序聊天室訊息串 |
+  | `changeSeq` | 數字 | 每次此訊息變更時前進，用於排序全域變更串流 |
+  | `revision` | 數字 | 建立時為 1，每次變更後遞增；僅在單一訊息內有意義，不可跨訊息比較 |
   | `attachments` | 陣列 | 附帶的 `Attachment` 陣列 |
   | `sender` | 物件 \| null | 發送者的 `PublicUser` 資料，若帳號已刪除則為 null |
   | `mentions` | 陣列 | 被提及的使用者 ID 陣列 |

--- a/docs/ZH-TW/database-design.md
+++ b/docs/ZH-TW/database-design.md
@@ -49,6 +49,18 @@
 | `reply_to_id` | UUID | 被引用的訊息 ID | FK(`messages`), 刪除時設為 SET NULL |
 | `is_recalled` | BOOLEAN | 訊息是否已被收回 | NOT NULL, 預設值: FALSE |
 | `sent_at` | TIMESTAMPTZ | 發送時間 | NOT NULL, 預設值: CURRENT_TIMESTAMP |
+| `message_seq` | BIGINT | 建立順序，建立時指派後永不改變，用於排序聊天室訊息串 | NOT NULL, UNIQUE, 由 trigger 指派 |
+| `change_seq` | BIGINT | 每次變更都前進，用於排序全域變更串流 | NOT NULL, UNIQUE, 由 trigger 指派 |
+| `revision` | INTEGER | 建立時為 1，每次成功變更後遞增；僅在單一訊息內有意義，不可跨訊息比較 | NOT NULL, 預設值: 1 |
+| `client_command_id` | UUID | 發送端提供的命令識別碼，用於讓重送的發送操作具冪等性 | UNIQUE (`sender_id`, `client_command_id`)，僅在非 NULL 時生效 |
+
+#### `message_sequence_counter` (序號計數器)
+`message_seq` 與 `change_seq` 背後的單列計數器。序號由 `next_message_seq()` **在寫入交易內** 發放，因此該列的鎖會持有至 COMMIT，發號順序即等於提交順序。此處不可改用 PostgreSQL sequence：`nextval()` 不受交易保護，先取號的交易可能在後取號的交易之後才提交，而游標已越過較大號碼的讀者將永久且靜默地跳過較小的號碼。詳見 [ADR-0003](../adr/0003-change-sequence-from-transactional-counter.md)。
+
+| 欄位名稱 | 類型 | 說明 | 條件約束 |
+| :--- | :--- | :--- | :--- |
+| `counter_id` | BOOLEAN | 將此表固定為單一列 | PK, 預設值: TRUE, CHECK (`counter_id`) |
+| `current_seq` | BIGINT | 目前已發放的最大號碼 | NOT NULL, 預設值: 0 |
 
 #### `attachments` (附件)
 | 欄位名稱 | 類型 | 說明 | 條件約束 |
@@ -73,8 +85,10 @@
 | `role` | VARCHAR(10) | 成員角色：'owner', 'admin', 'member', 'pending' | NOT NULL, 預設值: 'member', CHECK (role IN ('owner', 'admin', 'member', 'pending')) |
 | `nickname` | VARCHAR(255) | 成員在此聊天室的自訂暱稱 | |
 | `is_muted` | BOOLEAN | 成員在此聊天室是否被禁言 | NOT NULL, 預設值: FALSE |
-| `last_read_id` | UUID | 最後已讀的訊息 ID | FK(`messages`), 刪除時設為 SET NULL |
+| `last_read_id` | UUID | 最後已讀的訊息 ID，為 `last_read_seq` 的反正規化對應欄位 | FK(`messages`), 刪除時設為 SET NULL |
 | `join_time` | TIMESTAMPTZ | 加入聊天室時間 | NOT NULL, 預設值: CURRENT_TIMESTAMP |
+| `join_seq` | BIGINT | Join Boundary：`message_seq` 小於或等於此值的訊息皆早於此成員加入 | NOT NULL, 預設值: 0 |
+| `last_read_seq` | BIGINT | Read Position，以 `message_seq` 表達，且只能向前移動 | NOT NULL, 預設值: 0 |
 
 #### `friendships` (好友關係)
 | 欄位名稱 | 類型 | 說明 | 條件約束 |

--- a/docs/adr/0003-change-sequence-from-transactional-counter.md
+++ b/docs/adr/0003-change-sequence-from-transactional-counter.md
@@ -1,0 +1,91 @@
+# ADR-0003: Allocate change sequences from a transactional counter row
+
+- Status: Accepted
+- Date: 2026-08-09
+- Related: #282 (resumable realtime layer), #530 (this data model), #533 (sync cursor)
+
+## Context
+
+A client that has been disconnected must be able to ask "give me everything that
+changed since X" and be certain the answer is complete. That requires a total order
+over message *changes* — creation, edit and recall alike — that a client can carry
+as a single cursor.
+
+The existing schema cannot express this. `sent_at` does not change when a message is
+edited or recalled, so a timestamp cursor is blind to exactly the changes recovery
+exists to deliver. Message identifiers are UUIDs and carry no order.
+
+So the model needs numbers. The question this ADR settles is where those numbers
+come from.
+
+## Decision
+
+Message Sequence and Change Sequence are both drawn from a single counter row in
+`message_sequence_counter`, allocated by `next_message_seq()` **inside the same
+transaction that performs the write**.
+
+Both numbers come from the *same* counter, and a newly created message takes one
+allocation for both (`change_seq = message_seq`). A single cursor over `change_seq`
+therefore covers creations and modifications as one stream, which is what #533 needs
+to fetch changes across every accessible room in one request.
+
+## Rationale
+
+`INSERT ... ON CONFLICT DO UPDATE SET current_seq = current_seq + 1 RETURNING` holds
+the counter row's lock until COMMIT. Two consequences follow, and they are the whole
+point:
+
+- **Allocation order equals commit order.** A transaction cannot draw a number and
+  then commit after a transaction that drew a higher one, because the second
+  transaction cannot draw at all until the first has committed or rolled back.
+- **A rollback releases the number.** The increment is undone with the transaction,
+  so an abandoned write leaves no hole in the stream.
+
+Together these give the property a resumable client depends on: the set of committed
+change numbers is always a contiguous prefix. A reader can treat "I have seen
+everything up to N" as true without any risk of a straggler appearing below N later.
+
+READ COMMITTED is sufficient. No SERIALIZABLE isolation and no retry loop is needed.
+
+## Rejected alternatives
+
+**A PostgreSQL sequence (`nextval()`).** This is the obvious choice and it is wrong
+here. `nextval()` deliberately operates outside transaction semantics so that
+concurrent inserters never block each other. That means a transaction which draws
+sequence value 5 may commit *after* one which drew 6. A client whose cursor has
+already advanced past 6 will never see 5 — and nothing anywhere reports an error.
+The data loss is permanent and completely silent, which makes it far worse than a
+contention problem. Sequences also do not roll back, so every failed write leaves a
+permanent hole, and a reader cannot distinguish that hole from a change still in
+flight.
+
+**An advisory lock plus `MAX(change_seq) + 1`.** Correct, but it pays for an index
+scan on every write to compute the next value, and it reimplements what a counter row
+already does.
+
+**A separate append-only `message_changes` log table.** The more conventional shape,
+and a reasonable future direction. Rejected for now because it adds a table and a join
+without removing any of the work in #530, and because #533 converges on message id
+plus revision — clients re-fetch canonical state rather than replaying a change log,
+so the log's extra expressiveness would go unused.
+
+**Per-room counters.** Would reduce contention, but breaks the single-cursor
+requirement: a client would have to track and reconcile one cursor per room, which is
+precisely the "guess the gap room by room" behaviour #533 exists to remove. Multiple
+counter rows would also introduce a lock-ordering problem that a single counter does
+not have.
+
+## Consequences
+
+- **Every message write in the system serialises on one row.** This is a deliberate
+  ceiling. It is comfortable at this project's scale, and the critical section is one
+  row update, but it is a global one — so the transaction holding it must stay short.
+  `messageRepository.create` batches its mention inserts into a single statement for
+  this reason.
+- **Nothing may treat `current_seq` as a visibility watermark.** The counter's value
+  includes numbers drawn by transactions that have not yet committed. The head of the
+  stream must be derived from `MAX(change_seq)` over committed rows.
+- **Allocation must happen in the writing transaction.** Drawing a number in one
+  transaction and inserting in another discards the guarantee entirely.
+- Moving away from a single global counter after data exists would require renumbering
+  every message, so this decision is expensive to reverse.

--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -328,6 +328,8 @@ All errors return the following JSON structure:
   | `isMuted` | Boolean | Whether muted |
   | `lastReadId` | UUID \| null | Last read message ID |
   | `joinTime` | String | Join timestamp |
+  | `joinSeq` | Number | Join Boundary: messages at or below this `messageSeq` predate the membership |
+  | `lastReadSeq` | Number | Read Position, as a `messageSeq`. Only ever moves forward |
 - **Example**:
   ```json
   {
@@ -352,6 +354,9 @@ All errors return the following JSON structure:
   | `replyToId` | UUID \| null | ID of the replied parent message |
   | `isRecalled` | Boolean | Whether recalled |
   | `sentAt` | String | Sent timestamp |
+  | `messageSeq` | Number | Creation order, fixed at creation. Orders a room's thread |
+  | `changeSeq` | Number | Advances on every change to this message. Orders the global change stream |
+  | `revision` | Number | 1 at creation, incremented on each change. Per-message only — not comparable across messages |
   | `attachments` | Array | Array of `Attachment` objects |
   | `sender` | Object \| null | Sender `PublicUser` data, null if deleted |
   | `mentions` | Array | Array of mentioned user IDs |

--- a/docs/database-design.md
+++ b/docs/database-design.md
@@ -49,6 +49,18 @@ This document defines the relational schema for the real-time group chat applica
 | `reply_to_id` | UUID | Replied message ID | FK(`messages`), SET NULL |
 | `is_recalled` | BOOLEAN | If message has been recalled | NOT NULL, DEFAULT FALSE |
 | `sent_at` | TIMESTAMPTZ | Sent timestamp | NOT NULL, DEFAULT CURRENT_TIMESTAMP |
+| `message_seq` | BIGINT | Creation order, assigned once and never changed. Orders a room's thread | NOT NULL, UNIQUE, assigned by trigger |
+| `change_seq` | BIGINT | Advances on every change. Orders the global change stream | NOT NULL, UNIQUE, assigned by trigger |
+| `revision` | INTEGER | 1 at creation, incremented on each change. Per-message only — not comparable across messages | NOT NULL, DEFAULT 1 |
+| `client_command_id` | UUID | Sender-supplied command identifier used to make a retried send idempotent | UNIQUE (`sender_id`, `client_command_id`) WHERE NOT NULL |
+
+#### `message_sequence_counter`
+Single-row allocator behind `message_seq` and `change_seq`. Numbers are drawn by `next_message_seq()` **inside the writing transaction**, so the row lock is held until COMMIT and allocation order equals commit order. A PostgreSQL sequence cannot be used here: `nextval()` is non-transactional, so a transaction drawing a lower number may commit after one drawing a higher number, and a reader whose cursor has passed the higher number would skip the lower one permanently and silently. See [ADR-0003](adr/0003-change-sequence-from-transactional-counter.md).
+
+| Column Name | Type | Description | Constraints |
+| :--- | :--- | :--- | :--- |
+| `counter_id` | BOOLEAN | Pins the table to a single row | PK, DEFAULT TRUE, CHECK (`counter_id`) |
+| `current_seq` | BIGINT | Highest number allocated so far | NOT NULL, DEFAULT 0 |
 
 #### `attachments`
 | Column Name | Type | Description | Constraints |
@@ -73,8 +85,10 @@ This document defines the relational schema for the real-time group chat applica
 | `role` | VARCHAR(10) | Member role (`owner`, `admin`, `member`, `pending`) | NOT NULL, DEFAULT 'member', CHECK (role IN ('owner', 'admin', 'member', 'pending')) |
 | `nickname` | VARCHAR(255) | Nickname in this room | |
 | `is_muted` | BOOLEAN | Muted status | NOT NULL, DEFAULT FALSE |
-| `last_read_id` | UUID | ID of last read message | FK(`messages`), SET NULL |
+| `last_read_id` | UUID | ID of last read message; denormalised companion to `last_read_seq` | FK(`messages`), SET NULL |
 | `join_time` | TIMESTAMPTZ | Join timestamp | NOT NULL, DEFAULT CURRENT_TIMESTAMP |
+| `join_seq` | BIGINT | Join Boundary: messages at or below this `message_seq` predate the membership | NOT NULL, DEFAULT 0 |
+| `last_read_seq` | BIGINT | Read Position, expressed as a `message_seq`. Only ever moves forward | NOT NULL, DEFAULT 0 |
 
 #### `friendships`
 | Column Name | Type | Description | Constraints |

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -126,6 +126,12 @@ export interface Message {
   isRecalled: boolean;
   sentAt: Date;
   attachments?: Attachment[];
+  /** Creation order, assigned once and never changed. Orders a room's thread. */
+  messageSeq?: number;
+  /** Advances on every change to this message. Orders the global change stream. */
+  changeSeq?: number;
+  /** 1 at creation, incremented on each successful change. Per-message only — not comparable across messages. */
+  revision?: number;
 }
 
 /** Message enriched with the sender's public profile (via JOIN). */
@@ -148,6 +154,10 @@ export interface RoomMember {
   isMuted: boolean;
   lastReadId?: string;
   joinTime: Date;
+  /** Join Boundary: messages at or below this sequence predate the membership. */
+  joinSeq?: number;
+  /** Read Position. Only ever moves forward. */
+  lastReadSeq?: number;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## 變更描述 (Description)

為 #282 的可恢復即時通訊層建立訊息變更所需的資料模型。這是 #282 底下唯一同時卡住訊息修訂、增量同步、發送冪等與已讀位置單調四條需求的前置。

**根因**：現行 schema 使 delta recovery 在原理上不可能實作。`sent_at` 在編輯與收回時都不改變，因此任何以時間為基礎的游標都看不見這兩種變更；訊息識別碼是 UUID，本身不帶順序；已讀位置以不可比較先後的 `last_read_id` 保存，因此無法保證單調。

**本次變更**：

- `messages` 新增 `message_seq`（建立時指派、此後不變）、`change_seq`（每次變更前進）、`revision`（建立為 1，每次變更遞增）與 `client_command_id`。
- 序號由 `message_sequence_counter` 的計數器列在**寫入交易內**發放，並以 trigger 指派。刻意不使用 PostgreSQL sequence：`nextval()` 不受交易保護，先取號的交易可能在後取號的交易之後才提交，游標已越過較大號碼的讀者會永久且靜默地跳過較小的號碼。持有計數器列的鎖直到 COMMIT，使發號順序等於提交順序，且 rollback 會釋放號碼，因此已提交的號碼集合恆為連續前綴。
- 建立訊息時 `change_seq = message_seq`（同一次發號），單一游標即可同時涵蓋建立與變更，供 #533 使用。
- 以 partial unique index `(sender_id, client_command_id)` 保證同一使用者的同一命令識別碼只產生一筆訊息；重送回傳首次成功的結果而非重新執行副作用。
- `room_members` 新增以序號表達的 `join_seq`（Join Boundary）與 `last_read_seq`（Read Position）。Read Position 只能前進，較晚抵達或重送的請求無法讓未讀狀態倒退；`last_read_id` 保留為反正規化對應欄位並同步前進，因此前端不需在本 PR 變動。
- 訊息分頁、房間最新訊息與未讀計數改以序號比較，`roomRepository` 中兩處為換算已讀時間而存在的 self-join 已移除；`room_last_message_view` 改以 `DISTINCT ON` 搭配新索引。
- `markRecalled` 加上 `is_recalled = false` 條件，重複收回不再產生多餘的 revision 與變更事件。
- 建立訊息時的 mention 由逐筆 INSERT 改為單一語句，縮短全域序號分配的臨界區。

**與 issue 敘述不同之處**：issue 寫「依 `CONTRIBUTING.md` §4 直接修改 baseline，不新增 migration 檔」。實際讀 `CONTRIBUTING.md` §4 的內容相反，它要求所有 schema 變更都必須以 `node-pg-migrate` 寫在 `backend/migrations/` 下。此外 `node-pg-migrate` 以 `pgmigrations` 記錄已執行的 migration，修改已套用的 baseline 對任何跑過它的資料庫都是 no-op，而 CI 每次都以全新的 Postgres service container 執行，因此不會察覺這個分歧；baseline 也無法表達既有資料的 backfill。故本 PR 改以新增 migration 實作，並保留既有 baseline 不動。

## 相關的 Issue (Related Issue)

Closes #530

## 變更類型 (Type of Change)

- [x] `feat`: 新增功能 (Feature)
- [ ] `fix`: 修復 Bug
- [ ] `refactor`: 重構代碼
- [x] `docs`: 修改文件
- [x] `test`: 新增或修正測試案例
- [ ] `chore`: 建置流程或輔助工具變更
- [ ] `perf`: 效能優化
- [ ] `ci`: CI 設定變更

## 驗證與測試計畫 (Verification & Test Plan)

本次執行環境沒有可用的 Docker daemon，因此改以本機 PostgreSQL 16 叢集（`initdb`，監聽 5436，與 `docker-compose.test.yml` 的 `db-test` 對應埠相同）執行需要資料庫的測試。**Reviewer 仍應在專案標準的 Docker（PostgreSQL 18）測試環境重跑一次**；本次變更未使用任何 PG17+ 專屬語法。

### 本地測試 (Local Tests)
- [x] 後端型別檢查 (`pnpm exec tsc --noEmit`)：通過
- [x] 前端型別檢查 (`pnpm run typecheck`)：通過
- [x] 前端 Linter 檢查 (`pnpm run lint`)：通過
- [x] 後端 Linter 檢查 (`pnpm exec eslint src`)：通過
- [x] 單元測試 (`pnpm run test:unit`)：450 pass / 0 fail
- [x] 整合測試 (`pnpm run test:integration`)：45 pass / 0 fail（原為 33，本 PR 新增 12）
- [x] 前端測試 (`pnpm run test`)：30 pass / 0 fail
- [x] E2E 測試 (`pnpm run test:e2e`)：72 pass / 1 fail

E2E 唯一失敗項為 `API routes E2E > only echoes credentialed CORS for configured origins`。已在未修改的 `origin/main` 上以相同指令重跑確認該失敗為既有問題，與本 PR 無關（main 上同樣是 72 pass / 1 fail）。

### 新增測試涵蓋
`backend/tests/integration/repositories/messageSequences.int.test.ts`（10 項）與 `backend/tests/integration/schema.test.ts`（2 項）：
- 並行寫入下的序號連續性：8 個並行寫入者搭配同時輪詢的讀者，斷言讀者看到的每一個快照都是連續前綴，且最終集合恰為 1..N。這是對「先取號的交易必然先可見」的直接驗證。
- 交易 rollback 後號碼被釋放，不留下缺口。
- `message_seq` 於編輯與收回後不變，`change_seq` 前進，`revision` 遞增。
- 重複收回不產生新的 revision 與 change_seq。
- 命令識別碼重送回傳原訊息且只建立一筆；三個並行重送收斂為單一訊息；不同發送者可重用同一識別碼。
- 加入房間時記錄 Join Boundary；Read Position 只前進，倒退請求不生效。
- 資料庫層級的唯一約束測試（不經 repository）。

### 遷移驗證
- `node-pg-migrate up` → `down` → `up` 往返成功，down 後欄位確實移除。
- 由全新資料庫從零套用全部 migration 後，三個測試層級皆如上述通過。
- `bun src/models/seed.ts` 在新 schema 下執行成功，序號由 trigger 正確指派（2 則訊息 → seq 1、2，counter = 2，成員 `join_seq` = 0，因 seed 於訊息之前加入成員）。

### 手動測試 (Manual Verification)
未執行 UI 手動測試：本 PR 不含前端行為變更，對外 API 僅新增欄位（`messageSeq`、`changeSeq`、`revision`、`joinSeq`、`lastReadSeq`），既有欄位與語意不變。

## 資料庫變更 (Database Changes)

* 此變更是否包含資料庫 Schema 修改？ **是**
* 若為是，請寫明 Migration 檔案名稱：`backend/migrations/2026080900000_message_change_sequences.sql`
* 是否已確認遷移與 [docs/database-design.md](../docs/database-design.md) 設計一致？ **是**（英文與繁體中文版本皆已更新，並新增 `message_sequence_counter` 說明）

## API 與 WebSocket 協定一致性 (API & WebSocket Contract Check)

* 此變更是否涉及 API 路由或 WebSocket 事件的資料結構變更？ **是**（僅新增欄位，無破壞性變更）
* 是否已確認與 [docs/api-documentation.md](../docs/api-documentation.md) 規範完全一致？ **是**（英文與繁體中文版本的 `MessageWithSender` 與 `RoomMember` 皆已更新）

## Advisor 重點意見

實作前以 architect sub-agent（opus）審閱根因分析與方案，主要採納的意見：

1. **序號的粒度是關鍵決策**：`message_seq` 與 `change_seq` 必須取自**同一個全域計數器**，否則 #533 的單一游標無法同時涵蓋建立與編輯。代價是所有訊息寫入序列化於單一列——在本專案規模下可接受，且單一鎖反而完全避免了 per-room 計數器會帶來的死鎖順序問題。此取捨已記入 ADR-0003。
2. **臨界區長度**：原 `create()` 逐筆插入 mention，全部落在全域序號分配窗口內，已改為單一語句。
3. **冪等的缺口風險**：若以 `ON CONFLICT DO NOTHING` 實作，即使未插入也會消耗一個號碼而在串流留下缺口。故改為先查既有命令識別碼再插入，並以唯一索引攔截殘餘競態後重讀。
4. **`resetDb` 陷阱**：計數器表若不在 TRUNCATE 清單中，序號會跨測試累積，使單獨執行會通過、整套執行卻失敗的斷言出現。已加入清單，且發號函式自帶 upsert 以在 TRUNCATE 後自我重建。
5. **重複收回會推出幽靈 revision**：原 `markRecalled` 無 `WHERE is_recalled = false` 保護，已補上。
6. **backfill 順序**：`message_seq` 必須依既有的 `(sent_at, message_id)` keyset 順序指派而非實體順序，否則既有對話會被打亂。
7. **View 限制**：`CREATE OR REPLACE VIEW` 無法變更欄位清單，`room_last_message_view` 需先 DROP；`message_with_sender_view` 的新欄位則附加於末端。
8. Advisor 另建議將本 issue 拆成「寫入路徑」與「讀取路徑」兩個 PR。因每次執行僅允許一個 PR，若只交付寫入路徑會使 #530 的其餘工作無人追蹤，故合併為一個 PR；讓 `last_read_id` 保留為反正規化欄位是關鍵，它使約 20 處前端 `lastReadId` 使用點不必在本 PR 變動。

## 後續建議（不在本 PR 範圍）

- 對外暴露 `messageSeq` / `changeSeq` / `revision` 給前端並改以序號比較、移除 `last_read_id`，建議併入 #533 一併處理。
- Advisor 指出：命令識別碼重送的正確回應應為「原訊息 + 200」，而非 #282 所述的 `409` NACK——對 at-least-once 的 client 而言，`409` 會讓一次成功被當成失敗。本 PR 的 repository 層已回傳原訊息，建議 #531 定義 REST contract 時一併確認。

---
Generated with Claude Code (https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LkfgW39M8BvkuFmHWnMhai)_