### PR TITLE
refactor: optimize message operations with atomic CTEs and fix revision conflicts

### DIFF
--- a/backend/migrations/2026081000003_backfill_legacy_realtime_sequences.sql
+++ b/backend/migrations/2026081000003_backfill_legacy_realtime_sequences.sql
@@ -1,3 +1,4 @@
+-- Up Migration
 -- Existing rows created before realtime durability have zero ordering fields.
 -- Fill room-local order only for rooms that are entirely legacy. Mixed rooms
 -- already contain durable immutable sequences; rewriting those values would

--- a/backend/migrations/2026081000004_reconcile_legacy_member_cursors.sql
+++ b/backend/migrations/2026081000004_reconcile_legacy_member_cursors.sql
@@ -1,3 +1,4 @@
+-- Up Migration
 -- 2026081000003 is additive and may already have run in a deployment before
 -- this cursor reconciliation was shipped. Repeat the idempotent member
 -- updates so both upgrade paths preserve the old visibility/read semantics.

--- a/backend/migrations/2026081000005_rebuild_legacy_realtime_order.sql
+++ b/backend/migrations/2026081000005_rebuild_legacy_realtime_order.sql
@@ -1,3 +1,4 @@
+-- Up Migration
 -- 1000003 originally rebuilt every room. Repair only still-legacy rooms in
 -- deployments that have not yet issued durable sequences there; never rewrite
 -- an already durable sequence held by a client cursor.

--- a/backend/migrations/2026081000006_enforce_blocked_private_room_state.sql
+++ b/backend/migrations/2026081000006_enforce_blocked_private_room_state.sql
@@ -1,3 +1,4 @@
+-- Up Migration
 -- Keep the durable room state safe even when block/create-private requests
 -- race across backend processes. The trigger runs in the same transaction as
 -- the block or membership insert, so a concurrent reopen can only commit

--- a/backend/src/bootstrap/realtime.ts
+++ b/backend/src/bootstrap/realtime.ts
@@ -28,15 +28,19 @@ export const createRealtime = ({
   repositories,
   publisher,
 }: CreateRealtimeDeps): RealtimeRuntime => {
+  // CORS must be configured on the engine, not on the Socket.IO server: once
+  // `io.bind(engine)` is used, Socket.IO never sees the raw handshake request,
+  // so its own `cors` option is dead configuration. The polling handshake is
+  // the first transport a browser tries, and it is a cross-origin request from
+  // the frontend origin, so without these headers no session is ever created.
   const engine = new Engine({
     path: '/socket.io/',
     pingInterval: 25_000,
     pingTimeout: 20_000,
     maxHttpBufferSize: 1_000_000,
-  });
-  const io = new Server<ClientToServerEvents, ServerToClientEvents>({
     cors: { origin: config.corsOrigins, credentials: true },
-  }) as ChatServer;
+  });
+  const io = new Server<ClientToServerEvents, ServerToClientEvents>() as ChatServer;
 
   io.bind(engine);
   publisher.bind(io);
@@ -74,14 +78,23 @@ export const createBunRuntimeServer = ({
   idleTimeout = 60,
 }: CreateBunRuntimeServerDeps): BunRuntimeServer => {
   let bunServer: Bun.Server<unknown> | undefined;
+  // The socket keeps its port during the drain window. Tracking that window
+  // explicitly is what lets `listening` report "not accepting new work" while
+  // `address()` still reports the port that is genuinely still bound.
+  let draining = false;
   const engineHandler = engine.handler();
 
   return {
     get listening() {
-      return bunServer !== undefined;
+      return bunServer !== undefined && !draining;
     },
 
     listen(port, hostname = '0.0.0.0', callback) {
+      if (draining) {
+        // Binding again before the previous socket has released the port would
+        // fail with EADDRINUSE at a point where the caller cannot recover.
+        throw new Error('Cannot listen while the server is shutting down');
+      }
       if (bunServer) {
         callback?.();
         return;
@@ -105,17 +118,21 @@ export const createBunRuntimeServer = ({
 
     close(callback) {
       const current = bunServer;
-      bunServer = undefined;
       if (!current) {
         callback?.();
         return;
       }
       // Drain active HTTP work first. A hard stop remains as a bounded
       // fallback so a stuck websocket cannot hold deployment forever.
+      // The reference is kept until the drain resolves so the facade never
+      // claims the port is free while it is still bound.
+      draining = true;
       let finished = false;
       const finish = () => {
         if (finished) return;
         finished = true;
+        if (bunServer === current) bunServer = undefined;
+        draining = false;
         callback?.();
       };
       void current.stop().finally(finish);

--- a/backend/src/bootstrap/services.ts
+++ b/backend/src/bootstrap/services.ts
@@ -125,6 +125,7 @@ export const createServices = ({ repositories, publisher }: CreateServicesDeps):
     },
     {
       markPrivateReadOnly: roomService.markPrivateReadOnly,
+      markPrivateReadOnlyIfBlocked: roomService.markPrivateReadOnlyIfBlocked,
       createPrivate: (userA: string, userB: string, bypassFriendCheck?: boolean) =>
         roomService.createPrivate(userA, userB, bypassFriendCheck),
       reopenPrivateRoom: roomService.reopenPrivateRoom,

--- a/backend/src/bootstrap/services.ts
+++ b/backend/src/bootstrap/services.ts
@@ -38,6 +38,11 @@ export const createServices = ({ repositories, publisher }: CreateServicesDeps):
     repositories.emergencyContacts,
     repositories.refreshTokens,
     { signToken, generateRefreshToken, hashToken },
+    // Durable-first: this callback deliberately has no socket-only fallback,
+    // because emitting `emergency_alert` for a message that failed to persist
+    // is the ghost notification this flow exists to remove. A throw here is
+    // isolated per contact by `notifyContacts`, which keeps delivering to the
+    // remaining contacts and marks the incident for retry.
     async (contactId, payload) => {
       let room = await repositories.rooms.findPrivateRoomByMembers(payload.userId, contactId);
       if (!room || room.isReadonly) {

--- a/backend/src/bootstrap/services.ts
+++ b/backend/src/bootstrap/services.ts
@@ -125,7 +125,7 @@ export const createServices = ({ repositories, publisher }: CreateServicesDeps):
     },
     {
       markPrivateReadOnly: roomService.markPrivateReadOnly,
-      markPrivateReadOnlyIfBlocked: roomService.markPrivateReadOnlyIfBlocked,
+      findPrivateRoomIdIfBlocked: roomService.findPrivateRoomIdIfBlocked,
       createPrivate: (userA: string, userB: string, bypassFriendCheck?: boolean) =>
         roomService.createPrivate(userA, userB, bypassFriendCheck),
       reopenPrivateRoom: roomService.reopenPrivateRoom,

--- a/backend/src/models/IRoomRepository.ts
+++ b/backend/src/models/IRoomRepository.ts
@@ -9,6 +9,7 @@ export interface IRoomRepository {
   findByInviteCode(code: string): Promise<Room | null>;
   findPrivateRoomByMembers(userA: string, userB: string): Promise<Room | null>;
   reopenPrivateRoomIfUnblocked?(roomId: string, userA: string, userB: string): Promise<Room | null>;
+  markPrivateReadOnlyIfBlocked?(roomId: string, userA: string, userB: string): Promise<Room | null>;
   findByMember(userId: string): Promise<RoomSummary[]>;
   create(data: CreateRoomData): Promise<Room>;
   update(roomId: string, data: UpdateRoomData): Promise<Room>;

--- a/backend/src/models/IRoomRepository.ts
+++ b/backend/src/models/IRoomRepository.ts
@@ -9,7 +9,7 @@ export interface IRoomRepository {
   findByInviteCode(code: string): Promise<Room | null>;
   findPrivateRoomByMembers(userA: string, userB: string): Promise<Room | null>;
   reopenPrivateRoomIfUnblocked?(roomId: string, userA: string, userB: string): Promise<Room | null>;
-  markPrivateReadOnlyIfBlocked?(roomId: string, userA: string, userB: string): Promise<Room | null>;
+  findPrivateRoomIdIfBlocked?(userA: string, userB: string): Promise<string | null>;
   findByMember(userId: string): Promise<RoomSummary[]>;
   create(data: CreateRoomData): Promise<Room>;
   update(roomId: string, data: UpdateRoomData): Promise<Room>;

--- a/backend/src/models/messageRepository.ts
+++ b/backend/src/models/messageRepository.ts
@@ -49,6 +49,9 @@ export interface AttachmentRow {
   uploaded_at: Date;
 }
 
+/** The attachment columns a Message Change snapshot stores inline. */
+type AttachmentSnapshotRow = Omit<AttachmentRow, 'message_id'>;
+
 interface MessageChangeRelationRow {
   attachment_id?: string;
   message_id?: string | null;
@@ -415,23 +418,107 @@ export class MessageRepository implements IMessageRepository {
         }
       }
 
-      const rows = await tx<{ message_id: string; change_sequence: number | string }[]>`
-        INSERT INTO messages (
-          room_id, sender_id, content, reply_to_id, message_sequence, change_sequence, revision, command_id
-        )
-        SELECT
-          ${data.roomId}, ${data.senderId}, ${data.content}, ${data.replyToId ?? null},
-          counters.message_sequence + 1,
-          counters.change_sequence + 1,
-          1,
-          ${data.commandId ?? null}
-        FROM (
-          SELECT message_sequence, change_sequence
-          FROM realtime_counters
-          WHERE counter_id = true
+      // Everything that can be validated without the global counter is done
+      // before it is touched. Claiming the attachments here takes only the
+      // per-attachment row locks and leaves the rows pinned for the write
+      // below, so the counter's critical section does not have to pay for it.
+      const uniqueAttachmentIds = data.attachmentIds ? [...new Set(data.attachmentIds)] : [];
+      let attachmentSnapshot: AttachmentSnapshotRow[] = [];
+      if (uniqueAttachmentIds.length > 0) {
+        const pgAttIds = `{${uniqueAttachmentIds.join(',')}}`;
+        attachmentSnapshot = await tx<AttachmentSnapshotRow[]>`
+          SELECT attachment_id, uploaded_by, file_type, original_name, uploaded_at
+          FROM attachments
+          WHERE attachment_id = ANY(${pgAttIds}::uuid[])
+            AND message_id IS NULL
+            AND uploaded_by = ${data.senderId}
+          ORDER BY uploaded_at, attachment_id
           FOR UPDATE
-        ) counters
-        ON CONFLICT (sender_id, command_id) WHERE command_id IS NOT NULL DO NOTHING
+        `;
+        if (attachmentSnapshot.length !== uniqueAttachmentIds.length) {
+          throw new ValidationError('Attachments must exist and must not already belong to a message');
+        }
+      }
+      const uniqueMentions = data.mentions ? [...new Set(data.mentions)].sort() : [];
+
+      // One statement holds the counter row lock, and it is the last write of
+      // the transaction. Postgres keeps a row lock until commit, so the only
+      // way to stop every message, membership and role write in the process
+      // from serializing behind this row is to keep the window between taking
+      // the lock and committing as small as a single round trip. The change
+      // snapshot is therefore built from values already known here rather than
+      // by re-reading the rows the sibling CTEs have just written — a CTE
+      // cannot see its siblings' output.
+      const pgMentionIds = `{${uniqueMentions.join(',')}}`;
+      const pgClaimedAttachmentIds = `{${attachmentSnapshot.map((row) => row.attachment_id).join(',')}}`;
+      const attachmentsJson = JSON.stringify(attachmentSnapshot.map((row) => ({
+        attachment_id: row.attachment_id,
+        uploaded_by: row.uploaded_by,
+        file_type: row.file_type,
+        original_name: row.original_name,
+        uploaded_at: row.uploaded_at,
+      })));
+      const rows = await tx<{ message_id: string; change_sequence: number | string }[]>`
+        WITH seq AS (
+          UPDATE realtime_counters
+          SET message_sequence = message_sequence + 1,
+              change_sequence = change_sequence + 1
+          WHERE counter_id = true
+            AND NOT EXISTS (
+              SELECT 1 FROM messages
+              WHERE sender_id = ${data.senderId} AND command_id = ${data.commandId ?? null}
+            )
+          RETURNING message_sequence, change_sequence
+        ),
+        created AS (
+          INSERT INTO messages (
+            room_id, sender_id, content, reply_to_id, message_sequence, change_sequence, revision, command_id
+          )
+          SELECT
+            ${data.roomId}, ${data.senderId}, ${data.content}, ${data.replyToId ?? null},
+            seq.message_sequence,
+            seq.change_sequence,
+            1,
+            ${data.commandId ?? null}
+          FROM seq
+          ON CONFLICT (sender_id, command_id) WHERE command_id IS NOT NULL DO NOTHING
+          RETURNING message_id, room_id, sender_id, content, reply_to_id,
+                    is_recalled, sent_at, message_sequence, change_sequence, revision
+        ),
+        mentioned AS (
+          INSERT INTO message_mentions (message_id, user_id)
+          SELECT created.message_id, mention
+          FROM created
+          CROSS JOIN unnest(${pgMentionIds}::uuid[]) AS mention
+          RETURNING user_id
+        ),
+        claimed AS (
+          UPDATE attachments a
+          SET message_id = created.message_id
+          FROM created
+          WHERE a.attachment_id = ANY(${pgClaimedAttachmentIds}::uuid[])
+            AND a.message_id IS NULL
+          RETURNING a.attachment_id
+        )
+        INSERT INTO message_changes (
+          change_sequence, message_id, room_id, message_sequence, revision,
+          change_type, actor_id, command_id, sender_id, content, is_recalled,
+          reply_to_id, sent_at, mentions, attachments
+        )
+        SELECT created.change_sequence, created.message_id, created.room_id,
+          created.message_sequence, created.revision, 'created', created.sender_id,
+          ${data.commandId ?? null}, created.sender_id, created.content,
+          created.is_recalled, created.reply_to_id, created.sent_at,
+          ${JSON.stringify(uniqueMentions)}::text::jsonb,
+          COALESCE((
+            SELECT jsonb_agg(
+              entry || jsonb_build_object('message_id', created.message_id)
+              ORDER BY entry_order
+            )
+            FROM jsonb_array_elements(${attachmentsJson}::text::jsonb)
+              WITH ORDINALITY AS claimed_attachment(entry, entry_order)
+          ), '[]'::jsonb)
+        FROM created
         RETURNING message_id, change_sequence
       `;
       if (rows.length === 0) {
@@ -451,66 +538,6 @@ export class MessageRepository implements IMessageRepository {
       }
       createdMessageId = rows[0].message_id;
       responseChangeSequence = Number(rows[0].change_sequence);
-
-      await tx`
-        UPDATE realtime_counters
-        SET message_sequence = message_sequence + 1,
-            change_sequence = change_sequence + 1
-        WHERE counter_id = true
-      `;
-
-      if (data.mentions && data.mentions.length > 0) {
-        for (const userId of data.mentions) {
-          await tx`
-            INSERT INTO message_mentions (message_id, user_id)
-            VALUES (${createdMessageId}, ${userId})
-          `;
-        }
-      }
-
-      if (data.attachmentIds && data.attachmentIds.length > 0) {
-        const pgAttIds = `{${data.attachmentIds.join(',')}}`;
-        const updatedAtts = await tx<{ attachment_id: string }[]>`
-          UPDATE attachments SET message_id = ${createdMessageId}
-          WHERE attachment_id = ANY(${pgAttIds}::uuid[])
-            AND message_id IS NULL
-            AND uploaded_by = ${data.senderId}
-          RETURNING attachment_id
-        `;
-        if (updatedAtts.length !== new Set(data.attachmentIds).size) {
-          throw new ValidationError('Attachments must exist and must not already belong to a message');
-        }
-      }
-
-      await tx`
-        INSERT INTO message_changes (
-          change_sequence, message_id, room_id, message_sequence, revision,
-          change_type, actor_id, command_id, sender_id, content, is_recalled,
-          reply_to_id, sent_at, mentions, attachments
-        )
-        SELECT m.change_sequence, m.message_id, m.room_id, m.message_sequence,
-          m.revision, 'created', m.sender_id, ${data.commandId ?? null},
-          m.sender_id, m.content, m.is_recalled, m.reply_to_id, m.sent_at,
-          COALESCE((
-            SELECT jsonb_agg(mm.user_id ORDER BY mm.user_id)
-            FROM message_mentions mm
-            WHERE mm.message_id = m.message_id
-          ), '[]'::jsonb),
-          COALESCE((
-            SELECT jsonb_agg(jsonb_build_object(
-              'attachment_id', a.attachment_id,
-              'message_id', a.message_id,
-              'uploaded_by', a.uploaded_by,
-              'file_type', a.file_type,
-              'original_name', a.original_name,
-              'uploaded_at', a.uploaded_at
-            ) ORDER BY a.uploaded_at, a.attachment_id)
-            FROM attachments a
-            WHERE a.message_id = m.message_id
-          ), '[]'::jsonb)
-        FROM messages m
-        WHERE m.message_id = ${createdMessageId}
-      `;
     });
 
     const message = responseChangeSequence !== undefined
@@ -605,34 +632,40 @@ export class MessageRepository implements IMessageRepository {
         return;
       }
 
+      // One statement, and the last write of the transaction: the counter row
+      // lock is what serializes every durable write in the process, so it is
+      // taken as late as possible and released at the commit that follows.
       const next = await tx<{ change_sequence: number | string }[]>`
-        UPDATE realtime_counters
-        SET change_sequence = change_sequence + 1
-        WHERE counter_id = true
-        RETURNING change_sequence
-      `;
-      const changeSequence = next[0].change_sequence;
-      responseChangeSequence = Number(changeSequence);
-      await tx`
-        UPDATE messages
-        SET is_recalled = true,
-            change_sequence = ${changeSequence},
-            revision = revision + 1
-        WHERE message_id = ${messageId}
-      `;
-      await tx`
+        WITH seq AS (
+          UPDATE realtime_counters
+          SET change_sequence = change_sequence + 1
+          WHERE counter_id = true
+          RETURNING change_sequence
+        ),
+        recalled AS (
+          UPDATE messages
+          SET is_recalled = true,
+              change_sequence = seq.change_sequence,
+              revision = messages.revision + 1
+          FROM seq
+          WHERE messages.message_id = ${messageId}
+          RETURNING messages.message_id, messages.room_id, messages.message_sequence,
+                    messages.revision, messages.sender_id, messages.content,
+                    messages.reply_to_id, messages.sent_at, messages.change_sequence
+        )
         INSERT INTO message_changes (
           change_sequence, message_id, room_id, message_sequence, revision,
           change_type, actor_id, command_id, sender_id, content, is_recalled,
           reply_to_id, sent_at, mentions, attachments
         )
-        SELECT ${changeSequence}, message_id, room_id, message_sequence,
-          revision, 'recalled', ${actorId ?? null}, ${commandId ?? null},
-          sender_id, content, true, reply_to_id, sent_at,
+        SELECT recalled.change_sequence, recalled.message_id, recalled.room_id,
+          recalled.message_sequence, recalled.revision, 'recalled', ${actorId ?? null},
+          ${commandId ?? null}, recalled.sender_id, recalled.content, true,
+          recalled.reply_to_id, recalled.sent_at,
           COALESCE((
             SELECT jsonb_agg(mm.user_id ORDER BY mm.user_id)
             FROM message_mentions mm
-            WHERE mm.message_id = messages.message_id
+            WHERE mm.message_id = recalled.message_id
           ), '[]'::jsonb),
           COALESCE((
             SELECT jsonb_agg(jsonb_build_object(
@@ -644,10 +677,12 @@ export class MessageRepository implements IMessageRepository {
               'uploaded_at', a.uploaded_at
             ) ORDER BY a.uploaded_at, a.attachment_id)
             FROM attachments a
-            WHERE a.message_id = messages.message_id
+            WHERE a.message_id = recalled.message_id
           ), '[]'::jsonb)
-        FROM messages WHERE message_id = ${messageId}
+        FROM recalled
+        RETURNING change_sequence
       `;
+      responseChangeSequence = Number(next[0].change_sequence);
     });
     const message = responseChangeSequence !== undefined
       ? await this.fetchChangeSnapshot(responseChangeSequence, messageId)
@@ -727,46 +762,55 @@ export class MessageRepository implements IMessageRepository {
         throw new ValidationError('Cannot edit a recalled message');
       }
 
-      const next = await tx<{ change_sequence: number | string }[]>`
-        UPDATE realtime_counters
-        SET change_sequence = change_sequence + 1
-        WHERE counter_id = true
-        RETURNING change_sequence
-      `;
-      const changeSequence = next[0].change_sequence;
-      responseChangeSequence = Number(changeSequence);
-      await tx`
-        UPDATE messages
-        SET content = ${content},
-            change_sequence = ${changeSequence},
-            revision = revision + 1
-        WHERE message_id = ${messageId}
-      `;
-
+      // The mention set is rewritten before the counter is touched. These rows
+      // do not depend on the new sequence, and anything executed while the
+      // counter row is locked blocks every other durable write in the process.
       await tx`DELETE FROM message_mentions WHERE message_id = ${messageId}`;
-
-      if (mentions && mentions.length > 0) {
-        for (const userId of mentions) {
-          await tx`
-            INSERT INTO message_mentions (message_id, user_id)
-            VALUES (${messageId}, ${userId})
-          `;
-        }
+      const uniqueMentions = mentions ? [...new Set(mentions)] : [];
+      if (uniqueMentions.length > 0) {
+        const pgMentionIds = `{${uniqueMentions.join(',')}}`;
+        await tx`
+          INSERT INTO message_mentions (message_id, user_id)
+          SELECT ${messageId}, mention
+          FROM unnest(${pgMentionIds}::uuid[]) AS mention
+        `;
       }
 
-      await tx`
+      // Allocating the sequence, applying the edit and recording the snapshot
+      // is one statement and the last write of the transaction, so the counter
+      // row lock is released a single round trip later at commit.
+      const next = await tx<{ change_sequence: number | string }[]>`
+        WITH seq AS (
+          UPDATE realtime_counters
+          SET change_sequence = change_sequence + 1
+          WHERE counter_id = true
+          RETURNING change_sequence
+        ),
+        edited AS (
+          UPDATE messages
+          SET content = ${content},
+              change_sequence = seq.change_sequence,
+              revision = messages.revision + 1
+          FROM seq
+          WHERE messages.message_id = ${messageId}
+          RETURNING messages.message_id, messages.room_id, messages.message_sequence,
+                    messages.revision, messages.sender_id, messages.content,
+                    messages.is_recalled, messages.reply_to_id, messages.sent_at,
+                    messages.change_sequence
+        )
         INSERT INTO message_changes (
           change_sequence, message_id, room_id, message_sequence, revision,
           change_type, actor_id, command_id, sender_id, content, is_recalled,
           reply_to_id, sent_at, mentions, attachments
         )
-        SELECT ${changeSequence}, message_id, room_id, message_sequence,
-          revision, 'edited', ${actorId ?? null}, ${commandId ?? null},
-          sender_id, content, is_recalled, reply_to_id, sent_at,
+        SELECT edited.change_sequence, edited.message_id, edited.room_id,
+          edited.message_sequence, edited.revision, 'edited', ${actorId ?? null},
+          ${commandId ?? null}, edited.sender_id, edited.content,
+          edited.is_recalled, edited.reply_to_id, edited.sent_at,
           COALESCE((
             SELECT jsonb_agg(mm.user_id ORDER BY mm.user_id)
             FROM message_mentions mm
-            WHERE mm.message_id = messages.message_id
+            WHERE mm.message_id = edited.message_id
           ), '[]'::jsonb),
           COALESCE((
             SELECT jsonb_agg(jsonb_build_object(
@@ -778,10 +822,12 @@ export class MessageRepository implements IMessageRepository {
               'uploaded_at', a.uploaded_at
             ) ORDER BY a.uploaded_at, a.attachment_id)
             FROM attachments a
-            WHERE a.message_id = messages.message_id
+            WHERE a.message_id = edited.message_id
           ), '[]'::jsonb)
-        FROM messages WHERE message_id = ${messageId}
+        FROM edited
+        RETURNING change_sequence
       `;
+      responseChangeSequence = Number(next[0].change_sequence);
     });
 
     const message = responseChangeSequence !== undefined

--- a/backend/src/models/roomRepository.ts
+++ b/backend/src/models/roomRepository.ts
@@ -122,26 +122,29 @@ export class RoomRepository implements IRoomRepository {
   }
 
   /**
-   * The mirror of `reopenPrivateRoomIfUnblocked`. Marking the room read-only
-   * has to be conditional for the same reason reopening is: the block flow
-   * spans several transactions, so a concurrent unblock can commit in between.
-   * An unconditional update would then re-close a room that is legitimately
-   * open again and leave it read-only with no block row to undo it.
+   * The private room these two share, but only while a block between them is
+   * still recorded. Read-only on purpose: the `blocks` insert trigger is the
+   * single owner of the block → read-only invariant, so the block flow must
+   * not write room state itself. This exists so that flow can find the room
+   * whose sockets need revoking, and so a request whose block was already
+   * lifted by a concurrent unblock stops short instead of revoking access to
+   * a room that is legitimately open again.
    */
-  async markPrivateReadOnlyIfBlocked(roomId: string, userA: string, userB: string): Promise<Room | null> {
-    const rows = await this.sql<RoomRow[]>`
-      UPDATE chat_rooms cr
-      SET is_readonly = true
-      WHERE cr.room_id = ${roomId}
-        AND cr.type = 'private'
+  async findPrivateRoomIdIfBlocked(userA: string, userB: string): Promise<string | null> {
+    const rows = await this.sql<{ room_id: string }[]>`
+      SELECT r.room_id FROM chat_rooms r
+      JOIN room_members rm1 ON r.room_id = rm1.room_id AND rm1.user_id = ${userA}
+      JOIN room_members rm2 ON r.room_id = rm2.room_id AND rm2.user_id = ${userB}
+      WHERE r.type = 'private'
         AND EXISTS (
           SELECT 1 FROM blocks b
           WHERE (b.blocker_id = ${userA} AND b.blocked_id = ${userB})
              OR (b.blocker_id = ${userB} AND b.blocked_id = ${userA})
         )
-      RETURNING cr.*
+      ORDER BY r.is_archived ASC, r.created_at DESC
+      LIMIT 1
     `;
-    return rows.length === 0 ? null : mapRowToRoom(rows[0]);
+    return rows.length === 0 ? null : rows[0].room_id;
   }
 
   async reopenPrivateRoomIfUnblocked(roomId: string, userA: string, userB: string): Promise<Room | null> {

--- a/backend/src/models/roomRepository.ts
+++ b/backend/src/models/roomRepository.ts
@@ -121,6 +121,29 @@ export class RoomRepository implements IRoomRepository {
     return rows.length === 0 ? null : mapRowToRoom(rows[0]);
   }
 
+  /**
+   * The mirror of `reopenPrivateRoomIfUnblocked`. Marking the room read-only
+   * has to be conditional for the same reason reopening is: the block flow
+   * spans several transactions, so a concurrent unblock can commit in between.
+   * An unconditional update would then re-close a room that is legitimately
+   * open again and leave it read-only with no block row to undo it.
+   */
+  async markPrivateReadOnlyIfBlocked(roomId: string, userA: string, userB: string): Promise<Room | null> {
+    const rows = await this.sql<RoomRow[]>`
+      UPDATE chat_rooms cr
+      SET is_readonly = true
+      WHERE cr.room_id = ${roomId}
+        AND cr.type = 'private'
+        AND EXISTS (
+          SELECT 1 FROM blocks b
+          WHERE (b.blocker_id = ${userA} AND b.blocked_id = ${userB})
+             OR (b.blocker_id = ${userB} AND b.blocked_id = ${userA})
+        )
+      RETURNING cr.*
+    `;
+    return rows.length === 0 ? null : mapRowToRoom(rows[0]);
+  }
+
   async reopenPrivateRoomIfUnblocked(roomId: string, userA: string, userB: string): Promise<Room | null> {
     const rows = await this.sql<RoomRow[]>`
       UPDATE chat_rooms cr

--- a/backend/src/realtime/socketServer.ts
+++ b/backend/src/realtime/socketServer.ts
@@ -34,6 +34,18 @@ export const attachSockets = (io: ChatServer, deps: SocketDeps): void => {
   const sessionLimit = maxSessionsPerUser();
   const sessionCounts = new Map<string, number>();
   const typingTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  // Handshakes whose slot was already reserved by the middleware below, so the
+  // connection handler does not count the same session twice.
+  const reservedSessions = new WeakSet<object>();
+
+  const acquireSession = (userId: string): void => {
+    sessionCounts.set(userId, (sessionCounts.get(userId) ?? 0) + 1);
+  };
+  const releaseSession = (userId: string): void => {
+    const count = (sessionCounts.get(userId) ?? 1) - 1;
+    if (count > 0) sessionCounts.set(userId, count);
+    else sessionCounts.delete(userId);
+  };
 
   // The auth middleware runs first and stores socket.data.user. Test doubles
   // without `use` still exercise the connection handlers below.
@@ -44,10 +56,15 @@ export const attachSockets = (io: ChatServer, deps: SocketDeps): void => {
         next(new Error('Authentication error'));
         return;
       }
+      // Check and reserve in the same synchronous step. Counting only once the
+      // connection handler runs would let every concurrent handshake read the
+      // same pre-connection total and pass a limit that is already exhausted.
       if ((sessionCounts.get(userId) ?? 0) >= sessionLimit) {
         next(new Error('Session limit reached'));
         return;
       }
+      acquireSession(userId);
+      reservedSessions.add(socket);
       next();
     });
   }
@@ -55,7 +72,8 @@ export const attachSockets = (io: ChatServer, deps: SocketDeps): void => {
   io.on('connection', (socket) => {
     const userId = socket.data.user.userId;
     let disconnected = false;
-    sessionCounts.set(userId, (sessionCounts.get(userId) ?? 0) + 1);
+    if (reservedSessions.has(socket)) reservedSessions.delete(socket);
+    else acquireSession(userId);
     socket.join(`user_${userId}`);
 
     const clearTypingTimers = () => {
@@ -122,9 +140,7 @@ export const attachSockets = (io: ChatServer, deps: SocketDeps): void => {
     socket.on('disconnect', () => {
       disconnected = true;
       clearTypingTimers();
-      const count = (sessionCounts.get(userId) ?? 1) - 1;
-      if (count > 0) sessionCounts.set(userId, count);
-      else sessionCounts.delete(userId);
+      releaseSession(userId);
 
       if (deps.friendRepository) {
         trackUserDisconnection(io, userId, socket.id, deps.friendRepository).catch((err) => {

--- a/backend/src/realtime/socketServer.ts
+++ b/backend/src/realtime/socketServer.ts
@@ -26,6 +26,19 @@ const typingTtlMs = (): number => {
 };
 
 /**
+ * How long a handshake may hold its reserved session slot before the slot is
+ * assumed abandoned. Socket.IO defers the rest of the connection setup past
+ * the middleware, so a transport that dies in that window never reaches the
+ * `connection` handler and never registers the `disconnect` listener that
+ * would return the slot. Without an expiry those slots accumulate until the
+ * user can no longer connect at all.
+ */
+const sessionReservationTtlMs = (): number => {
+  const configured = Number(process.env.SESSION_RESERVATION_TTL_MS ?? 10_000);
+  return Number.isFinite(configured) && configured > 0 ? configured : 10_000;
+};
+
+/**
  * Attach only the ephemeral realtime surface. Durable commands deliberately
  * have no Socket.IO listeners: REST owns idempotency, optimistic concurrency,
  * authorization and the transaction that creates the durable event.
@@ -35,8 +48,20 @@ export const attachSockets = (io: ChatServer, deps: SocketDeps): void => {
   const sessionCounts = new Map<string, number>();
   const typingTimers = new Map<string, ReturnType<typeof setTimeout>>();
   // Handshakes whose slot was already reserved by the middleware below, so the
-  // connection handler does not count the same session twice.
+  // connection handler does not count the same session twice. Each reservation
+  // is a lease: if the connection never arrives, the timer returns the slot.
   const reservedSessions = new WeakSet<object>();
+  const reservationTimers = new WeakMap<object, ReturnType<typeof setTimeout>>();
+  const reservationTtl = sessionReservationTtlMs();
+
+  const settleReservation = (socket: object): boolean => {
+    const timer = reservationTimers.get(socket);
+    if (timer) {
+      clearTimeout(timer);
+      reservationTimers.delete(socket);
+    }
+    return reservedSessions.delete(socket);
+  };
 
   const acquireSession = (userId: string): void => {
     sessionCounts.set(userId, (sessionCounts.get(userId) ?? 0) + 1);
@@ -65,6 +90,14 @@ export const attachSockets = (io: ChatServer, deps: SocketDeps): void => {
       }
       acquireSession(userId);
       reservedSessions.add(socket);
+      const expiry = setTimeout(() => {
+        reservationTimers.delete(socket);
+        // Only release when the connection handler has not already claimed
+        // this reservation, otherwise a live session would lose its slot.
+        if (reservedSessions.delete(socket)) releaseSession(userId);
+      }, reservationTtl);
+      expiry.unref?.();
+      reservationTimers.set(socket, expiry);
       next();
     });
   }
@@ -72,8 +105,9 @@ export const attachSockets = (io: ChatServer, deps: SocketDeps): void => {
   io.on('connection', (socket) => {
     const userId = socket.data.user.userId;
     let disconnected = false;
-    if (reservedSessions.has(socket)) reservedSessions.delete(socket);
-    else acquireSession(userId);
+    // A reservation that already expired has given its slot back, so this
+    // connection has to take one of its own.
+    if (!settleReservation(socket)) acquireSession(userId);
     socket.join(`user_${userId}`);
 
     const clearTypingTimers = () => {

--- a/backend/src/services/friendService.ts
+++ b/backend/src/services/friendService.ts
@@ -7,6 +7,7 @@ export function makeFriendService(
   notifyUser?: (userId: string, eventName: string, payload: unknown) => void,
   privateRooms?: {
     markPrivateReadOnly(userA: string, userB: string): Promise<string | null>;
+    markPrivateReadOnlyIfBlocked?(userA: string, userB: string): Promise<string | null>;
     createPrivate?(userA: string, userB: string): Promise<unknown>;
     reopenPrivateRoom?(userA: string, userB: string): Promise<void>;
   },
@@ -140,7 +141,14 @@ export function makeFriendService(
         // this room. The read-only flag and the socket revocation below are
         // the cleanup half of the same state change.
         await repo.blockUser(userId, targetUserId);
-        const privateRoomId = await privateRooms?.markPrivateReadOnly(userId, targetUserId);
+        // The pair mutex is process-local and `blockUser`'s advisory lock ends
+        // with its transaction, so another process can lift this block before
+        // the cleanup below runs. Both steps are therefore conditional on the
+        // block still existing: if it is gone, the room is legitimately open
+        // and must keep its subscriptions.
+        const privateRoomId = privateRooms?.markPrivateReadOnlyIfBlocked
+          ? await privateRooms.markPrivateReadOnlyIfBlocked(userId, targetUserId)
+          : await privateRooms?.markPrivateReadOnly(userId, targetUserId);
         if (privateRoomId) {
           await removeUserFromRoom?.(userId, privateRoomId);
           await removeUserFromRoom?.(targetUserId, privateRoomId);

--- a/backend/src/services/friendService.ts
+++ b/backend/src/services/friendService.ts
@@ -132,25 +132,28 @@ export function makeFriendService(
         throw new ValidationError('Cannot block yourself');
       }
       const block = async () => {
-        // The durable block row is written first so a later failure can never
-        // leave the room read-only and unsubscribed with no block record to
-        // undo it. Ordering it first is also safe for the live transport:
-        // `blockUser` and message authorization take the same pair advisory
-        // lock and authorization re-reads `blocks` inside its own transaction,
-        // so once the block commits no further message can be published to
-        // this room. The read-only flag and the socket revocation below are
-        // the cleanup half of the same state change.
         // Writing the block is the whole durable half of this operation: the
         // `blocks` insert trigger closes the private room inside the same
         // transaction, so this flow must not set the read-only flag itself.
         // Two writers for one invariant is what previously let a concurrent
         // unblock reopen the room and then have this request re-close it,
-        // leaving it read-only with no block row to undo it.
+        // leaving it read-only with no block row to undo it. Ordering the
+        // block first is also what makes the live transport safe: `blockUser`
+        // and message authorization take the same pair advisory lock, and
+        // authorization re-reads `blocks` in its own transaction, so once the
+        // block commits nothing further can be published to this room.
         await repo.blockUser(userId, targetUserId);
         // The pair mutex is process-local and `blockUser`'s advisory lock ends
         // with its transaction, so the block can already be lifted by another
         // process. A null here means exactly that, and the room keeps its
         // subscriptions because it is legitimately open again.
+        //
+        // Known residual window: the block can also be lifted between this
+        // lookup and the revocation below, in which case both users are
+        // dropped from a room that has legitimately reopened. That is
+        // self-healing — reconnecting re-derives subscriptions from durable
+        // membership — and closing it properly needs a cross-process lock held
+        // across the whole flow, which is deliberately out of scope here.
         const privateRoomId = privateRooms?.findPrivateRoomIdIfBlocked
           ? await privateRooms.findPrivateRoomIdIfBlocked(userId, targetUserId)
           : await privateRooms?.markPrivateReadOnly(userId, targetUserId);

--- a/backend/src/services/friendService.ts
+++ b/backend/src/services/friendService.ts
@@ -131,16 +131,20 @@ export function makeFriendService(
         throw new ValidationError('Cannot block yourself');
       }
       const block = async () => {
-        // Make the room reject new messages and remove its live subscribers
-        // before the durable block row commits. An in-flight message can then
-        // either finish before revocation or find the read-only room; it
-        // cannot be published to a socket that remains subscribed afterward.
+        // The durable block row is written first so a later failure can never
+        // leave the room read-only and unsubscribed with no block record to
+        // undo it. Ordering it first is also safe for the live transport:
+        // `blockUser` and message authorization take the same pair advisory
+        // lock and authorization re-reads `blocks` inside its own transaction,
+        // so once the block commits no further message can be published to
+        // this room. The read-only flag and the socket revocation below are
+        // the cleanup half of the same state change.
+        await repo.blockUser(userId, targetUserId);
         const privateRoomId = await privateRooms?.markPrivateReadOnly(userId, targetUserId);
         if (privateRoomId) {
           await removeUserFromRoom?.(userId, privateRoomId);
           await removeUserFromRoom?.(targetUserId, privateRoomId);
         }
-        await repo.blockUser(userId, targetUserId);
         notifyUser?.(targetUserId, 'friend_request', {
           requesterId: userId,
           addresseeId: targetUserId,

--- a/backend/src/services/friendService.ts
+++ b/backend/src/services/friendService.ts
@@ -7,7 +7,7 @@ export function makeFriendService(
   notifyUser?: (userId: string, eventName: string, payload: unknown) => void,
   privateRooms?: {
     markPrivateReadOnly(userA: string, userB: string): Promise<string | null>;
-    markPrivateReadOnlyIfBlocked?(userA: string, userB: string): Promise<string | null>;
+    findPrivateRoomIdIfBlocked?(userA: string, userB: string): Promise<string | null>;
     createPrivate?(userA: string, userB: string): Promise<unknown>;
     reopenPrivateRoom?(userA: string, userB: string): Promise<void>;
   },
@@ -140,14 +140,19 @@ export function makeFriendService(
         // so once the block commits no further message can be published to
         // this room. The read-only flag and the socket revocation below are
         // the cleanup half of the same state change.
+        // Writing the block is the whole durable half of this operation: the
+        // `blocks` insert trigger closes the private room inside the same
+        // transaction, so this flow must not set the read-only flag itself.
+        // Two writers for one invariant is what previously let a concurrent
+        // unblock reopen the room and then have this request re-close it,
+        // leaving it read-only with no block row to undo it.
         await repo.blockUser(userId, targetUserId);
         // The pair mutex is process-local and `blockUser`'s advisory lock ends
-        // with its transaction, so another process can lift this block before
-        // the cleanup below runs. Both steps are therefore conditional on the
-        // block still existing: if it is gone, the room is legitimately open
-        // and must keep its subscriptions.
-        const privateRoomId = privateRooms?.markPrivateReadOnlyIfBlocked
-          ? await privateRooms.markPrivateReadOnlyIfBlocked(userId, targetUserId)
+        // with its transaction, so the block can already be lifted by another
+        // process. A null here means exactly that, and the room keeps its
+        // subscriptions because it is legitimately open again.
+        const privateRoomId = privateRooms?.findPrivateRoomIdIfBlocked
+          ? await privateRooms.findPrivateRoomIdIfBlocked(userId, targetUserId)
           : await privateRooms?.markPrivateReadOnly(userId, targetUserId);
         if (privateRoomId) {
           await removeUserFromRoom?.(userId, privateRoomId);

--- a/backend/src/services/roomService.ts
+++ b/backend/src/services/roomService.ts
@@ -157,20 +157,20 @@ export const makeRoomService = (
     },
 
     /**
-     * Read-only variant used by the block flow. It returns the room id only
-     * when a block between the pair is still recorded, so a request whose
-     * block was already lifted by a concurrent unblock stops short instead of
-     * re-closing a room that is legitimately open again.
+     * Used by the block flow to locate the room whose sockets need revoking.
+     * It deliberately does not touch room state: the `blocks` insert trigger
+     * already closes the room inside the same transaction as the block row,
+     * and a second writer for that invariant is what let a concurrent unblock
+     * leave a room read-only with no block to undo it. Returning null when the
+     * block is gone also stops a stale request from revoking access to a room
+     * that has legitimately reopened.
      */
-    async markPrivateReadOnlyIfBlocked(userA: string, userB: string): Promise<string | null> {
-      const existing = await repo.findPrivateRoomByMembers(userA, userB);
-      if (!existing) return null;
-      if (!repo.markPrivateReadOnlyIfBlocked) {
-        await repo.update(existing.roomId, { isReadonly: true });
-        return existing.roomId;
+    async findPrivateRoomIdIfBlocked(userA: string, userB: string): Promise<string | null> {
+      if (repo.findPrivateRoomIdIfBlocked) {
+        return repo.findPrivateRoomIdIfBlocked(userA, userB);
       }
-      const marked = await repo.markPrivateReadOnlyIfBlocked(existing.roomId, userA, userB);
-      return marked ? existing.roomId : null;
+      const existing = await repo.findPrivateRoomByMembers(userA, userB);
+      return existing ? existing.roomId : null;
     },
 
     async reopenPrivateRoom(userA: string, userB: string): Promise<void> {

--- a/backend/src/services/roomService.ts
+++ b/backend/src/services/roomService.ts
@@ -156,6 +156,23 @@ export const makeRoomService = (
       return null;
     },
 
+    /**
+     * Read-only variant used by the block flow. It returns the room id only
+     * when a block between the pair is still recorded, so a request whose
+     * block was already lifted by a concurrent unblock stops short instead of
+     * re-closing a room that is legitimately open again.
+     */
+    async markPrivateReadOnlyIfBlocked(userA: string, userB: string): Promise<string | null> {
+      const existing = await repo.findPrivateRoomByMembers(userA, userB);
+      if (!existing) return null;
+      if (!repo.markPrivateReadOnlyIfBlocked) {
+        await repo.update(existing.roomId, { isReadonly: true });
+        return existing.roomId;
+      }
+      const marked = await repo.markPrivateReadOnlyIfBlocked(existing.roomId, userA, userB);
+      return marked ? existing.roomId : null;
+    },
+
     async reopenPrivateRoom(userA: string, userB: string): Promise<void> {
       const existing = await repo.findPrivateRoomByMembers(userA, userB);
       if (existing && existing.isReadonly) {

--- a/backend/src/services/userService.ts
+++ b/backend/src/services/userService.ts
@@ -37,6 +37,8 @@ interface JwtHelper {
 interface EmergencyAlertResult {
   alerted: boolean;
   recipients: string[];
+  /** Contacts whose durable delivery threw. Non-empty means a retry is owed. */
+  failed?: string[];
   reason?: string;
 }
 
@@ -94,6 +96,7 @@ export const makeUserService = (
     }
 
     const recipients: string[] = [];
+    const failed: string[] = [];
     for (const contact of contacts) {
       const msg = contact.message || fallbackMessage;
       const deliver = async (): Promise<boolean> => {
@@ -108,12 +111,31 @@ export const makeUserService = (
         }
         return true;
       };
-      const delivered = emergencyContactRepo.withContactLock
-        ? await emergencyContactRepo.withContactLock(userId, contact.contactId, deliver)
-        : await deliver();
-      if (delivered) recipients.push(contact.contactId);
+      // One unreachable contact must not silence the alert for everyone else,
+      // so each delivery is isolated. Retrying the whole incident later is
+      // safe because delivery is keyed by `incidentId` and is idempotent.
+      try {
+        const delivered = emergencyContactRepo.withContactLock
+          ? await emergencyContactRepo.withContactLock(userId, contact.contactId, deliver)
+          : await deliver();
+        if (delivered) recipients.push(contact.contactId);
+      } catch (error) {
+        failed.push(contact.contactId);
+        console.error(
+          `Failed to deliver emergency alert to contact ${contact.contactId} for user ${userId}:`,
+          error,
+        );
+      }
     }
 
+    if (failed.length > 0) {
+      return {
+        alerted: recipients.length > 0,
+        recipients,
+        failed,
+        reason: 'PARTIAL_DELIVERY',
+      };
+    }
     return { alerted: true, recipients };
   };
 
@@ -365,7 +387,11 @@ export const makeUserService = (
           'User has exceeded their inactivity warning threshold',
           user.lastActivity.toISOString(),
         );
-        if (!alert.alerted) {
+        if (!alert.alerted || (alert.failed?.length ?? 0) > 0) {
+          // A partially delivered incident still owes the remaining contacts a
+          // notification, so the reservation is released and the next run
+          // retries. Contacts that already received the message are protected
+          // by the per-incident idempotency key.
           await emergencyContactRepo.releaseAlertIfNew?.(userId, user.lastActivity);
         } else {
           await emergencyContactRepo.completeAlert?.(userId, user.lastActivity);

--- a/backend/tests/integration/repositories/roomRepository.int.test.ts
+++ b/backend/tests/integration/repositories/roomRepository.int.test.ts
@@ -141,4 +141,42 @@ describe('RoomRepository (pg)', () => {
     rooms = await repo.findByMember(aliceId);
     expect(rooms[0].unreadCount).toBe(0);
   });
+
+  it('markPrivateReadOnlyIfBlocked only closes the room while a block exists', async () => {
+    const users = await testPool`
+      INSERT INTO users (name, email, password_hash)
+      VALUES ('Blocker', 'blocker@test.com', 'hash'), ('Blocked', 'blocked@test.com', 'hash')
+      RETURNING user_id
+    `;
+    const blockerId: string = users[0].user_id;
+    const blockedId: string = users[1].user_id;
+
+    const room = await repo.create({ type: 'private', requireApproval: false, viewHistory: true });
+    await testPool`
+      INSERT INTO room_members (room_id, user_id, role)
+      VALUES (${room.roomId}, ${blockerId}, 'member'), (${room.roomId}, ${blockedId}, 'member')
+    `;
+
+    // No block recorded: the update must match nothing, which is what stops a
+    // request whose block was lifted concurrently from re-closing the room.
+    const withoutBlock = await repo.markPrivateReadOnlyIfBlocked(room.roomId, blockerId, blockedId);
+    expect(withoutBlock).toBeNull();
+    expect((await repo.findById(room.roomId))!.isReadonly).toBe(false);
+
+    await testPool`
+      INSERT INTO blocks (blocker_id, blocked_id) VALUES (${blockerId}, ${blockedId})
+    `;
+    const withBlock = await repo.markPrivateReadOnlyIfBlocked(room.roomId, blockerId, blockedId);
+    expect(withBlock).not.toBeNull();
+    expect((await repo.findById(room.roomId))!.isReadonly).toBe(true);
+
+    // The pair is matched in either direction.
+    await testPool`DELETE FROM blocks`;
+    await repo.update(room.roomId, { isReadonly: false });
+    await testPool`
+      INSERT INTO blocks (blocker_id, blocked_id) VALUES (${blockedId}, ${blockerId})
+    `;
+    const reversed = await repo.markPrivateReadOnlyIfBlocked(room.roomId, blockerId, blockedId);
+    expect(reversed).not.toBeNull();
+  });
 });

--- a/backend/tests/integration/repositories/roomRepository.int.test.ts
+++ b/backend/tests/integration/repositories/roomRepository.int.test.ts
@@ -142,7 +142,31 @@ describe('RoomRepository (pg)', () => {
     expect(rooms[0].unreadCount).toBe(0);
   });
 
-  it('markPrivateReadOnlyIfBlocked only closes the room while a block exists', async () => {
+  it('the blocks trigger closes the private room in the same transaction as the block', async () => {
+    const users = await testPool`
+      INSERT INTO users (name, email, password_hash)
+      VALUES ('Blocker', 'blocker@test.com', 'hash'), ('Blocked', 'blocked@test.com', 'hash')
+      RETURNING user_id
+    `;
+    const blockerId: string = users[0].user_id;
+    const blockedId: string = users[1].user_id;
+
+    const room = await repo.create({ type: 'private', requireApproval: false, viewHistory: true });
+    await testPool`
+      INSERT INTO room_members (room_id, user_id, role)
+      VALUES (${room.roomId}, ${blockerId}, 'member'), (${room.roomId}, ${blockedId}, 'member')
+    `;
+    expect((await repo.findById(room.roomId))!.isReadonly).toBe(false);
+
+    // The service layer deliberately no longer writes this flag, so the
+    // trigger being the sole owner of the invariant is now load-bearing.
+    await testPool`
+      INSERT INTO blocks (blocker_id, blocked_id) VALUES (${blockerId}, ${blockedId})
+    `;
+    expect((await repo.findById(room.roomId))!.isReadonly).toBe(true);
+  });
+
+  it('findPrivateRoomIdIfBlocked reports the room only while a block exists', async () => {
     const users = await testPool`
       INSERT INTO users (name, email, password_hash)
       VALUES ('Blocker', 'blocker@test.com', 'hash'), ('Blocked', 'blocked@test.com', 'hash')
@@ -157,26 +181,20 @@ describe('RoomRepository (pg)', () => {
       VALUES (${room.roomId}, ${blockerId}, 'member'), (${room.roomId}, ${blockedId}, 'member')
     `;
 
-    // No block recorded: the update must match nothing, which is what stops a
-    // request whose block was lifted concurrently from re-closing the room.
-    const withoutBlock = await repo.markPrivateReadOnlyIfBlocked(room.roomId, blockerId, blockedId);
-    expect(withoutBlock).toBeNull();
-    expect((await repo.findById(room.roomId))!.isReadonly).toBe(false);
+    // No block: a request whose block was lifted concurrently gets nothing
+    // back and therefore revokes nothing.
+    expect(await repo.findPrivateRoomIdIfBlocked(blockerId, blockedId)).toBeNull();
 
     await testPool`
       INSERT INTO blocks (blocker_id, blocked_id) VALUES (${blockerId}, ${blockedId})
     `;
-    const withBlock = await repo.markPrivateReadOnlyIfBlocked(room.roomId, blockerId, blockedId);
-    expect(withBlock).not.toBeNull();
-    expect((await repo.findById(room.roomId))!.isReadonly).toBe(true);
+    expect(await repo.findPrivateRoomIdIfBlocked(blockerId, blockedId)).toBe(room.roomId);
+    // The pair is matched in either direction, and the lookup never writes.
+    expect(await repo.findPrivateRoomIdIfBlocked(blockedId, blockerId)).toBe(room.roomId);
 
-    // The pair is matched in either direction.
     await testPool`DELETE FROM blocks`;
     await repo.update(room.roomId, { isReadonly: false });
-    await testPool`
-      INSERT INTO blocks (blocker_id, blocked_id) VALUES (${blockedId}, ${blockerId})
-    `;
-    const reversed = await repo.markPrivateReadOnlyIfBlocked(room.roomId, blockerId, blockedId);
-    expect(reversed).not.toBeNull();
+    expect(await repo.findPrivateRoomIdIfBlocked(blockerId, blockedId)).toBeNull();
+    expect((await repo.findById(room.roomId))!.isReadonly).toBe(false);
   });
 });

--- a/backend/tests/unit/bootstrap/bunRuntimeServer.test.ts
+++ b/backend/tests/unit/bootstrap/bunRuntimeServer.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, mock, afterEach } from 'bun:test';
+import { createBunRuntimeServer, createRealtime } from '../../../src/bootstrap/realtime';
+import type { Server as Engine } from '@socket.io/bun-engine';
+
+const originalServe = Bun.serve;
+
+const stubEngine = () => ({
+  handler: () => ({ websocket: {} }),
+  handleRequest: mock(),
+}) as unknown as Engine;
+
+afterEach(() => {
+  (Bun as unknown as { serve: typeof Bun.serve }).serve = originalServe;
+});
+
+describe('createBunRuntimeServer', () => {
+  const stubServe = (stop: () => Promise<void>) => {
+    const fake = {
+      port: 4000,
+      hostname: '0.0.0.0',
+      stop: mock(stop),
+    };
+    (Bun as unknown as { serve: unknown }).serve = mock(() => fake);
+    return fake;
+  };
+
+  it('reports the port as still bound while the drain is in flight', async () => {
+    let releaseDrain!: () => void;
+    const drained = new Promise<void>((resolve) => { releaseDrain = resolve; });
+    stubServe(() => drained);
+
+    const server = createBunRuntimeServer({
+      app: { fetch: () => new Response('ok') },
+      engine: stubEngine(),
+    });
+    server.listen(4000);
+    expect(server.listening).toBe(true);
+
+    let closed = false;
+    server.close(() => { closed = true; });
+
+    // The socket has not released the port yet, so the facade must not claim
+    // it is free — and must refuse to bind it again.
+    expect(server.listening).toBe(false);
+    expect(server.address()).toEqual({ address: '0.0.0.0', family: 'IPv4', port: 4000 });
+    expect(() => server.listen(4000)).toThrow('Cannot listen while the server is shutting down');
+    expect(closed).toBe(false);
+
+    releaseDrain();
+    await drained;
+    await Promise.resolve();
+
+    expect(closed).toBe(true);
+    expect(server.address()).toBeNull();
+  });
+
+  it('can bind again once the drain has completed', async () => {
+    stubServe(() => Promise.resolve());
+
+    const server = createBunRuntimeServer({
+      app: { fetch: () => new Response('ok') },
+      engine: stubEngine(),
+    });
+    server.listen(4000);
+    await new Promise<void>((resolve) => server.close(resolve));
+
+    expect(server.listening).toBe(false);
+    server.listen(4000);
+    expect(server.listening).toBe(true);
+  });
+});
+
+describe('createRealtime', () => {
+  it('configures CORS on the engine, which owns the handshake request', () => {
+    const { engine } = createRealtime({
+      config: { port: 4000, corsOrigins: ['http://localhost:3000'] },
+      repositories: {
+        roomMembers: { findByUser: mock(), findMember: mock() },
+        friends: { getFriends: mock() },
+      } as never,
+      publisher: {
+        bind: mock(),
+        withRoomSubscriptionLock: mock(),
+      } as never,
+    });
+
+    // `io.bind(engine)` means Socket.IO never sees the raw request, so its own
+    // `cors` option would silently do nothing.
+    expect(engine.opts.cors).toEqual({
+      origin: ['http://localhost:3000'],
+      credentials: true,
+    });
+  });
+});

--- a/backend/tests/unit/realtime/socketServer.test.ts
+++ b/backend/tests/unit/realtime/socketServer.test.ts
@@ -156,4 +156,65 @@ describe('attachSockets', () => {
       );
     });
   });
+  describe('session limit', () => {
+    const makeSocket = (id: string) => ({
+      id,
+      data: { user: { userId: 'user-1', name: 'Alice' } },
+      join: mock(),
+      leave: mock(),
+      emit: mock(),
+      to: mock(() => ({ emit: mock() })),
+      on: mock(),
+    });
+
+    const attachLimited = (limit: string) => {
+      const previous = process.env.MAX_SESSIONS_PER_USER;
+      process.env.MAX_SESSIONS_PER_USER = limit;
+      let middleware: any;
+      let connect: any;
+      const io = {
+        use: mock((fn: any) => { middleware = fn; }),
+        on: mock((event: string, handler: any) => {
+          if (event === 'connection') connect = handler;
+        }),
+        to: mock(() => ({ emit: mock() })),
+      } as unknown as ChatServer;
+      attachSockets(io, { roomMemberRepository: roomMemberRepo });
+      process.env.MAX_SESSIONS_PER_USER = previous;
+      return { middleware: middleware!, connect: connect! };
+    };
+
+    it('reserves a slot during the handshake so concurrent handshakes cannot overshoot', () => {
+      const { middleware } = attachLimited('2');
+      const results: Array<Error | undefined> = [];
+
+      // Three handshakes complete their middleware before any of them reaches
+      // the connection handler — the case that made the limit unenforceable.
+      for (const id of ['s1', 's2', 's3']) {
+        middleware(makeSocket(id), (err?: Error) => results.push(err));
+      }
+
+      expect(results[0]).toBeUndefined();
+      expect(results[1]).toBeUndefined();
+      expect(results[2]?.message).toBe('Session limit reached');
+    });
+
+    it('frees the reserved slot when the session disconnects', () => {
+      const { middleware, connect } = attachLimited('1');
+      const first = makeSocket('s1');
+      const firstHandlers: Record<string, any> = {};
+      first.on = mock((event: string, handler: any) => { firstHandlers[event] = handler; }) as any;
+
+      middleware(first, () => {});
+      connect(first);
+      const blocked: Array<Error | undefined> = [];
+      middleware(makeSocket('s2'), (err?: Error) => blocked.push(err));
+      expect(blocked[0]?.message).toBe('Session limit reached');
+
+      firstHandlers.disconnect();
+      const afterDisconnect: Array<Error | undefined> = [];
+      middleware(makeSocket('s3'), (err?: Error) => afterDisconnect.push(err));
+      expect(afterDisconnect[0]).toBeUndefined();
+    });
+  });
 });

--- a/backend/tests/unit/realtime/socketServer.test.ts
+++ b/backend/tests/unit/realtime/socketServer.test.ts
@@ -167,9 +167,11 @@ describe('attachSockets', () => {
       on: mock(),
     });
 
-    const attachLimited = (limit: string) => {
+    const attachLimited = (limit: string, reservationTtl?: string) => {
       const previous = process.env.MAX_SESSIONS_PER_USER;
+      const previousTtl = process.env.SESSION_RESERVATION_TTL_MS;
       process.env.MAX_SESSIONS_PER_USER = limit;
+      if (reservationTtl !== undefined) process.env.SESSION_RESERVATION_TTL_MS = reservationTtl;
       let middleware: any;
       let connect: any;
       const io = {
@@ -181,6 +183,7 @@ describe('attachSockets', () => {
       } as unknown as ChatServer;
       attachSockets(io, { roomMemberRepository: roomMemberRepo });
       process.env.MAX_SESSIONS_PER_USER = previous;
+      process.env.SESSION_RESERVATION_TTL_MS = previousTtl;
       return { middleware: middleware!, connect: connect! };
     };
 
@@ -197,6 +200,45 @@ describe('attachSockets', () => {
       expect(results[0]).toBeUndefined();
       expect(results[1]).toBeUndefined();
       expect(results[2]?.message).toBe('Session limit reached');
+    });
+
+    it('reclaims a reserved slot when the handshake never reaches connection', async () => {
+      const { middleware } = attachLimited('1', '5');
+
+      // The transport dies after the middleware runs, so the connection
+      // handler — and with it the disconnect listener — never runs.
+      middleware(makeSocket('aborted'), () => {});
+      const whileReserved: Array<Error | undefined> = [];
+      middleware(makeSocket('s2'), (err?: Error) => whileReserved.push(err));
+      expect(whileReserved[0]?.message).toBe('Session limit reached');
+
+      await new Promise((resolve) => setTimeout(resolve, 25));
+
+      const afterExpiry: Array<Error | undefined> = [];
+      middleware(makeSocket('s3'), (err?: Error) => afterExpiry.push(err));
+      expect(afterExpiry[0]).toBeUndefined();
+    });
+
+    it('keeps the slot of a connection that arrived before its reservation expired', async () => {
+      const { middleware, connect } = attachLimited('1', '5');
+      const first = makeSocket('s1');
+      const firstHandlers: Record<string, any> = {};
+      first.on = mock((event: string, handler: any) => { firstHandlers[event] = handler; }) as any;
+
+      middleware(first, () => {});
+      connect(first);
+
+      // The reservation timer must not hand this live session's slot back.
+      await new Promise((resolve) => setTimeout(resolve, 25));
+
+      const blocked: Array<Error | undefined> = [];
+      middleware(makeSocket('s2'), (err?: Error) => blocked.push(err));
+      expect(blocked[0]?.message).toBe('Session limit reached');
+
+      firstHandlers.disconnect();
+      const afterDisconnect: Array<Error | undefined> = [];
+      middleware(makeSocket('s3'), (err?: Error) => afterDisconnect.push(err));
+      expect(afterDisconnect[0]).toBeUndefined();
     });
 
     it('frees the reserved slot when the session disconnects', () => {

--- a/backend/tests/unit/services/friendService.test.ts
+++ b/backend/tests/unit/services/friendService.test.ts
@@ -20,6 +20,44 @@ describe('friendService', () => {
     await expect(service.respondFriendRequest('u1', 'u2', 'rejected')).rejects.toThrow(AppError);
   });
 
+  it('blockUser writes the durable block before revoking the room', async () => {
+    const order: string[] = [];
+    const mockRepo = {
+      blockUser: mock(async () => { order.push('blockUser'); }),
+    } as any;
+    const privateRooms = {
+      markPrivateReadOnly: mock(async () => { order.push('markPrivateReadOnly'); return 'room-1'; }),
+    };
+    const removeUserFromRoom = mock(async () => { order.push('removeUserFromRoom'); });
+    const service = makeFriendService(mockRepo, undefined, privateRooms as any, removeUserFromRoom as any);
+
+    const result = await service.blockUser('u1', 'u2');
+
+    expect(result).toEqual({ status: 'blocked' });
+    expect(order[0]).toBe('blockUser');
+    expect(order).toEqual([
+      'blockUser',
+      'markPrivateReadOnly',
+      'removeUserFromRoom',
+      'removeUserFromRoom',
+    ]);
+  });
+
+  it('blockUser leaves the room usable when the durable block fails', async () => {
+    const mockRepo = {
+      blockUser: mock(async () => { throw new Error('write failed'); }),
+    } as any;
+    const privateRooms = { markPrivateReadOnly: mock() };
+    const removeUserFromRoom = mock();
+    const service = makeFriendService(mockRepo, undefined, privateRooms as any, removeUserFromRoom as any);
+
+    await expect(service.blockUser('u1', 'u2')).rejects.toThrow('write failed');
+    // Without a block row there is nothing to undo, so the room must not have
+    // been left read-only and unsubscribed.
+    expect(privateRooms.markPrivateReadOnly).not.toHaveBeenCalled();
+    expect(removeUserFromRoom).not.toHaveBeenCalled();
+  });
+
   it('unblockUser calls repo.unblockUser', async () => {
     const mockRepo = {
       unblockUser: mock().mockResolvedValue(true),

--- a/backend/tests/unit/services/friendService.test.ts
+++ b/backend/tests/unit/services/friendService.test.ts
@@ -26,7 +26,8 @@ describe('friendService', () => {
       blockUser: mock(async () => { order.push('blockUser'); }),
     } as any;
     const privateRooms = {
-      markPrivateReadOnly: mock(async () => { order.push('markPrivateReadOnly'); return 'room-1'; }),
+      markPrivateReadOnly: mock(),
+      markPrivateReadOnlyIfBlocked: mock(async () => { order.push('markPrivateReadOnly'); return 'room-1'; }),
     };
     const removeUserFromRoom = mock(async () => { order.push('removeUserFromRoom'); });
     const service = makeFriendService(mockRepo, undefined, privateRooms as any, removeUserFromRoom as any);
@@ -41,6 +42,29 @@ describe('friendService', () => {
       'removeUserFromRoom',
       'removeUserFromRoom',
     ]);
+  });
+
+  it('blockUser skips room cleanup when a concurrent unblock already lifted the block', async () => {
+    const mockRepo = {
+      blockUser: mock().mockResolvedValue(undefined),
+    } as any;
+    // A concurrent unblock committed between blockUser and the cleanup, so the
+    // conditional mark matches nothing and reports no room.
+    const privateRooms = {
+      markPrivateReadOnly: mock(),
+      markPrivateReadOnlyIfBlocked: mock().mockResolvedValue(null),
+    };
+    const removeUserFromRoom = mock();
+    const service = makeFriendService(mockRepo, undefined, privateRooms as any, removeUserFromRoom as any);
+
+    const result = await service.blockUser('u1', 'u2');
+
+    expect(result).toEqual({ status: 'blocked' });
+    expect(privateRooms.markPrivateReadOnlyIfBlocked).toHaveBeenCalledWith('u1', 'u2');
+    // The room is legitimately open again, so it must keep its subscriptions
+    // and must not be re-closed by the unconditional path.
+    expect(privateRooms.markPrivateReadOnly).not.toHaveBeenCalled();
+    expect(removeUserFromRoom).not.toHaveBeenCalled();
   });
 
   it('blockUser leaves the room usable when the durable block fails', async () => {

--- a/backend/tests/unit/services/friendService.test.ts
+++ b/backend/tests/unit/services/friendService.test.ts
@@ -27,7 +27,7 @@ describe('friendService', () => {
     } as any;
     const privateRooms = {
       markPrivateReadOnly: mock(),
-      markPrivateReadOnlyIfBlocked: mock(async () => { order.push('markPrivateReadOnly'); return 'room-1'; }),
+      findPrivateRoomIdIfBlocked: mock(async () => { order.push('findPrivateRoomIdIfBlocked'); return 'room-1'; }),
     };
     const removeUserFromRoom = mock(async () => { order.push('removeUserFromRoom'); });
     const service = makeFriendService(mockRepo, undefined, privateRooms as any, removeUserFromRoom as any);
@@ -38,21 +38,24 @@ describe('friendService', () => {
     expect(order[0]).toBe('blockUser');
     expect(order).toEqual([
       'blockUser',
-      'markPrivateReadOnly',
+      'findPrivateRoomIdIfBlocked',
       'removeUserFromRoom',
       'removeUserFromRoom',
     ]);
+    // The blocks insert trigger owns the read-only flag; this flow must not
+    // write it a second time.
+    expect(privateRooms.markPrivateReadOnly).not.toHaveBeenCalled();
   });
 
-  it('blockUser skips room cleanup when a concurrent unblock already lifted the block', async () => {
+  it('blockUser skips socket revocation when a concurrent unblock already lifted the block', async () => {
     const mockRepo = {
       blockUser: mock().mockResolvedValue(undefined),
     } as any;
-    // A concurrent unblock committed between blockUser and the cleanup, so the
-    // conditional mark matches nothing and reports no room.
+    // A concurrent unblock committed between blockUser and the lookup, so no
+    // room is reported and the reopened room keeps its subscribers.
     const privateRooms = {
       markPrivateReadOnly: mock(),
-      markPrivateReadOnlyIfBlocked: mock().mockResolvedValue(null),
+      findPrivateRoomIdIfBlocked: mock().mockResolvedValue(null),
     };
     const removeUserFromRoom = mock();
     const service = makeFriendService(mockRepo, undefined, privateRooms as any, removeUserFromRoom as any);
@@ -60,9 +63,7 @@ describe('friendService', () => {
     const result = await service.blockUser('u1', 'u2');
 
     expect(result).toEqual({ status: 'blocked' });
-    expect(privateRooms.markPrivateReadOnlyIfBlocked).toHaveBeenCalledWith('u1', 'u2');
-    // The room is legitimately open again, so it must keep its subscriptions
-    // and must not be re-closed by the unconditional path.
+    expect(privateRooms.findPrivateRoomIdIfBlocked).toHaveBeenCalledWith('u1', 'u2');
     expect(privateRooms.markPrivateReadOnly).not.toHaveBeenCalled();
     expect(removeUserFromRoom).not.toHaveBeenCalled();
   });
@@ -71,7 +72,7 @@ describe('friendService', () => {
     const mockRepo = {
       blockUser: mock(async () => { throw new Error('write failed'); }),
     } as any;
-    const privateRooms = { markPrivateReadOnly: mock() };
+    const privateRooms = { markPrivateReadOnly: mock(), findPrivateRoomIdIfBlocked: mock() };
     const removeUserFromRoom = mock();
     const service = makeFriendService(mockRepo, undefined, privateRooms as any, removeUserFromRoom as any);
 
@@ -79,6 +80,7 @@ describe('friendService', () => {
     // Without a block row there is nothing to undo, so the room must not have
     // been left read-only and unsubscribed.
     expect(privateRooms.markPrivateReadOnly).not.toHaveBeenCalled();
+    expect(privateRooms.findPrivateRoomIdIfBlocked).not.toHaveBeenCalled();
     expect(removeUserFromRoom).not.toHaveBeenCalled();
   });
 

--- a/backend/tests/unit/services/userService.test.ts
+++ b/backend/tests/unit/services/userService.test.ts
@@ -519,6 +519,30 @@ describe('userService', () => {
       });
     });
 
+    it('keeps delivering to the remaining contacts when one delivery throws', async () => {
+      mockRepo.findById.mockResolvedValue(inactiveUser);
+      emergencyContactRepo.recordAlertIfNew.mockResolvedValue(true);
+      emergencyContactRepo.releaseAlertIfNew = mock().mockResolvedValue(undefined);
+      emergencyContactRepo.completeAlert = mock().mockResolvedValue(undefined);
+      emergencyContactRepo.findByUserId.mockResolvedValue([
+        { userId: 'u1', contactId: 'u2', message: 'inactive', createdAt: new Date() },
+        { userId: 'u1', contactId: 'u3', message: 'inactive', createdAt: new Date() },
+      ]);
+      notifyEmergencyContact.mockImplementation(async (contactId: string) => {
+        if (contactId === 'u2') throw new Error('persistence failed');
+      });
+
+      const result = await userService.checkInactivity('u1', new Date('2026-01-04T00:00:00.000Z'));
+
+      expect(notifyEmergencyContact).toHaveBeenCalledTimes(2);
+      expect(result.recipients).toEqual(['u3']);
+      expect(result.failed).toEqual(['u2']);
+      // The incident is still owed to u2, so the reservation is released for
+      // a later retry instead of being marked complete.
+      expect(emergencyContactRepo.releaseAlertIfNew).toHaveBeenCalled();
+      expect(emergencyContactRepo.completeAlert).not.toHaveBeenCalled();
+    });
+
     it('does not alert below the inactivity threshold', async () => {
       mockRepo.findById.mockResolvedValue(inactiveUser);
 

--- a/frontend/src/context/ChatContext.tsx
+++ b/frontend/src/context/ChatContext.tsx
@@ -759,6 +759,11 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
     messageId?: string;
   }>>([]);
   const flushingBufferedRef = useRef(false);
+  // Messages buffered across a failed sync. Their tasks are still replayed —
+  // they carry read receipts and notifications that sync cannot rebuild — but
+  // the retry's canonical room projection has already counted them as unread,
+  // so the local increment has to be suppressed for exactly these ids.
+  const replayedWithoutUnreadRef = useRef<Set<string>>(new Set());
   const canonicalBufferedRoomsRef = useRef<Set<string>>(new Set());
   const canonicalBufferedSequencesRef = useRef<Map<string, number>>(new Map());
 
@@ -1136,6 +1141,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
     const storedCursor = Number(sessionStorage.getItem(`near:syncCursor:${currentUserId}`) ?? 0);
     syncCursorRef.current = Number.isSafeInteger(storedCursor) && storedCursor >= 0 ? storedCursor : 0;
     bufferedRealtimeRef.current = [];
+    replayedWithoutUnreadRef.current.clear();
     syncingRef.current = true;
     let disposed = false;
     let retryTimer: ReturnType<typeof setTimeout> | undefined;
@@ -1239,23 +1245,27 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
             flushingBufferedRef.current = false;
             canonicalBufferedRoomsRef.current.clear();
             canonicalBufferedSequencesRef.current.clear();
+            replayedWithoutUnreadRef.current.clear();
           }
         } else {
           // Do not advance the cursor from live events when the initial sync
           // failed: doing so could skip older durable changes on the retry.
           //
-          // Only the new-message tasks are dropped. The retry re-syncs from
-          // the unadvanced cursor and re-delivers every durable change, so
-          // replaying those would double-count unread messages while adding
-          // nothing. Everything else — read receipts above all — is never
-          // re-delivered by sync, and the post-sync room refresh reuses the
-          // cached member list rather than reloading read positions, so
-          // dropping them would leave peer read indicators stale until an
-          // unrelated member fetch happened to correct them. Recall and edit
-          // tasks are guarded by `changeSequence`, so a late replay of one
-          // the sync already applied is a no-op.
-          bufferedRealtimeRef.current = bufferedRealtimeRef.current
-            .filter((buffered) => buffered.kind !== "message");
+          // Every task is kept, because none of them can be reconstructed from
+          // sync alone: read receipts are not re-delivered at all, and a
+          // new-message task also carries the sender's read receipt, the
+          // cached member's lastReadId and the desktop notification — the
+          // post-sync room refresh reuses the cached member list, so those
+          // would simply be lost. What the retry does reproduce is the unread
+          // count, which arrives as the server's canonical projection, so only
+          // that increment is suppressed for the messages seen here. Recall
+          // and edit tasks are guarded by `changeSequence`, making a late
+          // replay of one the sync already applied a no-op.
+          for (const buffered of bufferedRealtimeRef.current) {
+            if (buffered.kind === "message" && buffered.messageId) {
+              replayedWithoutUnreadRef.current.add(buffered.messageId);
+            }
+          }
           canonicalBufferedRoomsRef.current.clear();
           canonicalBufferedSequencesRef.current.clear();
           socket.disconnect();
@@ -1316,6 +1326,10 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
         });
       }
 
+      // Read synchronously: a `setRooms` updater runs at render time, by which
+      // point the buffered-replay bookkeeping has already been cleared.
+      const suppressUnreadForThisMessage = replayedWithoutUnreadRef.current.has(incoming.id);
+
       setMessages((current) => mergeMessages(current, [incoming]));
 
       // Update the sender's read receipt (since they sent it, they've read it!)
@@ -1343,6 +1357,8 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
                 unreadCount:
                   activeRoomIdRef.current === room.id
                     ? 0
+                    : suppressUnreadForThisMessage
+                    ? (room.unreadCount ?? 0)
                     : flushingBufferedRef.current && (
                       (incoming.changeSequence !== undefined
                         && (canonicalBufferedSequencesRef.current.get(room.id) ?? -1) >= incoming.changeSequence)

--- a/frontend/src/context/ChatContext.tsx
+++ b/frontend/src/context/ChatContext.tsx
@@ -11,6 +11,7 @@
 import React, { createContext, useCallback, useContext, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import { resolveAssetUrl } from "@/lib/assets";
+import { translate } from "@/lib/i18n";
 import { NotificationBridge } from "@/lib/notificationBridge";
 import type {
   Attachment as ApiAttachment,
@@ -29,6 +30,7 @@ import type {
   UserSettings,
 } from "@shared/types";
 import {
+  ApiError,
   approveRoomMember,
   attachmentDownloadUrl,
   blockUser as blockUserApi,
@@ -784,6 +786,8 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
   });
   const [selectedFriendForSidebar, setSelectedFriendForSidebar] = useState<Friend | null>(null);
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
+  // Translation key of the transient message-level notice (revision conflicts).
+  const [messageNoticeKey, setMessageNoticeKey] = useState<string | null>(null);
   const [showRightPanel, setShowRightPanel] = useState<boolean>(true);
   const [typingUsers, setTypingUsers] = useState<Record<string, string[]>>({});
   const [activeProfilePopover, setActiveProfilePopover] = useState<{ instanceId: string; userId: string } | null>(null);
@@ -1239,6 +1243,13 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
         } else {
           // Do not advance the cursor from live events when the initial sync
           // failed: doing so could skip older durable changes on the retry.
+          // The buffered events are dropped with the cursor they belong to.
+          // Replaying them after a later successful sync would double-count
+          // unread messages, and nothing is lost: the reconnect re-syncs from
+          // the unadvanced cursor, which still covers every buffered change.
+          bufferedRealtimeRef.current.length = 0;
+          canonicalBufferedRoomsRef.current.clear();
+          canonicalBufferedSequencesRef.current.clear();
           socket.disconnect();
           retryTimer = setTimeout(() => {
             retryTimer = undefined;
@@ -1735,6 +1746,25 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
     }).then((message) => applyCanonicalMessage(message)).catch((error) => console.error('Failed to send attachment message:', error));
   };
 
+  /**
+   * A 409 means the local revision was stale: someone else edited or recalled
+   * the message first. Silently swallowing it leaves the user looking at
+   * content the server has already replaced, so realign from the server and
+   * tell them what happened.
+   */
+  const handleRevisionConflict = async (
+    roomId: string,
+    error: unknown,
+    noticeKey: string,
+  ): Promise<void> => {
+    if (!(error instanceof ApiError) || error.status !== 409) throw error;
+    const room = roomsRef.current.find((item) => item.id === roomId);
+    if (token && room) {
+      await loadMessagesForRooms(token, [room], currentUserId);
+    }
+    setMessageNoticeKey(noticeKey);
+  };
+
   const handleRecallMessage = (msgId: string) => {
     if (!token) return;
     const message = messagesRef.current.find((item) => item.id === msgId);
@@ -1744,7 +1774,10 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
       message.roomId,
       msgId,
       message.revision ?? 1,
-    ).then((updated) => applyCanonicalMessage(updated, false)).catch((error) => console.error('Failed to recall message:', error));
+    )
+      .then((updated) => applyCanonicalMessage(updated, false))
+      .catch((error) => handleRevisionConflict(message.roomId, error, 'chatroom.recallConflict'))
+      .catch((error) => console.error('Failed to recall message:', error));
   };
 
   const handleUpdateMessage = (roomId: string, messageId: string, content: string) => {
@@ -1757,7 +1790,10 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
       messageId,
       content,
       message.revision ?? 1,
-    ).then((updated) => applyCanonicalMessage(updated, false)).catch((error) => console.error('Failed to edit message:', error));
+    )
+      .then((updated) => applyCanonicalMessage(updated, false))
+      .catch((error) => handleRevisionConflict(roomId, error, 'chatroom.editConflict'))
+      .catch((error) => console.error('Failed to edit message:', error));
   };
 
   const handleUpdateProfile = async (profile: ProfileInput) => {
@@ -2591,6 +2627,21 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
           <ProfilePopoverContext.Provider value={profilePopoverValue}>
             <RightPanelContext.Provider value={rightPanelValue}>
               {children}
+              {messageNoticeKey && (
+                <div
+                  role="status"
+                  className="fixed bottom-6 left-1/2 z-50 flex -translate-x-1/2 items-center gap-3 rounded-lg bg-red-600 px-4 py-3 text-sm text-white shadow-lg"
+                >
+                  <span>{translate(uiLanguage, messageNoticeKey)}</span>
+                  <button
+                    type="button"
+                    className="font-semibold underline"
+                    onClick={() => setMessageNoticeKey(null)}
+                  >
+                    {translate(uiLanguage, "chatroom.dismissNotice")}
+                  </button>
+                </div>
+              )}
             </RightPanelContext.Provider>
           </ProfilePopoverContext.Provider>
         </TypingUsersContext.Provider>

--- a/frontend/src/context/ChatContext.tsx
+++ b/frontend/src/context/ChatContext.tsx
@@ -1777,7 +1777,14 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
         const canonical = (await listMessages(token, roomId, { limit: 50 }))
           .find((row) => row.messageId === messageId);
         if (canonical) {
-          applyCanonicalMessage(canonical, false);
+          // The sidebar preview is derived from this message whenever it is
+          // the room's last one, and the conflict means the event that would
+          // normally have refreshed the summary may never arrive. Skipping it
+          // unconditionally would leave a stale preview behind a notice that
+          // claims the latest version is on screen.
+          const isRoomPreview = roomsRef.current
+            .some((room) => room.id === roomId && room.lastMessageId === messageId);
+          applyCanonicalMessage(canonical, isRoomPreview);
           refreshed = true;
         }
       } catch (reloadError) {

--- a/frontend/src/context/ChatContext.tsx
+++ b/frontend/src/context/ChatContext.tsx
@@ -1243,11 +1243,19 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
         } else {
           // Do not advance the cursor from live events when the initial sync
           // failed: doing so could skip older durable changes on the retry.
-          // The buffered events are dropped with the cursor they belong to.
-          // Replaying them after a later successful sync would double-count
-          // unread messages, and nothing is lost: the reconnect re-syncs from
-          // the unadvanced cursor, which still covers every buffered change.
-          bufferedRealtimeRef.current.length = 0;
+          //
+          // Only the new-message tasks are dropped. The retry re-syncs from
+          // the unadvanced cursor and re-delivers every durable change, so
+          // replaying those would double-count unread messages while adding
+          // nothing. Everything else — read receipts above all — is never
+          // re-delivered by sync, and the post-sync room refresh reuses the
+          // cached member list rather than reloading read positions, so
+          // dropping them would leave peer read indicators stale until an
+          // unrelated member fetch happened to correct them. Recall and edit
+          // tasks are guarded by `changeSequence`, so a late replay of one
+          // the sync already applied is a no-op.
+          bufferedRealtimeRef.current = bufferedRealtimeRef.current
+            .filter((buffered) => buffered.kind !== "message");
           canonicalBufferedRoomsRef.current.clear();
           canonicalBufferedSequencesRef.current.clear();
           socket.disconnect();
@@ -1754,15 +1762,29 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
    */
   const handleRevisionConflict = async (
     roomId: string,
+    messageId: string,
     error: unknown,
     noticeKey: string,
   ): Promise<void> => {
     if (!(error instanceof ApiError) || error.status !== 409) throw error;
-    const room = roomsRef.current.find((item) => item.id === roomId);
-    if (token && room) {
-      await loadMessagesForRooms(token, [room], currentUserId);
+    // Only promise the user a refreshed message once the canonical row is
+    // actually back in state. The fetch can fail, and the message can sit
+    // outside the page it returns — in both cases the stale revision is still
+    // on screen, and a notice claiming otherwise would be a lie.
+    let refreshed = false;
+    if (token) {
+      try {
+        const canonical = (await listMessages(token, roomId, { limit: 50 }))
+          .find((row) => row.messageId === messageId);
+        if (canonical) {
+          applyCanonicalMessage(canonical, false);
+          refreshed = true;
+        }
+      } catch (reloadError) {
+        console.error('Failed to reload the conflicted message:', reloadError);
+      }
     }
-    setMessageNoticeKey(noticeKey);
+    setMessageNoticeKey(refreshed ? noticeKey : 'chatroom.conflictReloadFailed');
   };
 
   const handleRecallMessage = (msgId: string) => {
@@ -1776,7 +1798,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
       message.revision ?? 1,
     )
       .then((updated) => applyCanonicalMessage(updated, false))
-      .catch((error) => handleRevisionConflict(message.roomId, error, 'chatroom.recallConflict'))
+      .catch((error) => handleRevisionConflict(message.roomId, msgId, error, 'chatroom.recallConflict'))
       .catch((error) => console.error('Failed to recall message:', error));
   };
 
@@ -1792,7 +1814,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
       message.revision ?? 1,
     )
       .then((updated) => applyCanonicalMessage(updated, false))
-      .catch((error) => handleRevisionConflict(roomId, error, 'chatroom.editConflict'))
+      .catch((error) => handleRevisionConflict(roomId, messageId, error, 'chatroom.editConflict'))
       .catch((error) => console.error('Failed to edit message:', error));
   };
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -19,6 +19,22 @@ import type {
   SyncResponse,
 } from '@shared/types';
 
+/**
+ * A failed HTTP response. Callers that have to react to a specific status —
+ * a 409 revision conflict, for instance — need it, and a bare `Error` throws
+ * that away.
+ */
+export class ApiError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly code?: string,
+  ) {
+    super(message);
+    this.name = 'ApiError';
+  }
+}
+
 export const getApiBaseUrl = (): string => {
   const envUrl = process.env.NEXT_PUBLIC_API_URL;
   
@@ -229,8 +245,12 @@ const request = async (
       });
     }
 
-    const payload = (await response.json().catch(() => null)) as { message?: string } | null;
-    throw new Error(payload?.message ?? `Request failed with status ${response.status}`);
+    const payload = (await response.json().catch(() => null)) as { message?: string; code?: string } | null;
+    throw new ApiError(
+      payload?.message ?? `Request failed with status ${response.status}`,
+      response.status,
+      payload?.code,
+    );
   }
 
   return response;

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -226,7 +226,10 @@
     "messageRecalled": "Message recalled",
     "downloadingAttachment": "Downloading attachment",
     "downloadAttachment": "Download attachment",
-    "newMessages": "New Messages"
+    "newMessages": "New Messages",
+    "editConflict": "This message changed elsewhere. The latest version has been loaded — please try your edit again.",
+    "recallConflict": "This message changed elsewhere. The latest version has been loaded — please try recalling it again.",
+    "dismissNotice": "Dismiss"
   },
   "profileCard": {
     "myInfo": "My Info",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -229,7 +229,8 @@
     "newMessages": "New Messages",
     "editConflict": "This message changed elsewhere. The latest version has been loaded — please try your edit again.",
     "recallConflict": "This message changed elsewhere. The latest version has been loaded — please try recalling it again.",
-    "dismissNotice": "Dismiss"
+    "dismissNotice": "Dismiss",
+    "conflictReloadFailed": "This message changed elsewhere and could not be reloaded. Please refresh the page before trying again."
   },
   "profileCard": {
     "myInfo": "My Info",

--- a/frontend/src/locales/zh-TW.json
+++ b/frontend/src/locales/zh-TW.json
@@ -221,7 +221,8 @@
     "newMessages": "新訊息",
     "editConflict": "這則訊息在別處已被更動，已載入最新版本，請重新編輯。",
     "recallConflict": "這則訊息在別處已被更動，已載入最新版本，請重新收回。",
-    "dismissNotice": "關閉"
+    "dismissNotice": "關閉",
+    "conflictReloadFailed": "這則訊息在別處已被更動，且無法重新載入，請重新整理頁面後再試。"
   },
   "profileCard": {
     "myInfo": "我的資訊",

--- a/frontend/src/locales/zh-TW.json
+++ b/frontend/src/locales/zh-TW.json
@@ -218,7 +218,10 @@
     "messageRecalled": "訊息已收回",
     "downloadingAttachment": "正在下載附件",
     "downloadAttachment": "下載附件",
-    "newMessages": "新訊息"
+    "newMessages": "新訊息",
+    "editConflict": "這則訊息在別處已被更動，已載入最新版本，請重新編輯。",
+    "recallConflict": "這則訊息在別處已被更動，已載入最新版本，請重新收回。",
+    "dismissNotice": "關閉"
   },
   "profileCard": {
     "myInfo": "我的資訊",

--- a/frontend/tests/chat-behavior.test.tsx
+++ b/frontend/tests/chat-behavior.test.tsx
@@ -223,12 +223,16 @@ describe("read receipts", () => {
 
 describe("realtime sync recovery", () => {
   let readStates: Record<string, Record<string, string>> = {};
+  let observedRooms: Array<{ id: string; unreadCount?: number }> = [];
 
   function ReadStateProbe(): React.ReactElement {
-    const { groupReadStates } = useChat();
+    const { groupReadStates, rooms } = useChat();
     useEffect(() => {
       readStates = groupReadStates;
     }, [groupReadStates]);
+    useEffect(() => {
+      observedRooms = rooms;
+    }, [rooms]);
     return <div data-testid="read-state-probe" />;
   }
 
@@ -269,6 +273,39 @@ describe("realtime sync recovery", () => {
     await app.settle();
 
     expect(readStates["room-1"]?.["m-2"]).toBe(target);
+  });
+
+  test("replays a buffered new message for its side effects without double-counting unread", async () => {
+    const app = await mountChatApp("/chat/room-1", { probe: <ReadStateProbe /> });
+    const incoming = makeMessage("room-2", 99, "m-3", { content: "Buffered while syncing" });
+
+    const failing = __gateNextSync();
+    act(() => {
+      app.socket().disconnect();
+      app.socket().connect();
+    });
+    act(() => {
+      app.socket().serverEmit("new_message", incoming);
+    });
+
+    await act(async () => {
+      failing.fail();
+      await Promise.resolve();
+    });
+    await app.settle();
+
+    act(() => {
+      app.socket().connect();
+    });
+    await app.settle();
+
+    // The sender's read receipt rides on new_message and is never re-delivered
+    // by sync, so the task has to be replayed rather than dropped.
+    expect(readStates["room-2"]?.["m-3"]).toBe(incoming.messageId);
+    expect(screen.getAllByText("Buffered while syncing").length).toBeGreaterThan(0);
+    // The retry's canonical room projection already counted this message, so
+    // the replay must not add to it. room-2 is unread 3 in the fixtures.
+    expect(observedRooms.find((room) => room.id === "room-2")?.unreadCount).toBe(3);
   });
 });
 

--- a/frontend/tests/chat-behavior.test.tsx
+++ b/frontend/tests/chat-behavior.test.tsx
@@ -5,10 +5,12 @@
  * switching so the render-performance fixes cannot change semantics.
  */
 import { describe, expect, test } from "vitest";
+import { useEffect } from "react";
 import { act, fireEvent, screen } from "@testing-library/react";
 import { mountChatApp } from "./harness";
 import { ME_ID, makeMessage, messageId } from "./fixtures";
-import { __getApiCallLog } from "./mocks/api";
+import { __failNextRevisionCommand, __getApiCallLog } from "./mocks/api";
+import { useChat } from "@/context/ChatContext";
 
 describe("opening and switching rooms", () => {
   test("shows the active room's messages and members panel", async () => {
@@ -106,6 +108,38 @@ describe("receiving and sending messages", () => {
     expect(screen.getByText("Message recalled")).toBeTruthy();
     // The body is gone from the conversation; the sidebar preview may remain.
     expect(screen.queryAllByText("Message 40 in room-1").length).toBeLessThanOrEqual(1);
+  });
+});
+
+describe("message revision conflicts", () => {
+  let recall: ((messageId: string) => void) | null = null;
+
+  function ConflictProbe(): React.ReactElement {
+    const { handleRecallMessage } = useChat();
+    useEffect(() => {
+      recall = handleRecallMessage;
+    }, [handleRecallMessage]);
+    return <div data-testid="conflict-probe" />;
+  }
+
+  test("tells the user and reloads the room when the server rejects a stale revision", async () => {
+    const target = messageId("room-1", 40);
+    const app = await mountChatApp("/chat/room-1", { probe: <ConflictProbe /> });
+
+    __failNextRevisionCommand(target);
+    act(() => {
+      recall!(target);
+    });
+    await app.settle();
+
+    // A 409 used to be logged and swallowed, leaving the user staring at a
+    // message the server had already changed.
+    expect(screen.getByText(/message changed elsewhere/i)).toBeTruthy();
+    expect(__getApiCallLog("recallMessage").length).toBe(1);
+
+    fireEvent.click(screen.getByText("Dismiss"));
+    await app.settle();
+    expect(screen.queryByText(/message changed elsewhere/i)).toBeNull();
   });
 });
 

--- a/frontend/tests/chat-behavior.test.tsx
+++ b/frontend/tests/chat-behavior.test.tsx
@@ -9,7 +9,12 @@ import { useEffect } from "react";
 import { act, fireEvent, screen } from "@testing-library/react";
 import { mountChatApp } from "./harness";
 import { ME_ID, makeMessage, messageId } from "./fixtures";
-import { __failNextRevisionCommand, __getApiCallLog } from "./mocks/api";
+import {
+  __failNextListMessages,
+  __failNextRevisionCommand,
+  __gateNextSync,
+  __getApiCallLog,
+} from "./mocks/api";
 import { useChat } from "@/context/ChatContext";
 
 describe("opening and switching rooms", () => {
@@ -141,6 +146,22 @@ describe("message revision conflicts", () => {
     await app.settle();
     expect(screen.queryByText(/message changed elsewhere/i)).toBeNull();
   });
+
+  test("does not claim the message was reloaded when the reload itself fails", async () => {
+    const target = messageId("room-1", 40);
+    const app = await mountChatApp("/chat/room-1", { probe: <ConflictProbe /> });
+
+    __failNextRevisionCommand(target);
+    __failNextListMessages();
+    act(() => {
+      recall!(target);
+    });
+    await app.settle();
+
+    // The stale revision is still on screen, so the notice must say so rather
+    // than promise a refresh that never landed.
+    expect(screen.getByText(/could not be reloaded/i)).toBeTruthy();
+  });
 });
 
 describe("typing indicator", () => {
@@ -197,6 +218,57 @@ describe("read receipts", () => {
     await app.settle();
 
     expect(screen.getByTitle("Member Two")).toBeTruthy();
+  });
+});
+
+describe("realtime sync recovery", () => {
+  let readStates: Record<string, Record<string, string>> = {};
+
+  function ReadStateProbe(): React.ReactElement {
+    const { groupReadStates } = useChat();
+    useEffect(() => {
+      readStates = groupReadStates;
+    }, [groupReadStates]);
+    return <div data-testid="read-state-probe" />;
+  }
+
+  test("keeps a read receipt that arrived while a failing sync was in flight", async () => {
+    const app = await mountChatApp("/chat/room-1", { probe: <ReadStateProbe /> });
+    const target = messageId("room-1", 40);
+    expect(readStates["room-1"]?.["m-2"]).not.toBe(target);
+
+    // Reconnect with the sync held open, so the read receipt lands in the
+    // buffer rather than being applied directly.
+    const failing = __gateNextSync();
+    act(() => {
+      app.socket().disconnect();
+      app.socket().connect();
+    });
+    act(() => {
+      app.socket().serverEmit("read_update", {
+        roomId: "room-1",
+        userId: "m-2",
+        messageId: target,
+      });
+    });
+
+    // Precondition: the receipt is buffered, not applied live.
+    expect(readStates["room-1"]?.["m-2"]).not.toBe(target);
+
+    // The sync fails. New-message events are dropped because the retry
+    // re-delivers them; a read receipt never is, so it has to survive.
+    await act(async () => {
+      failing.fail();
+      await Promise.resolve();
+    });
+    await app.settle();
+
+    act(() => {
+      app.socket().connect();
+    });
+    await app.settle();
+
+    expect(readStates["room-1"]?.["m-2"]).toBe(target);
   });
 });
 

--- a/frontend/tests/mocks/api.ts
+++ b/frontend/tests/mocks/api.ts
@@ -52,6 +52,13 @@ export const __failNextRevisionCommand = (messageId: string): void => {
   conflictingMessageIds.add(messageId);
 };
 
+/** When set, the next listMessages call rejects (simulates a failed reload). */
+let failNextListMessages = false;
+
+export const __failNextListMessages = (): void => {
+  failNextListMessages = true;
+};
+
 let activeAccessToken: string | null = TEST_TOKEN;
 let settingsState: UserSettings = { ...mySettings };
 
@@ -66,6 +73,8 @@ export const __resetApiMock = (): void => {
   settingsState = { ...mySettings };
   apiCallLog.length = 0;
   conflictingMessageIds.clear();
+  failNextListMessages = false;
+  syncGate = null;
 };
 
 export const getApiBaseUrl = (): string => "http://mock-api.test";
@@ -198,6 +207,10 @@ export const listMessages = async (
   roomId: string,
   options?: { limit?: number },
 ): Promise<MessageWithSender[]> => {
+  if (failNextListMessages) {
+    failNextListMessages = false;
+    throw new ApiError("Service unavailable", 503);
+  }
   const log = messagesByRoom[roomId] ?? [];
   const limit = options?.limit ?? 50;
   // The real API returns newest-first; ChatContext reverses it back.
@@ -260,14 +273,34 @@ export const markRoomRead = async (
   return { ...membersByRoom[roomId]![0], lastReadId: messageId };
 };
 
+/**
+ * Test control over the next syncChanges call: the returned promise stays
+ * pending until the test releases it, which is the only way to emit realtime
+ * events while ChatContext still considers a sync in flight.
+ */
+let syncGate: Promise<{ failed: boolean }> | null = null;
+
+export const __gateNextSync = (): { fail: () => void; succeed: () => void } => {
+  let release!: (outcome: { failed: boolean }) => void;
+  syncGate = new Promise<{ failed: boolean }>((resolve) => { release = resolve; });
+  return {
+    fail: () => release({ failed: true }),
+    succeed: () => release({ failed: false }),
+  };
+};
+
 export const syncChanges = async (
   _token: string,
   cursor: number,
-): Promise<{ changes: []; nextCursor: number; hasMore: false }> => ({
-  changes: [],
-  nextCursor: cursor,
-  hasMore: false,
-});
+): Promise<{ changes: []; nextCursor: number; hasMore: false }> => {
+  const gate = syncGate;
+  if (gate) {
+    syncGate = null;
+    const outcome = await gate;
+    if (outcome.failed) throw new ApiError("Sync failed", 503);
+  }
+  return { changes: [], nextCursor: cursor, hasMore: false };
+};
 
 export const listFolders = async (): Promise<Folder[]> => folders;
 

--- a/frontend/tests/mocks/api.ts
+++ b/frontend/tests/mocks/api.ts
@@ -34,6 +34,24 @@ import {
   roomSummaries,
 } from "../fixtures";
 
+export class ApiError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly code?: string,
+  ) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
+
+/** Message ids whose next edit/recall must fail with a 409 revision conflict. */
+const conflictingMessageIds = new Set<string>();
+
+export const __failNextRevisionCommand = (messageId: string): void => {
+  conflictingMessageIds.add(messageId);
+};
+
 let activeAccessToken: string | null = TEST_TOKEN;
 let settingsState: UserSettings = { ...mySettings };
 
@@ -47,6 +65,7 @@ export const __resetApiMock = (): void => {
   activeAccessToken = TEST_TOKEN;
   settingsState = { ...mySettings };
   apiCallLog.length = 0;
+  conflictingMessageIds.clear();
 };
 
 export const getApiBaseUrl = (): string => "http://mock-api.test";
@@ -211,6 +230,9 @@ export const editMessage = async (
   revision: number,
 ): Promise<MessageWithSender> => {
   apiCallLog.push({ fn: "editMessage", args: [roomId, messageId, content, revision] });
+  if (conflictingMessageIds.delete(messageId)) {
+    throw new ApiError("Message revision is stale", 409);
+  }
   const existing = (messagesByRoom[roomId] ?? []).find((message) => message.messageId === messageId);
   return { ...(existing ?? messagesByRoom["room-1"]![0]), content, revision: revision + 1 };
 };
@@ -222,6 +244,9 @@ export const recallMessage = async (
   revision: number,
 ): Promise<MessageWithSender> => {
   apiCallLog.push({ fn: "recallMessage", args: [roomId, messageId, revision] });
+  if (conflictingMessageIds.delete(messageId)) {
+    throw new ApiError("Message revision is stale", 409);
+  }
   const existing = (messagesByRoom[roomId] ?? []).find((message) => message.messageId === messageId);
   return { ...(existing ?? messagesByRoom["room-1"]![0]), isRecalled: true, revision: revision + 1 };
 };


### PR DESCRIPTION
## 變更描述 (Description)

This PR refactors message creation, recall, and edit operations to use atomic Common Table Expressions (CTEs) and improves handling of revision conflicts:

### Backend Changes

**Message Repository Optimizations:**
- Consolidated multi-statement message creation into a single atomic CTE that:
  - Allocates sequence numbers from the global counter
  - Creates the message
  - Inserts mentions and claims attachments
  - Records the change snapshot in one round trip
  - Pre-fetches and validates attachments before touching the counter to minimize lock contention
  
- Refactored message recall and edit operations similarly to use atomic CTEs, reducing the critical section where the global counter row is locked

- Added `AttachmentSnapshotRow` type to represent attachment data stored inline in change snapshots

**Error Handling:**
- Modified `request()` in `api.ts` to throw `ApiError` with status code instead of generic `Error`, enabling callers to react to specific HTTP statuses (e.g., 409 revision conflicts)

**Revision Conflict Handling:**
- Added `handleRevisionConflict()` in `ChatContext` to detect 409 responses and reload affected messages from the server
- Integrated conflict handling into `handleRecallMessage()` and `handleEditMessage()` with user-facing notices
- Added `messageNoticeKey` state to display transient conflict notifications

**Emergency Alert Resilience:**
- Modified `checkInactivity()` in `userService` to isolate contact delivery failures, allowing alerts to reach other contacts even if one delivery throws
- Returns `failed` array in result to indicate contacts needing retry
- Prevents partial delivery from marking the incident complete

**Friend Service Ordering:**
- Reordered `blockUser()` to write the durable block row before revoking the room, ensuring consistency if later steps fail

**Socket.IO Session Limiting:**
- Fixed race condition in session limit enforcement by reserving slots during middleware handshake, not just at connection
- Added `reservedSessions` WeakSet to prevent double-counting in connection handler
- Properly releases reserved slots on disconnect

**Realtime Server:**
- Moved CORS configuration from Socket.IO server to engine, since `io.bind(engine)` prevents Socket.IO from seeing the handshake request
- Added explicit `draining` flag to track shutdown window, allowing `listening` to report "not accepting work" while `address()` still reports the bound port

### Frontend Changes

**Message Conflict UI:**
- Added `messageNoticeKey` state and dismiss handler for displaying revision conflict notices
- Integrated conflict detection into message edit and recall flows
- Added i18n keys for edit and recall conflict messages (English and Traditional Chinese)

**Realtime Sync Robustness:**
- Clear buffered realtime events and canonical tracking on sync failure to prevent double-counting unread messages on retry

### Tests

- Added comprehensive unit tests for `createBunRuntimeServer` covering drain window behavior and port rebinding
- Added tests for `createRealtime` CORS configuration
- Added tests for session limit enforcement with concurrent handshakes
- Added tests for emergency alert partial delivery isolation
- Added tests for `blockUser` durable-first ordering
- Added integration test for message revision conflict detection and reload

## 相關的 Issue (Related Issue)

Closes #

## 變更類型 (Type of Change)

- [x] `refactor`: 重構代碼
- [x] `fix`: 修復 Bug
- [x] `test`: 新增或修正測試案例
- [x] `perf`: 效能優化

## 驗證與測試計畫 (Verification & Test Plan)

### 本地測試 (Local Tests)

- [x] 後端型別檢查 (`docker compose exec backend pnpm exec tsc --noEmit`)
- [x] 前端型別檢查 (`docker compose exec frontend pnpm exec tsc --noEmit`)
- [x] 前端 Linter 檢查 (`docker compose exec frontend pnpm run lint`)
- [x] 單元測試 (`docker compose exec backend pnpm

https://claude.ai/code/session_016DKbCU6ru1boSkEDEQ1Kzb