### PR TITLE
feat(backend): 以 Bun.SQL 實作 migration runner，移除 node-pg-migrate 與 pg

### DIFF
--- a/.github/workflows/ci-database.yml
+++ b/.github/workflows/ci-database.yml
@@ -29,7 +29,7 @@ jobs:
           --health-timeout 5s
           --health-retries 10
     env:
-      # node-pg-migrate reads DATABASE_URL; the test helpers read
+      # The migration runner reads DATABASE_URL; the test helpers read
       # DATABASE_URL_TEST (tests/helpers/testPool.ts throws without it). Both
       # are needed — see the explicit DATABASE_URL on the migrate step below.
       DATABASE_URL_TEST: postgresql://postgres:postgres@localhost:5433/ntnu_test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ To get details on database schemas, REST APIs, or local setups, refer to the fol
 
 ### 1. Database Operations & Schema Integrity
 - Prisma has been **completely removed**. The database is accessed via raw SQL.
-- When modifying schemas, do not run arbitrary SQL manually on the DB. You must write migrations under [backend/migrations/](backend/migrations/) using `node-pg-migrate`.
+- When modifying schemas, do not run arbitrary SQL manually on the DB. You must write migrations under [backend/migrations/](backend/migrations/) as plain SQL; they are applied by the Bun runner in [backend/scripts/migrate.ts](backend/scripts/migrate.ts).
 - Refer to [docs/database-design.md](docs/database-design.md) for actual column structures, default values, and foreign keys.
 
 ### 2. API Contract Verification

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,7 @@ To ensure consistent project communications:
   CI creates a fresh database on every run and is unaffected.
 * **After the first real deployment**: `init.sql` is frozen. From that point on,
   every schema modification is an additive migration under `backend/migrations/`
-  using `node-pg-migrate`, and the baseline is never edited again. Whoever performs
+  as plain SQL applied by the Bun runner in `backend/scripts/migrate.ts`, and the baseline is never edited again. Whoever performs
   the first deployment is responsible for flipping this rule in this document.
 * **Migration Commands** (Execute inside the backend container):
   - **Create migration**: `docker compose exec backend pnpm run migrate:create <name>`

--- a/CONTRIBUTING.zh-TW.md
+++ b/CONTRIBUTING.zh-TW.md
@@ -79,7 +79,7 @@
   **不新增 migration 檔**。這讓 Schema 保持為單一份可讀的定義，而不是「基準檔 + 一疊補丁」。
   本機已有 volume 的人需執行一次 `docker compose down -v` 才會套用；CI 每次都建立全新資料庫，不受影響。
 * **首次正式部署之後**：`init.sql` 即凍結。自此每次 Schema 變更都必須是
-  `backend/migrations/` 底下以 `node-pg-migrate` 撰寫的 additive migration，基準檔不再修改。
+  `backend/migrations/` 底下的 additive SQL migration（由 `backend/scripts/migrate.ts` 這個 Bun runner 套用），基準檔不再修改。
   執行首次部署的人負責回來翻轉本文件的這條規則。
 * **Migration 相關指令**（請於後端容器內執行）：
   - **建立遷移檔**：`docker compose exec backend pnpm run migrate:create <name>`

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ A real-time group chat application built as an NTNU Database Theories course pro
 .
 ├── backend/                # Hono API backend
 │   ├── src/                # Backend TypeScript source code (routes, services, models, middlewares, realtime, utils)
-│   ├── migrations/         # PostgreSQL node-pg-migrate schema migrations
+│   ├── migrations/         # PostgreSQL schema migrations (Bun runner)
 │   └── Dockerfile          # Backend container configurations
 ├── frontend/               # Next.js frontend web app
 │   ├── app/                # React App Router pages and layouts

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -46,7 +46,7 @@
 .
 ├── backend/                # Hono API 後端服務
 │   ├── src/                # 後端 TypeScript 源碼 (routes, services, models, middlewares, realtime, utils)
-│   ├── migrations/         # PostgreSQL node-pg-migrate 遷移腳本
+│   ├── migrations/         # PostgreSQL 遷移腳本（Bun runner）
 │   └── Dockerfile          # 後端映像檔配置
 ├── frontend/               # Next.js 前端網頁應用
 │   ├── app/                # React App Router 頁面與佈局

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -13,7 +13,7 @@ This directory contains the Bun + Hono TypeScript API server for the chat applic
 | [src/index.ts](src/index.ts) | Composition Root: calls the `src/bootstrap/` factories in dependency order and launches the HTTP server. Holds wiring only — no construction logic of its own |
 | [src/bootstrap/](src/bootstrap/) | One factory per assembly stage: `config`, `repositories`, `services`, `httpApp`, `realtime`, `jobs`, `start` |
 | [src/models/db.ts](src/models/db.ts) | Exports the shared `pg.Pool` instance initialized from the `DATABASE_URL` environment variable |
-| [migrations/](migrations/) | PostgreSQL migration files written in raw SQL managed by `node-pg-migrate` |
+| [migrations/](migrations/) | PostgreSQL migration files written in raw SQL, applied by the Bun runner in [scripts/migrate.ts](scripts/migrate.ts) |
 | [package.json](package.json) | NPM scripts (`pnpm run dev` for `bun --watch`, `pnpm run test`) and dependencies |
 
 ## Subdirectories
@@ -28,7 +28,7 @@ This directory contains the Bun + Hono TypeScript API server for the chat applic
 ### 1. Database Access & Query Policies
 - Prisma has been completely removed.
 - **NEVER** use Prisma or any ORM. You must use raw SQL queries parameterized via `pool.query()` in repositories.
-- Schema modifications must be performed by creating a new migration file under `migrations/` via `pnpm run migrate:create <name>`. Refer to existing migrations to understand table names and schema patterns.
+- Schema modifications must be performed by creating a new migration file under `migrations/` via `bun run migrate:create <name>`. Refer to existing migrations to understand table names and schema patterns.
 
 ### 2. Architecture & Layering Rules
 The server strictly implements a 3-tier Hono architecture:

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,6 +8,11 @@ FROM oven/bun:1.3.14-slim
 # pnpm 11 requires `node:sqlite`, which bun does not implement, so pnpm cannot
 # execute on a bun-only image. Graft the node toolchain in rather than switching
 # the base image — bun stays the runtime and the test runner. (Approach from #419.)
+#
+# The package manager is now the ONLY reason node is here. #421 removed the
+# other one by replacing `node-pg-migrate` with a `Bun.SQL` runner, so nothing
+# the application itself runs needs node any more. This COPY can go when the
+# package manager does — see #416 for the bun-toolchain proposal.
 COPY --from=node:24-slim /usr/local/ /usr/local/
 
 RUN apt-get update -y \

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -9,6 +9,12 @@ ENV CI=true
 # pnpm 11 requires `node:sqlite`, which bun does not implement, so pnpm cannot
 # execute on a bun-only image. Graft the node toolchain in rather than switching
 # the base image — bun stays the runtime. (Approach from #419.)
+#
+# The package manager is now the ONLY reason node is here, and only in this
+# builder stage — the runner stage below has always been bun-only. #421 removed
+# the other reason by replacing `node-pg-migrate` with a `Bun.SQL` runner, so
+# the migration step the runner executes at startup no longer needs node. This
+# COPY can go when the package manager does — see #416.
 COPY --from=node:24-slim /usr/local/ /usr/local/
 RUN corepack enable pnpm && corepack prepare pnpm@11.15.0 --activate
 
@@ -26,6 +32,10 @@ COPY tsconfig.base.json ./
 COPY shared/ ./shared/
 COPY backend/tsconfig.json ./backend/
 COPY backend/src ./backend/src
+# Typechecked here as well as in CI: the runner stage runs migrate:up at
+# startup, so a type error in scripts/ would surface as a failed container boot
+# rather than a failed build.
+COPY backend/scripts ./backend/scripts
 
 WORKDIR /workspace/backend
 # `pnpm exec`, not `bun exec`: the binary lives in pnpm's

--- a/backend/eslint.config.mjs
+++ b/backend/eslint.config.mjs
@@ -3,7 +3,7 @@ import tsParser from "@typescript-eslint/parser";
 
 export default [
   {
-    files: ["src/**/*.ts"],
+    files: ["src/**/*.ts", "scripts/**/*.ts"],
     languageOptions: {
       parser: tsParser,
       parserOptions: {

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,7 +9,7 @@
     "start": "bun src/index.ts",
     "migrate:up": "bun scripts/migrate.ts up",
     "migrate:down": "bun scripts/migrate.ts down",
-    "migrate:create": "node-pg-migrate create",
+    "migrate:create": "bun scripts/migrate.ts create",
     "test": "bun test tests/unit && bun test tests/integration && bun test tests/e2e",
     "db:seed": "bun src/models/seed.ts",
     "test:unit": "bun test tests/unit",
@@ -20,15 +20,13 @@
     "test:db:up": "docker compose -f ../docker-compose.test.yml up -d --wait && pnpm run migrate:test",
     "test:db:down": "docker compose -f ../docker-compose.test.yml down",
     "migrate:test": "DATABASE_URL=postgresql://postgres:postgres@localhost:5436/ntnu_test bun scripts/migrate.ts up",
-    "lint": "eslint src && tsc --noEmit"
+    "lint": "eslint src scripts && tsc --noEmit"
   },
   "dependencies": {
     "@hono/zod-validator": "^0.9.0",
     "@socket.io/bun-engine": "^0.1.1",
     "hono": "^4.12.34",
     "hono-rate-limiter": "^0.5.3",
-    "node-pg-migrate": "^9.0.0",
-    "pg": "^8.22.0",
     "sharp": "^0.35.3",
     "socket.io": "^4.8.3",
     "zod": "^4.4.3"
@@ -36,7 +34,6 @@
   "devDependencies": {
     "@hono/node-server": "^2.0.11",
     "@types/node": "^26.1.2",
-    "@types/pg": "^8.21.0",
     "@types/supertest": "^7.2.1",
     "@typescript-eslint/eslint-plugin": "^8.65.0",
     "@typescript-eslint/parser": "^8.65.0",

--- a/backend/scripts/lib/create-migration.ts
+++ b/backend/scripts/lib/create-migration.ts
@@ -1,0 +1,86 @@
+/**
+ * Scaffolds a new migration file.
+ *
+ * This is deliberately not a like-for-like port of `node-pg-migrate create`.
+ * That command was broken for this repository in two ways, both of which only
+ * showed up after the file was written:
+ *
+ *  1. It defaulted `--migration-file-language` to `js` and wrote a `.js`
+ *     migration. Every migration here is plain SQL and the runner is now
+ *     SQL-only, so the generated file could never have been applied.
+ *  2. Its default `timestamp` prefix is `Date.now()` — about `1786…` today —
+ *     while the migrations in this repository are numbered `YYYYMMDD` plus a
+ *     five digit counter, currently `2026…`. A newly created migration
+ *     therefore sorted *before* all 24 existing ones and the next `migrate:up`
+ *     failed with "Not run migration … is preceding already run migration …".
+ *
+ * So: always `.sql`, and a prefix that continues the numbering already in use.
+ */
+import { mkdir } from "node:fs/promises";
+import { basename, join } from "node:path";
+
+import { getNumericPrefix, listMigrationFilePaths } from "./migration-files";
+
+/** The two section headers the runner splits on. */
+const TEMPLATE = "-- Up Migration\n\n-- Down Migration\n";
+
+/**
+ * Normalizes a migration name the way the previous CLI did: positional
+ * arguments are joined with dashes, and runs of spaces or underscores collapse
+ * into a single dash. `create add user index` and `create "add_user index"`
+ * both yield `add-user-index`.
+ */
+export function normalizeMigrationName(nameParts: string[]): string {
+  return nameParts.join("-").replace(/[ _]+/g, "-");
+}
+
+/**
+ * Builds a prefix that sorts after every existing migration.
+ *
+ * The base is today's `YYYYMMDD` followed by a five digit counter, matching the
+ * existing files. Should that land on or below the highest prefix already
+ * present — a migration dated today, or one dated in the future — it steps to
+ * one past the maximum instead, so the result is always strictly greatest and
+ * `migrate:up` can apply it.
+ */
+export function buildMigrationPrefix(
+  existingFileNames: string[],
+  now: Date,
+): string {
+  const year = now.getUTCFullYear();
+  const month = `${now.getUTCMonth() + 1}`.padStart(2, "0");
+  const day = `${now.getUTCDate()}`.padStart(2, "0");
+
+  const highest = existingFileNames.reduce(
+    (max, fileName) => Math.max(max, getNumericPrefix(fileName)),
+    0,
+  );
+
+  const candidate = Number(`${year}${month}${day}00000`);
+
+  return `${candidate > highest ? candidate : highest + 1}`;
+}
+
+/** Writes the template and returns the created path. */
+export async function createMigration(
+  nameParts: string[],
+  dir: string,
+  now: Date = new Date(),
+): Promise<string> {
+  const name = normalizeMigrationName(nameParts);
+
+  if (!name) {
+    throw new Error("'migrationName' is required.");
+  }
+
+  await mkdir(dir, { recursive: true });
+
+  const existing = (await listMigrationFilePaths(dir)).map((path) =>
+    basename(path),
+  );
+  const path = join(dir, `${buildMigrationPrefix(existing, now)}_${name}.sql`);
+
+  await Bun.write(path, TEMPLATE);
+
+  return path;
+}

--- a/backend/scripts/lib/migration-files.ts
+++ b/backend/scripts/lib/migration-files.ts
@@ -1,0 +1,184 @@
+/**
+ * Filesystem and parsing half of the migration runner.
+ *
+ * Everything here is pure with respect to the database, so the ordering and
+ * section-splitting rules that decide *what* runs — and in which order — can be
+ * unit tested without a PostgreSQL instance.
+ *
+ * The rules are deliberately identical to the ones `node-pg-migrate@9` applied
+ * to this repository before it was replaced. `pgmigrations` already records 24
+ * applied migrations by name on every existing environment, so any divergence
+ * in ordering or naming would make a deployed database re-run or skip work.
+ */
+import { readdir } from "node:fs/promises";
+import { basename, extname, resolve } from "node:path";
+
+/** Section markers understood inside a `.sql` migration. */
+export type MigrationDirection = "up" | "down";
+
+export interface MigrationSections {
+  /** SQL of the Up section, or the whole file when no marker is present. */
+  up: string;
+  /** SQL of the Down section; absent when the file declares no Down section. */
+  down?: string;
+}
+
+export interface MigrationFile {
+  /** Absolute path of the `.sql` file. */
+  path: string;
+  /** Name recorded in `pgmigrations` — the file name without its extension. */
+  name: string;
+  sections: MigrationSections;
+}
+
+/**
+ * Matches `-- Up Migration` / `-- Down Migration` headers, tolerating extra
+ * dashes and spacing (`--- up   migration`), case, and leading whitespace.
+ */
+function createSectionRegex(direction: MigrationDirection): RegExp {
+  return new RegExp(`^\\s*--[\\s-]*${direction}\\s+migration`, "im");
+}
+
+/**
+ * Splits a migration file into its Up and Down SQL.
+ *
+ * A file with no `Up Migration` header is treated as being entirely Up SQL,
+ * which is what lets a bare `.sql` file work without any ceremony. Each section
+ * runs to the start of the other one, so the order of the two headers in the
+ * file does not matter. Only the *first* occurrence of each header is
+ * significant — a later `-- up migration` mentioned inside the Down SQL is just
+ * text, not a second section.
+ */
+export function parseMigrationSections(content: string): MigrationSections {
+  const upStart = content.search(createSectionRegex("up"));
+  const downStart = content.search(createSectionRegex("down"));
+
+  const up =
+    upStart >= 0
+      ? content.slice(upStart, downStart < upStart ? undefined : downStart)
+      : content;
+
+  const down =
+    downStart >= 0
+      ? content.slice(downStart, upStart < downStart ? undefined : upStart)
+      : undefined;
+
+  return down === undefined ? { up } : { up, down };
+}
+
+/**
+ * Reads the leading digits of a file name as its ordering key.
+ *
+ * A 17-digit prefix is an ISO timestamp with milliseconds (`utc` filename
+ * format) and is converted to epoch milliseconds so it sorts against the
+ * 13-digit `Date.now()` prefixes this repository actually uses. Any other
+ * length is read as a plain number.
+ */
+export function getNumericPrefix(fileName: string): number {
+  const prefix = /^\d+/.exec(fileName)?.[0];
+
+  if (!prefix) {
+    throw new Error(`Cannot determine numeric prefix for "${fileName}"`);
+  }
+
+  if (prefix.length === 17) {
+    const year = prefix.slice(0, 4);
+    const month = prefix.slice(4, 6);
+    const date = prefix.slice(6, 8);
+    const hours = prefix.slice(8, 10);
+    const minutes = prefix.slice(10, 12);
+    const seconds = prefix.slice(12, 14);
+    const ms = prefix.slice(14, 17);
+
+    return new Date(
+      `${year}-${month}-${date}T${hours}:${minutes}:${seconds}.${ms}Z`,
+    ).valueOf();
+  }
+
+  return Number(prefix);
+}
+
+/**
+ * Orders two migration file names: numeric prefix first, then a numeric-aware
+ * locale comparison as the tie-breaker. Two files sharing a prefix — this
+ * repository has a pair on `2026053000000` — are therefore still totally
+ * ordered, and identically to how they were first applied.
+ */
+export function compareMigrationFileNames(a: string, b: string): number {
+  return (
+    getNumericPrefix(a) - getNumericPrefix(b) ||
+    a.localeCompare(b, undefined, {
+      usage: "sort",
+      numeric: true,
+      sensitivity: "variant",
+      ignorePunctuation: true,
+    })
+  );
+}
+
+/** The name a migration is recorded under in `pgmigrations`. */
+export function getMigrationName(filePath: string): string {
+  return basename(filePath, extname(filePath));
+}
+
+/**
+ * Lists migration files in `dir`, sorted into application order.
+ *
+ * Dotfiles are skipped, matching the previous tool's default ignore pattern.
+ * Anything else that is not `.sql` is a hard error rather than a silent skip:
+ * this runner only understands SQL, so a `.js` or `.ts` migration left in the
+ * directory would otherwise be ignored and quietly never applied.
+ */
+export async function listMigrationFilePaths(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = entries.filter(
+    (entry) =>
+      (entry.isFile() || entry.isSymbolicLink()) && !entry.name.startsWith("."),
+  );
+
+  const unsupported = files.filter(
+    (entry) => extname(entry.name).toLowerCase() !== ".sql",
+  );
+
+  if (unsupported.length > 0) {
+    throw new Error(
+      `Unsupported migration files in ${dir}: ${unsupported
+        .map((entry) => entry.name)
+        .join(", ")}\n` +
+        "This runner executes .sql migrations only. Rewrite them as SQL or " +
+        "remove them — leaving them here would silently skip them.",
+    );
+  }
+
+  return files
+    .map((entry) => entry.name)
+    .sort(compareMigrationFileNames)
+    .map((name) => resolve(dir, name));
+}
+
+/** Reads and parses every migration in `dir`, in application order. */
+export async function loadMigrationFiles(dir: string): Promise<MigrationFile[]> {
+  const paths = await listMigrationFilePaths(dir);
+
+  return Promise.all(
+    paths.map(async (path) => ({
+      path,
+      name: getMigrationName(path),
+      sections: parseMigrationSections(await Bun.file(path).text()),
+    })),
+  );
+}
+
+/**
+ * Returns the SQL to execute for one direction, or `undefined` when the section
+ * is blank.
+ *
+ * A section that is only comments is still sent — PostgreSQL accepts it as an
+ * empty query — so a migration whose Down section is documented but
+ * intentionally a no-op behaves the same as it did before.
+ */
+export function getExecutableSql(sql: string): string | undefined {
+  const trimmed = sql.trim();
+
+  return trimmed.length === 0 ? undefined : trimmed;
+}

--- a/backend/scripts/lib/migration-runner.ts
+++ b/backend/scripts/lib/migration-runner.ts
@@ -1,0 +1,309 @@
+/**
+ * Database half of the migration runner, built on `Bun.SQL`.
+ *
+ * This replaces `node-pg-migrate` (see #421). The application layer already
+ * spoke to PostgreSQL through `Bun.SQL`; the migration tool was the last thing
+ * in the backend that needed a Node runtime and the only reason `pg` and
+ * `@types/pg` were still installed.
+ *
+ * The contract with an already-migrated database is preserved exactly: same
+ * `pgmigrations` table and columns, same recorded names, same ordering, same
+ * advisory lock id, and the same all-or-nothing transaction around a run. An
+ * environment migrated by the old tool continues from where it left off without
+ * re-running or skipping anything.
+ */
+import { SQL } from "bun";
+import type { ReservedSQL } from "bun";
+
+import {
+  getExecutableSql,
+  loadMigrationFiles,
+  type MigrationDirection,
+  type MigrationFile,
+} from "./migration-files";
+
+/** Version table, schema and lock id inherited from `node-pg-migrate`. */
+export const MIGRATIONS_TABLE = "pgmigrations";
+export const MIGRATIONS_SCHEMA = "public";
+
+/**
+ * The well-known advisory lock id `node-pg-migrate` used. Keeping the same
+ * value matters during a rolling deployment: a container still running the old
+ * tool and one running this runner must contend for the *same* lock rather than
+ * migrating concurrently.
+ */
+export const ADVISORY_LOCK_ID = 7241865325823964;
+
+/** Both identifiers are compile-time constants, never user input. */
+const QUALIFIED_MIGRATIONS_TABLE = `"${MIGRATIONS_SCHEMA}"."${MIGRATIONS_TABLE}"`;
+
+export interface MigrationRunOptions {
+  databaseUrl: string;
+  direction: MigrationDirection;
+  /** Migrations directory, resolved from the current working directory. */
+  dir: string;
+  /** How many migrations to run. Defaults to all pending for `up`, 1 for `down`. */
+  count?: number;
+  /** Dumps each migration's SQL before executing it. */
+  verbose?: boolean;
+  logger?: Pick<Console, "info" | "warn" | "error">;
+}
+
+/**
+ * Creates the version table when absent.
+ *
+ * Runs before the migration transaction and is committed on its own, so a
+ * failing migration still leaves a usable (empty) version table behind — the
+ * same split the previous tool had.
+ */
+async function ensureMigrationsTable(connection: ReservedSQL): Promise<void> {
+  const tables = await connection.unsafe(
+    `SELECT table_name
+     FROM information_schema.tables
+     WHERE table_schema = $1 AND table_name = $2`,
+    [MIGRATIONS_SCHEMA, MIGRATIONS_TABLE],
+  );
+
+  if (tables.length === 0) {
+    await connection.unsafe(
+      `CREATE TABLE ${QUALIFIED_MIGRATIONS_TABLE} ` +
+        "(id SERIAL PRIMARY KEY, name varchar(255) NOT NULL, run_on timestamp NOT NULL)",
+    );
+
+    return;
+  }
+
+  // Repairs the one legacy shape the previous tool also repaired: a version
+  // table created before it added a primary key.
+  const primaryKeys = await connection.unsafe(
+    `SELECT constraint_name
+     FROM information_schema.table_constraints
+     WHERE table_schema = $1 AND table_name = $2 AND constraint_type = 'PRIMARY KEY'`,
+    [MIGRATIONS_SCHEMA, MIGRATIONS_TABLE],
+  );
+
+  if (primaryKeys.length === 0) {
+    await connection.unsafe(
+      `ALTER TABLE ${QUALIFIED_MIGRATIONS_TABLE} ADD PRIMARY KEY (id)`,
+    );
+  }
+}
+
+/** Names of already-applied migrations, oldest first. */
+async function getAppliedNames(connection: ReservedSQL): Promise<string[]> {
+  const rows = (await connection.unsafe(
+    `SELECT name FROM ${QUALIFIED_MIGRATIONS_TABLE} ORDER BY run_on, id`,
+  )) as Array<{ name: string }>;
+
+  return rows.map((row) => row.name);
+}
+
+/**
+ * Rejects a migration directory that has gained a file ordered *before* one
+ * already applied — the classic result of two branches merging with
+ * interleaved timestamps. Applying it now would produce a database whose schema
+ * depends on merge order, so the run stops instead.
+ */
+function assertConsistentOrder(
+  appliedNames: string[],
+  migrations: MigrationFile[],
+): void {
+  const shared = Math.min(appliedNames.length, migrations.length);
+
+  for (let index = 0; index < shared; index += 1) {
+    const appliedName = appliedNames[index];
+    const migrationName = migrations[index]?.name;
+
+    if (appliedName !== migrationName) {
+      throw new Error(
+        `Not run migration ${migrationName} is preceding already run migration ${appliedName}`,
+      );
+    }
+  }
+}
+
+/** Pending migrations, oldest first, capped by `count`. */
+function selectPending(
+  appliedNames: string[],
+  migrations: MigrationFile[],
+  count: number | undefined,
+): MigrationFile[] {
+  const applied = new Set(appliedNames);
+  const pending = migrations.filter(
+    (migration) => !applied.has(migration.name),
+  );
+
+  return count === undefined ? pending : pending.slice(0, Math.abs(count));
+}
+
+/** Applied migrations to revert, newest first, defaulting to a single one. */
+function selectApplied(
+  appliedNames: string[],
+  migrations: MigrationFile[],
+  count: number | undefined,
+): MigrationFile[] {
+  const byName = new Map(
+    migrations.map((migration) => [migration.name, migration]),
+  );
+
+  const targets = appliedNames.slice(-Math.abs(count ?? 1)).reverse();
+  const missing = targets.filter((name) => !byName.has(name));
+
+  if (missing.length > 0) {
+    throw new Error(
+      `Definitions of migrations ${missing.join(", ")} have been deleted.`,
+    );
+  }
+
+  return targets.map((name) => byName.get(name) as MigrationFile);
+}
+
+/**
+ * Runs one migration and records it, inside the caller's transaction.
+ *
+ * The section is sent as a single statement so PostgreSQL's simple query
+ * protocol executes the file as written — migrations here contain multiple
+ * statements, dollar-quoted function bodies and `DO` blocks, none of which
+ * survive naive statement splitting.
+ */
+async function applyMigration(
+  connection: ReservedSQL,
+  migration: MigrationFile,
+  direction: MigrationDirection,
+  options: Required<Pick<MigrationRunOptions, "verbose" | "logger">>,
+): Promise<void> {
+  const { logger, verbose } = options;
+  const section =
+    direction === "up" ? migration.sections.up : migration.sections.down;
+
+  if (section === undefined) {
+    throw new Error(
+      `User has disabled ${direction} migration on file: ${migration.name}`,
+    );
+  }
+
+  logger.info(`### MIGRATION ${migration.name} (${direction.toUpperCase()}) ###`);
+
+  const sql = getExecutableSql(section);
+
+  if (verbose && sql) {
+    logger.info(`${sql}\n`);
+  }
+
+  if (sql) {
+    await connection.unsafe(sql);
+  }
+
+  if (direction === "up") {
+    await connection.unsafe(
+      `INSERT INTO ${QUALIFIED_MIGRATIONS_TABLE} (name, run_on) VALUES ($1, NOW())`,
+      [migration.name],
+    );
+  } else {
+    await connection.unsafe(
+      `DELETE FROM ${QUALIFIED_MIGRATIONS_TABLE} WHERE name = $1`,
+      [migration.name],
+    );
+  }
+}
+
+/**
+ * Applies or reverts migrations and returns the names that ran.
+ *
+ * The whole run is one transaction, so a failure half-way leaves the schema and
+ * `pgmigrations` untouched rather than partially advanced.
+ */
+export async function runMigrations(
+  options: MigrationRunOptions,
+): Promise<string[]> {
+  const { databaseUrl, direction, dir, count } = options;
+  const logger = options.logger ?? console;
+  const verbose = options.verbose ?? false;
+
+  // A pool of one keeps every statement — including the advisory lock, which is
+  // session-scoped — on the connection `reserve()` hands back.
+  const sql = new SQL(databaseUrl, { max: 1 });
+
+  try {
+    const connection = await sql.reserve();
+
+    try {
+      const [lock] = (await connection.unsafe(
+        `SELECT pg_try_advisory_lock(${ADVISORY_LOCK_ID}) AS obtained`,
+      )) as Array<{ obtained: boolean }>;
+
+      if (!lock?.obtained) {
+        throw new Error("Another migration is already running.");
+      }
+
+      try {
+        await connection.unsafe(`SET search_path TO "${MIGRATIONS_SCHEMA}"`);
+        await ensureMigrationsTable(connection);
+
+        const migrations = await loadMigrationFiles(dir);
+        const appliedNames = await getAppliedNames(connection);
+
+        assertConsistentOrder(appliedNames, migrations);
+
+        const toRun =
+          direction === "up"
+            ? selectPending(appliedNames, migrations, count)
+            : selectApplied(appliedNames, migrations, count);
+
+        if (toRun.length === 0) {
+          logger.info("No migrations to run!");
+
+          return [];
+        }
+
+        logger.info("> Migrating files:");
+
+        for (const migration of toRun) {
+          logger.info(`> - ${migration.name}`);
+        }
+
+        await connection.unsafe("BEGIN");
+
+        let failed: MigrationFile | undefined;
+
+        try {
+          for (const migration of toRun) {
+            failed = migration;
+            await applyMigration(connection, migration, direction, {
+              logger,
+              verbose,
+            });
+          }
+
+          failed = undefined;
+          await connection.unsafe("COMMIT");
+        } catch (error) {
+          logger.warn("> Rolling back attempted migration ...");
+          await connection.unsafe("ROLLBACK");
+
+          // The driver's error says what PostgreSQL rejected but not which file
+          // it came from, and a run of two dozen migrations is one statement
+          // stream to it. Naming the file is the difference between a usable
+          // failure and a syntax error with no address.
+          throw failed === undefined
+            ? error
+            : new Error(`Migration failed: ${failed.name} (${direction})`, {
+                cause: error,
+              });
+        }
+
+        return toRun.map((migration) => migration.name);
+      } finally {
+        await connection
+          .unsafe(`SELECT pg_advisory_unlock(${ADVISORY_LOCK_ID})`)
+          .catch((error: unknown) => {
+            logger.warn(`Failed to release migration lock: ${String(error)}`);
+          });
+      }
+    } finally {
+      connection.release();
+    }
+  } finally {
+    await sql.close();
+  }
+}

--- a/backend/scripts/migrate.ts
+++ b/backend/scripts/migrate.ts
@@ -1,87 +1,116 @@
 /**
- * Migration entrypoint driven by node-pg-migrate's programmatic API.
+ * Schema migration entrypoint. Bun only — no Node, no `pg` (see #421).
  *
- * The production image is bun-only (no node, and pnpm's node_modules/.bin is
- * not on bun's PATH), so the `node-pg-migrate` CLI shim cannot run there.
- * Invoking bin/node-pg-migrate.js with bun does not work either: the CLI does
- * `await import("dotenv")` behind a try/catch that only swallows node's
- * ERR_MODULE_NOT_FOUND, while bun resolves static import specifiers ahead of
- * execution and fails the whole module when the optional package is absent —
- * which it is, because dotenv/dotenv-expand/config are not dependencies here.
+ * The backend's application layer has run on `Bun.SQL` since #403; this script
+ * was the last thing that needed a Node runtime, because `node-pg-migrate`
+ * ships a Node CLI. Its programmatic API removed the CLI dependency but not the
+ * `pg` driver underneath it, so the runner is now implemented directly against
+ * `Bun.SQL` in ./lib.
  *
- * Calling `runner()` directly sidesteps the CLI's optional imports entirely
- * and keeps one code path for dev, CI and the production container.
+ * The on-disk and in-database contracts are unchanged: same `pgmigrations`
+ * table, same recorded names, same ordering, same advisory lock. A database
+ * migrated by the previous tool continues from exactly where it left off.
  *
- * Usage: bun scripts/migrate.ts <up|down> [count]
+ * Usage:
+ *   bun scripts/migrate.ts up [count]
+ *   bun scripts/migrate.ts down [count]
+ *   bun scripts/migrate.ts create <name...>
+ *
+ * Set MIGRATE_VERBOSE=1 to dump each migration's SQL before it executes.
  */
-import { runner } from "node-pg-migrate";
+import { createMigration } from "./lib/create-migration";
+import { runMigrations } from "./lib/migration-runner";
 
-const USAGE = "Usage: bun scripts/migrate.ts <up|down> [count]";
+const USAGE =
+  "Usage:\n" +
+  "  bun scripts/migrate.ts up [count]\n" +
+  "  bun scripts/migrate.ts down [count]\n" +
+  "  bun scripts/migrate.ts create <name...>";
 
-const args = Bun.argv.slice(2);
-const [direction, countArg] = args;
+/** Resolved from the current working directory, so run this from `backend/`. */
+const MIGRATIONS_DIR = "migrations";
 
-if (direction !== "up" && direction !== "down") {
-  console.error(USAGE);
+function fail(message: string): never {
+  console.error(message);
   process.exit(1);
 }
 
-// Anything past the count is rejected rather than ignored. This entrypoint
-// deliberately implements two of the CLI's arguments and none of its flags, so
-// silently dropping the rest would turn a habitual `up 1 --dry-run` into a real
-// schema change — the CLI promises that flag only prints SQL. Failing here
-// keeps the gap visible; forward a flag explicitly if one is ever needed.
-if (args.length > 2) {
-  console.error(
-    `Unexpected argument: ${args[2]}\n` +
-      "This entrypoint accepts a direction and an optional count only — it does " +
-      "not forward node-pg-migrate CLI flags such as --dry-run.\n" +
-      USAGE,
-  );
-  process.exit(1);
-}
+// Wrapped in a function rather than using top-level await: the backend's
+// tsconfig compiles to commonjs, which does not allow it.
+async function main(): Promise<void> {
+  const [action, ...rest] = Bun.argv.slice(2);
 
-const databaseUrl = process.env.DATABASE_URL;
+  if (action === "create") {
+    try {
+      const path = await createMigration(rest, MIGRATIONS_DIR);
 
-if (!databaseUrl) {
-  console.error("The DATABASE_URL environment variable is not set.");
-  process.exit(1);
-}
-
-// Left undefined when no count is passed, which node-pg-migrate reads as
-// "every pending migration" — the same default as the CLI.
-let count: number | undefined;
-
-if (countArg !== undefined) {
-  // Digits only: `Number.parseInt` alone would read "1abc" as 1 and "--dry-run"
-  // is better reported as a bad argument than as a bad number.
-  if (!/^\d+$/.test(countArg)) {
-    console.error(`Invalid migration count: ${countArg}\n${USAGE}`);
-    process.exit(1);
+      console.log(`Created migration -- ${path}`);
+      process.exit(0);
+    } catch (error) {
+      fail(
+        `${error instanceof Error ? error.message : String(error)}\n${USAGE}`,
+      );
+    }
   }
 
-  count = Number.parseInt(countArg, 10);
+  if (action !== "up" && action !== "down") {
+    fail(USAGE);
+  }
+
+  // Anything past the count is rejected rather than ignored. This entrypoint
+  // deliberately implements a direction and an optional count and no flags, so
+  // silently dropping the rest would turn a habitual `up 1 --dry-run` into a
+  // real schema change — a flag that used to promise it only printed SQL.
+  // Failing here keeps the gap visible; add a flag explicitly if one is needed.
+  if (rest.length > 1) {
+    fail(
+      `Unexpected argument: ${rest[1]}\n` +
+        "This entrypoint accepts a direction and an optional count only — it " +
+        "does not accept flags such as --dry-run.\n" +
+        USAGE,
+    );
+  }
+
+  const [countArg] = rest;
+
+  // Left undefined when no count is passed, which the runner reads as "every
+  // pending migration" for `up` and "one migration" for `down`.
+  let count: number | undefined;
+
+  if (countArg !== undefined) {
+    // Digits only: `Number.parseInt` alone would read "1abc" as 1, and
+    // "--dry-run" is better reported as a bad argument than as a bad number.
+    if (!/^\d+$/.test(countArg)) {
+      fail(`Invalid migration count: ${countArg}\n${USAGE}`);
+    }
+
+    count = Number.parseInt(countArg, 10);
+  }
+
+  const databaseUrl = process.env.DATABASE_URL;
+
+  if (!databaseUrl) {
+    fail("The DATABASE_URL environment variable is not set.");
+  }
+
+  try {
+    await runMigrations({
+      databaseUrl,
+      direction: action,
+      dir: MIGRATIONS_DIR,
+      count,
+      verbose: process.env.MIGRATE_VERBOSE === "1",
+    });
+
+    console.log("Migrations complete!");
+    process.exit(0);
+  } catch (error) {
+    console.error(error);
+    process.exit(1);
+  }
 }
 
-// Values below mirror the CLI defaults so behaviour does not shift with this
-// entrypoint: migrations/ directory, pgmigrations table, public schema,
-// order checking on, and all pending migrations in a single transaction.
-try {
-  await runner({
-    databaseUrl: { connectionString: databaseUrl },
-    dir: "migrations",
-    direction,
-    count,
-    migrationsTable: "pgmigrations",
-    schema: ["public"],
-    checkOrder: true,
-    singleTransaction: true,
-    verbose: true,
-  });
-
-  console.log("Migrations complete!");
-  process.exit(0);
-} catch (error) {
+main().catch((error: unknown) => {
   console.error(error);
   process.exit(1);
-}
+});

--- a/backend/tests/unit/scripts/migrationFiles.test.ts
+++ b/backend/tests/unit/scripts/migrationFiles.test.ts
@@ -1,0 +1,277 @@
+import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
+import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
+import { basename } from 'node:path';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  compareMigrationFileNames,
+  getExecutableSql,
+  getMigrationName,
+  getNumericPrefix,
+  listMigrationFilePaths,
+  loadMigrationFiles,
+  parseMigrationSections,
+} from '../../../scripts/lib/migration-files';
+import {
+  buildMigrationPrefix,
+  createMigration,
+  normalizeMigrationName,
+} from '../../../scripts/lib/create-migration';
+
+/**
+ * These rules decide which migrations run and in what order, against databases
+ * that already have 24 of them recorded by name. Getting them wrong re-runs or
+ * skips schema changes on a deployed environment, so they are pinned here
+ * rather than only exercised end to end against a live database.
+ */
+describe('parseMigrationSections', () => {
+  it('splits a file on its Up and Down headers', () => {
+    const sections = parseMigrationSections(
+      '-- Up Migration\nCREATE TABLE t (a int);\n-- Down Migration\nDROP TABLE t;\n',
+    );
+
+    expect(sections.up).toContain('CREATE TABLE t (a int);');
+    expect(sections.up).not.toContain('DROP TABLE t;');
+    expect(sections.down).toContain('DROP TABLE t;');
+    expect(sections.down).not.toContain('CREATE TABLE t (a int);');
+  });
+
+  it('accepts extra dashes, casing and spacing in the headers', () => {
+    const sections = parseMigrationSections(
+      '--- up   migration\nSELECT 1;\n----DOWN\tmigration\nSELECT 2;\n',
+    );
+
+    expect(sections.up).toContain('SELECT 1;');
+    expect(sections.down).toContain('SELECT 2;');
+  });
+
+  it('splits correctly when Down comes before Up', () => {
+    const sections = parseMigrationSections(
+      '-- Down Migration\nDROP TABLE t;\n-- Up Migration\nCREATE TABLE t (a int);\n',
+    );
+
+    expect(sections.up).toContain('CREATE TABLE t (a int);');
+    expect(sections.up).not.toContain('DROP TABLE t;');
+    expect(sections.down).toContain('DROP TABLE t;');
+    expect(sections.down).not.toContain('CREATE TABLE t (a int);');
+  });
+
+  it('treats a file with no headers as entirely Up SQL', () => {
+    const sections = parseMigrationSections('CREATE TABLE t (a int);');
+
+    expect(sections.up).toBe('CREATE TABLE t (a int);');
+    expect(sections.down).toBeUndefined();
+  });
+
+  it('ignores a header mentioned again inside a section', () => {
+    // Two migrations in this repository repeat a header word in prose. Only the
+    // first occurrence of each may start a section.
+    const sections = parseMigrationSections(
+      '-- Up Migration\nSELECT 1;\n-- the up migration above is idempotent\n-- Down Migration\nSELECT 2;\n',
+    );
+
+    expect(sections.up).toContain('SELECT 1;');
+    expect(sections.up).toContain('idempotent');
+    expect(sections.down).toContain('SELECT 2;');
+    expect(sections.down).not.toContain('SELECT 1;');
+  });
+
+  it('reports no Down section when the file has none', () => {
+    const sections = parseMigrationSections('-- Up Migration\nSELECT 1;\n');
+
+    expect(sections.down).toBeUndefined();
+  });
+});
+
+describe('getNumericPrefix', () => {
+  it('reads the leading digits of a file name', () => {
+    expect(getNumericPrefix('2026081000006_enforce.sql')).toBe(2026081000006);
+    expect(getNumericPrefix('1716300000000_init.sql')).toBe(1716300000000);
+  });
+
+  it('reads a 17 digit prefix as a UTC timestamp', () => {
+    expect(getNumericPrefix('20260810123456789_x.sql')).toBe(
+      Date.UTC(2026, 7, 10, 12, 34, 56, 789),
+    );
+  });
+
+  it('rejects a file name with no numeric prefix', () => {
+    expect(() => getNumericPrefix('init.sql')).toThrow(
+      'Cannot determine numeric prefix',
+    );
+  });
+});
+
+describe('compareMigrationFileNames', () => {
+  it('orders by numeric prefix, not lexically', () => {
+    // Lexically "1716..." > "999..." would be wrong; numerically it is not.
+    expect(
+      compareMigrationFileNames('999_early.sql', '1716300000000_init.sql'),
+    ).toBeLessThan(0);
+  });
+
+  it('breaks a shared prefix by name', () => {
+    // This exact pair exists in the repository and must keep the order it was
+    // first applied in.
+    expect(
+      compareMigrationFileNames(
+        '2026053000000_create-friendships-and-blocks.sql',
+        '2026053000000_emergency_contacts.sql',
+      ),
+    ).toBeLessThan(0);
+  });
+});
+
+describe('getMigrationName', () => {
+  it('strips the extension to produce the recorded name', () => {
+    expect(getMigrationName('/a/b/2026081000006_enforce.sql')).toBe(
+      '2026081000006_enforce',
+    );
+  });
+});
+
+describe('getExecutableSql', () => {
+  it('returns trimmed SQL', () => {
+    expect(getExecutableSql('\n  SELECT 1;\n')).toBe('SELECT 1;');
+  });
+
+  it('returns undefined for a blank section', () => {
+    expect(getExecutableSql('   \n\n')).toBeUndefined();
+  });
+});
+
+describe('migration directory listing', () => {
+  let dir: string;
+
+  beforeAll(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'migration-files-'));
+  });
+
+  afterAll(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('sorts by prefix and skips dotfiles', async () => {
+    await writeFile(join(dir, '2026081000001_second.sql'), '-- Up Migration\n');
+    await writeFile(join(dir, '999_first.sql'), '-- Up Migration\n');
+    await writeFile(join(dir, '.keep'), '');
+    await mkdir(join(dir, 'nested'), { recursive: true });
+
+    const paths = await listMigrationFilePaths(dir);
+
+    expect(paths.map((path) => basename(path))).toEqual([
+      '999_first.sql',
+      '2026081000001_second.sql',
+    ]);
+  });
+
+  it('refuses to run when a non-SQL migration is present', async () => {
+    const jsPath = join(dir, '2026081000002_legacy.js');
+    await writeFile(jsPath, 'exports.up = () => {};');
+
+    // Silently skipping it would leave a migration permanently unapplied.
+    await expect(listMigrationFilePaths(dir)).rejects.toThrow(
+      'Unsupported migration files',
+    );
+
+    await rm(jsPath);
+  });
+
+  it('loads names and sections together', async () => {
+    const migrations = await loadMigrationFiles(dir);
+
+    expect(migrations.map((migration) => migration.name)).toEqual([
+      '999_first',
+      '2026081000001_second',
+    ]);
+    expect(migrations[0]?.sections.up).toContain('Up Migration');
+  });
+});
+
+describe('normalizeMigrationName', () => {
+  it('joins parts with dashes and collapses spaces and underscores', () => {
+    expect(normalizeMigrationName(['add', 'user', 'index'])).toBe(
+      'add-user-index',
+    );
+    expect(normalizeMigrationName(['add_user  index'])).toBe('add-user-index');
+  });
+
+  it('returns an empty string when no parts are given', () => {
+    expect(normalizeMigrationName([])).toBe('');
+  });
+});
+
+describe('buildMigrationPrefix', () => {
+  const existing = [
+    '1716300000000_init.sql',
+    '2026081000006_enforce_blocked_private_room_state.sql',
+  ];
+
+  it('uses todays date and sorts after every existing migration', () => {
+    const prefix = buildMigrationPrefix(existing, new Date('2026-08-11T09:00:00Z'));
+
+    expect(prefix).toBe('2026081100000');
+    expect(getNumericPrefix(prefix)).toBeGreaterThan(2026081000006);
+  });
+
+  it('steps past the highest prefix when the date collides', () => {
+    // A second migration created the same day, or a migration already dated in
+    // the future, must still sort last rather than tie or fall behind.
+    const prefix = buildMigrationPrefix(
+      [...existing, '2026081100000_first_today.sql'],
+      new Date('2026-08-11T09:00:00Z'),
+    );
+
+    expect(prefix).toBe('2026081100001');
+  });
+
+  it('steps past a future-dated migration', () => {
+    const prefix = buildMigrationPrefix(
+      [...existing, '2027010100000_from_the_future.sql'],
+      new Date('2026-08-11T09:00:00Z'),
+    );
+
+    expect(getNumericPrefix(prefix)).toBeGreaterThan(2027010100000);
+  });
+});
+
+describe('createMigration', () => {
+  let dir: string;
+
+  beforeAll(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'create-migration-'));
+  });
+
+  afterAll(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('writes a .sql template that parses into both sections', async () => {
+    const path = await createMigration(['add', 'thing'], dir);
+
+    expect(basename(path)).toMatch(/^\d+_add-thing\.sql$/);
+
+    const sections = parseMigrationSections(await Bun.file(path).text());
+
+    // Both sections must exist, and both must hold nothing but their header
+    // comment, so `up` then `down` on a freshly created migration is a no-op
+    // rather than an error. PostgreSQL accepts a comment-only query.
+    expect(sections.up).toBeDefined();
+    expect(sections.down).toBeDefined();
+
+    for (const section of [sections.up, sections.down as string]) {
+      const statements = section
+        .split('\n')
+        .filter((line) => line.trim().length > 0 && !line.trim().startsWith('--'));
+
+      expect(statements).toEqual([]);
+    }
+  });
+
+  it('requires a name', async () => {
+    await expect(createMigration([], dir)).rejects.toThrow(
+      "'migrationName' is required.",
+    );
+  });
+});

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -11,5 +11,5 @@
     "forceConsistentCasingInFileNames": true,
     "types": ["bun-types"]
   },
-  "include": ["src/**/*", "tests/**/*"]
+  "include": ["src/**/*", "tests/**/*", "scripts/**/*"]
 }

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -195,9 +195,41 @@ docker compose exec backend bun run db:seed
 
 ### Common Commands
 - **Create a new migration**: `docker compose exec backend bun run migrate:create <name>`
-- **Run migrations**: `docker compose exec backend bun run migrate:up`
-- **Rollback migrations**: `docker compose exec backend bun run migrate:down`
+- **Run migrations**: `docker compose exec backend bun run migrate:up` (optionally `migrate:up <count>`)
+- **Rollback migrations**: `docker compose exec backend bun run migrate:down` (one migration; `migrate:down <count>` for more)
 - **Seed database**: `docker compose exec backend bun run db:seed`
+
+### About the Migration Runner
+Migrations are applied by `backend/scripts/migrate.ts`, a small runner built on
+`Bun.SQL`. It replaced `node-pg-migrate` in #421 so the backend depends on Bun
+alone — no Node runtime, no `pg` driver.
+
+What it does:
+
+- Applies every `.sql` file in `backend/migrations/`, ordered by the numeric
+  prefix in the file name, and records each one by name in the `pgmigrations`
+  table. A file already recorded there is never re-applied.
+- Splits each file on its `-- Up Migration` and `-- Down Migration` headers.
+- Runs a whole invocation in **one transaction**. If any migration fails,
+  nothing from that run is committed and the error names the file that failed.
+- Takes a PostgreSQL advisory lock first, so two containers starting at once
+  cannot migrate concurrently — the second exits with
+  `Another migration is already running.`
+- Refuses to start if `backend/migrations/` contains a non-`.sql` file, rather
+  than skipping it silently.
+- Stops with `Not run migration … is preceding already run migration …` when a
+  branch merge leaves a new migration ordered before one already applied. Rename
+  the file with a higher prefix so it sorts last.
+
+The `pgmigrations` table, the recorded names, the ordering rules and the
+advisory lock id are all unchanged from `node-pg-migrate`, so databases migrated
+by the old tool continue from exactly where they left off.
+
+Set `MIGRATE_VERBOSE=1` to print each migration's SQL before it runs.
+
+Migrations are SQL only. `migrate:create` writes
+`backend/migrations/<YYYYMMDD><counter>_<name>.sql` containing both section
+headers, choosing a prefix that always sorts after the existing migrations.
 
 ### Repairing a Broken Dev Database
 If you encounter `relation ... already exists` errors during migration, or migration state goes out of sync:

--- a/docs/ZH-TW/DEVELOPMENT.md
+++ b/docs/ZH-TW/DEVELOPMENT.md
@@ -181,9 +181,36 @@ docker compose exec backend bun run db:seed
 
 ### 常見指令
 - **建立新的遷移檔**：`docker compose exec backend bun run migrate:create <name>`
-- **執行資料庫遷移**：`docker compose exec backend bun run migrate:up`
-- **回滾資料庫遷移**：`docker compose exec backend bun run migrate:down`
+- **執行資料庫遷移**：`docker compose exec backend bun run migrate:up`（可加上數量：`migrate:up <count>`）
+- **回滾資料庫遷移**：`docker compose exec backend bun run migrate:down`（預設回滾一個；`migrate:down <count>` 可指定數量）
 - **寫入種子資料**：`docker compose exec backend bun run db:seed`
+
+### 關於 Migration Runner
+遷移由 `backend/scripts/migrate.ts` 執行，這是一個以 `Bun.SQL` 實作的最小 runner。
+它在 #421 取代了 `node-pg-migrate`，讓後端只依賴 Bun — 不再需要 Node 執行環境，也不再需要 `pg` driver。
+
+它的行為：
+
+- 套用 `backend/migrations/` 底下所有 `.sql` 檔，依檔名的數字前綴排序，並將每個檔案以名稱記錄在
+  `pgmigrations` 表中。已記錄的檔案不會重複套用。
+- 依 `-- Up Migration` 與 `-- Down Migration` 標頭切分每個檔案。
+- 單次執行是**一個交易**。任何一個遷移失敗時，該次執行不會提交任何內容，
+  且錯誤訊息會指出失敗的檔案名稱。
+- 執行前先取得 PostgreSQL advisory lock，因此兩個同時啟動的容器不會並行遷移；
+  後者會以 `Another migration is already running.` 結束。
+- 若 `backend/migrations/` 中出現非 `.sql` 檔案，會直接失敗，而不是靜默略過。
+- 當分支合併導致新的遷移排在已套用的遷移之前時，會以
+  `Not run migration … is preceding already run migration …` 中止。
+  請將該檔案改名為更大的前綴，使其排在最後。
+
+`pgmigrations` 表、記錄的名稱、排序規則與 advisory lock id 都與 `node-pg-migrate` 相同，
+因此由舊工具遷移過的資料庫可以無縫接續。
+
+設定 `MIGRATE_VERBOSE=1` 可在執行前印出每個遷移的 SQL。
+
+遷移檔一律為 SQL。`migrate:create` 會產生
+`backend/migrations/<YYYYMMDD><序號>_<name>.sql`，內含兩個區段標頭，
+並自動選擇一定會排在既有遷移之後的前綴。
 
 ### 修復損壞的開發資料庫
 如果遷移過程中遇到 `relation ... already exists` 錯誤，或者遷移狀態發生混亂：

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,12 +31,6 @@ importers:
       hono-rate-limiter:
         specifier: ^0.5.3
         version: 0.5.3(hono@4.12.34)
-      node-pg-migrate:
-        specifier: ^9.0.0
-        version: 9.0.0(@types/pg@8.21.0)(pg@8.22.0)
-      pg:
-        specifier: ^8.22.0
-        version: 8.22.0
       sharp:
         specifier: ^0.35.3
         version: 0.35.3(@types/node@26.1.2)
@@ -53,9 +47,6 @@ importers:
       '@types/node':
         specifier: ^26.1.2
         version: 26.1.2
-      '@types/pg':
-        specifier: ^8.21.0
-        version: 8.21.0
       '@types/supertest':
         specifier: ^7.2.1
         version: 7.2.1
@@ -1137,9 +1128,6 @@ packages:
   '@types/node@26.1.2':
     resolution: {integrity: sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==}
 
-  '@types/pg@8.21.0':
-    resolution: {integrity: sha512-AYdtudzabjLZgVgRZmAnU8bAnVUXzuJX2IYHeSIiIHm68olD+LgQYCGWdtcNYnP0uq9c4S4NibVG3Ni7VbKW7Q==}
-
   '@types/react-dom@19.2.4':
     resolution: {integrity: sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==}
     peerDependencies:
@@ -1445,10 +1433,6 @@ packages:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
-  ansi-regex@6.2.2:
-    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
-    engines: {node: '>=12'}
-
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
@@ -1456,10 +1440,6 @@ packages:
   ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
-
-  ansi-styles@6.2.3:
-    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
-    engines: {node: '>=12'}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -1611,10 +1591,6 @@ packages:
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
-  cliui@9.0.1:
-    resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
-    engines: {node: '>=20'}
-
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
@@ -1743,9 +1719,6 @@ packages:
 
   electron-to-chromium@1.5.403:
     resolution: {integrity: sha512-MQsYmdaLzvaCX5j+ZZBr5Fm6uCCnPQcRtlvmvRlWqrXy+BH2O4ffXIAScF+JQznQWB9brWp4lSD9Z4yNmaf2BA==}
-
-  emoji-regex@10.6.0:
-    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
@@ -2049,14 +2022,6 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
-  get-caller-file@2.0.5:
-    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
-    engines: {node: 6.* || 8.* || >= 10.*}
-
-  get-east-asian-width@1.6.0:
-    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
-    engines: {node: '>=18'}
-
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -2079,10 +2044,6 @@ packages:
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
-
-  glob@13.0.6:
-    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
-    engines: {node: 18 || 20 || >=22}
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
@@ -2495,10 +2456,6 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
-  minipass@7.1.3:
-    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
-    engines: {node: '>=16 || 14 >=14.17'}
-
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -2543,17 +2500,6 @@ packages:
   node-exports-info@1.6.2:
     resolution: {integrity: sha512-kXs9Go0cah0qHVV2v389IXQLdLCeE1xfFtjOAF+iobu0OIoG1pje8At2vMHyaPMiPMnG/LWP50twML21eMcAag==}
     engines: {node: '>= 0.4'}
-
-  node-pg-migrate@9.0.0:
-    resolution: {integrity: sha512-lp5+UZx1KKgOz/y0h6BYGPuJ5wVlZTgiBPGXCGoX6Bs6X9LtiIhrI4V2yW4mPwnJBfptVq0KtLQtXHcoEKOyig==}
-    engines: {node: '>=20.11.0'}
-    hasBin: true
-    peerDependencies:
-      '@types/pg': '>=6.0.0 <9.0.0'
-      pg: '>=4.3.0 <9.0.0'
-    peerDependenciesMeta:
-      '@types/pg':
-        optional: true
 
   node-releases@2.0.53:
     resolution: {integrity: sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==}
@@ -2632,46 +2578,8 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
-  path-scurry@2.0.2:
-    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
-    engines: {node: 18 || 20 || >=22}
-
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
-
-  pg-cloudflare@1.4.0:
-    resolution: {integrity: sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==}
-
-  pg-connection-string@2.14.0:
-    resolution: {integrity: sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==}
-
-  pg-int8@1.0.1:
-    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
-    engines: {node: '>=4.0.0'}
-
-  pg-pool@3.14.0:
-    resolution: {integrity: sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==}
-    peerDependencies:
-      pg: '>=8.0'
-
-  pg-protocol@1.15.0:
-    resolution: {integrity: sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==}
-
-  pg-types@2.2.0:
-    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
-    engines: {node: '>=4'}
-
-  pg@8.22.0:
-    resolution: {integrity: sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==}
-    engines: {node: '>= 16.0.0'}
-    peerDependencies:
-      pg-native: '>=3.0.1'
-    peerDependenciesMeta:
-      pg-native:
-        optional: true
-
-  pgpass@1.0.5:
-    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -2695,22 +2603,6 @@ packages:
   postcss@8.5.25:
     resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
     engines: {node: ^10 || ^12 || >=14}
-
-  postgres-array@2.0.0:
-    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
-    engines: {node: '>=4'}
-
-  postgres-bytea@1.0.1:
-    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
-    engines: {node: '>=0.10.0'}
-
-  postgres-date@1.0.7:
-    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
-    engines: {node: '>=0.10.0'}
-
-  postgres-interval@1.2.0:
-    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
-    engines: {node: '>=0.10.0'}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -2884,10 +2776,6 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
-  split2@4.2.0:
-    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
-    engines: {node: '>= 10.x'}
-
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
@@ -2900,10 +2788,6 @@ packages:
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
-
-  string-width@7.2.0:
-    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
-    engines: {node: '>=18'}
 
   string.prototype.includes@2.0.1:
     resolution: {integrity: sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==}
@@ -2927,10 +2811,6 @@ packages:
   string.prototype.trimstart@1.0.8:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
-
-  strip-ansi@7.2.0:
-    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
-    engines: {node: '>=12'}
 
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -3221,10 +3101,6 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
-  wrap-ansi@9.0.2:
-    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
-    engines: {node: '>=18'}
-
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -3251,24 +3127,8 @@ packages:
     resolution: {integrity: sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==}
     engines: {node: '>=0.4.0'}
 
-  xtend@4.0.2:
-    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
-    engines: {node: '>=0.4'}
-
-  y18n@5.0.8:
-    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
-    engines: {node: '>=10'}
-
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
-
-  yargs-parser@22.0.0:
-    resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
-
-  yargs@18.0.0:
-    resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -4138,12 +3998,6 @@ snapshots:
     dependencies:
       undici-types: 8.3.0
 
-  '@types/pg@8.21.0':
-    dependencies:
-      '@types/node': 26.1.2
-      pg-protocol: 1.15.0
-      pg-types: 2.2.0
-
   '@types/react-dom@19.2.4(@types/react@19.2.18)':
     dependencies:
       '@types/react': 19.2.18
@@ -4481,15 +4335,11 @@ snapshots:
 
   ansi-regex@5.0.1: {}
 
-  ansi-regex@6.2.2: {}
-
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
 
   ansi-styles@5.2.0: {}
-
-  ansi-styles@6.2.3: {}
 
   argparse@2.0.1: {}
 
@@ -4659,12 +4509,6 @@ snapshots:
 
   client-only@0.0.1: {}
 
-  cliui@9.0.1:
-    dependencies:
-      string-width: 7.2.0
-      strip-ansi: 7.2.0
-      wrap-ansi: 9.0.2
-
   clsx@2.1.1: {}
 
   color-convert@2.0.1:
@@ -4786,8 +4630,6 @@ snapshots:
       gopd: 1.2.0
 
   electron-to-chromium@1.5.403: {}
-
-  emoji-regex@10.6.0: {}
 
   emoji-regex@9.2.2: {}
 
@@ -5304,10 +5146,6 @@ snapshots:
 
   gensync@1.0.0-beta.2: {}
 
-  get-caller-file@2.0.5: {}
-
-  get-east-asian-width@1.6.0: {}
-
   get-intrinsic@1.3.0:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -5343,12 +5181,6 @@ snapshots:
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
-
-  glob@13.0.6:
-    dependencies:
-      minimatch: 10.2.5
-      minipass: 7.1.3
-      path-scurry: 2.0.2
 
   globals@14.0.0: {}
 
@@ -5723,8 +5555,6 @@ snapshots:
 
   minimist@1.2.8: {}
 
-  minipass@7.1.3: {}
-
   ms@2.1.3: {}
 
   nanoid@3.3.18: {}
@@ -5766,15 +5596,6 @@ snapshots:
       es-errors: 1.3.0
       object.entries: 1.1.9
       semver: 6.3.1
-
-  node-pg-migrate@9.0.0(@types/pg@8.21.0)(pg@8.22.0):
-    dependencies:
-      glob: 13.0.6
-      jiti: 2.7.0
-      pg: 8.22.0
-      yargs: 18.0.0
-    optionalDependencies:
-      '@types/pg': 8.21.0
 
   node-releases@2.0.53: {}
 
@@ -5863,47 +5684,7 @@ snapshots:
 
   path-parse@1.0.7: {}
 
-  path-scurry@2.0.2:
-    dependencies:
-      lru-cache: 11.5.2
-      minipass: 7.1.3
-
   pathe@2.0.3: {}
-
-  pg-cloudflare@1.4.0:
-    optional: true
-
-  pg-connection-string@2.14.0: {}
-
-  pg-int8@1.0.1: {}
-
-  pg-pool@3.14.0(pg@8.22.0):
-    dependencies:
-      pg: 8.22.0
-
-  pg-protocol@1.15.0: {}
-
-  pg-types@2.2.0:
-    dependencies:
-      pg-int8: 1.0.1
-      postgres-array: 2.0.0
-      postgres-bytea: 1.0.1
-      postgres-date: 1.0.7
-      postgres-interval: 1.2.0
-
-  pg@8.22.0:
-    dependencies:
-      pg-connection-string: 2.14.0
-      pg-pool: 3.14.0(pg@8.22.0)
-      pg-protocol: 1.15.0
-      pg-types: 2.2.0
-      pgpass: 1.0.5
-    optionalDependencies:
-      pg-cloudflare: 1.4.0
-
-  pgpass@1.0.5:
-    dependencies:
-      split2: 4.2.0
 
   picocolors@1.1.1: {}
 
@@ -5920,16 +5701,6 @@ snapshots:
       nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
-
-  postgres-array@2.0.0: {}
-
-  postgres-bytea@1.0.1: {}
-
-  postgres-date@1.0.7: {}
-
-  postgres-interval@1.2.0:
-    dependencies:
-      xtend: 4.0.2
 
   prelude-ls@1.2.1: {}
 
@@ -6222,8 +5993,6 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  split2@4.2.0: {}
-
   stable-hash@0.0.5: {}
 
   stackback@0.0.2: {}
@@ -6234,12 +6003,6 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       internal-slot: 1.1.0
-
-  string-width@7.2.0:
-    dependencies:
-      emoji-regex: 10.6.0
-      get-east-asian-width: 1.6.0
-      strip-ansi: 7.2.0
 
   string.prototype.includes@2.0.1:
     dependencies:
@@ -6291,10 +6054,6 @@ snapshots:
       call-bind: 1.0.9
       define-properties: 1.2.1
       es-object-atoms: 1.1.2
-
-  strip-ansi@7.2.0:
-    dependencies:
-      ansi-regex: 6.2.2
 
   strip-bom@3.0.0: {}
 
@@ -6601,12 +6360,6 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
-  wrap-ansi@9.0.2:
-    dependencies:
-      ansi-styles: 6.2.3
-      string-width: 7.2.0
-      strip-ansi: 7.2.0
-
   wrappy@1.0.2: {}
 
   ws@8.21.0: {}
@@ -6617,22 +6370,7 @@ snapshots:
 
   xmlhttprequest-ssl@2.1.2: {}
 
-  xtend@4.0.2: {}
-
-  y18n@5.0.8: {}
-
   yallist@3.1.1: {}
-
-  yargs-parser@22.0.0: {}
-
-  yargs@18.0.0:
-    dependencies:
-      cliui: 9.0.1
-      escalade: 3.2.0
-      get-caller-file: 2.0.5
-      string-width: 7.2.0
-      y18n: 5.0.8
-      yargs-parser: 22.0.0
 
   yocto-queue@0.1.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -69,6 +69,6 @@ overrides:
   # other's major. Both lines carry GHSA-rgw5-rvv9-x895; the 1.x line also
   # carries GHSA-3jxr-9vmj-r5cp and GHSA-mh99-v99m-4gvg.
   #   1.x: eslint 9 -> minimatch@3, fixed in 1.1.18
-  #   5.x: node-pg-migrate -> glob -> minimatch@10, fixed in 5.0.9
+  #   5.x: eslint 10 / typescript-eslint -> minimatch@10, fixed in 5.0.9
   "brace-expansion@<2": "^1.1.18"
   "brace-expansion@>=5": "^5.0.9"


### PR DESCRIPTION
## 變更描述 (Description)

後端應用層自 #403 起已完全使用 `Bun.SQL`，但 schema 遷移工具鏈仍停留在 `node-pg-migrate`。這是後端最後一個需要 Node 執行環境的地方，也是 `pg` 與 `@types/pg` 仍然存在的唯一原因。

本 PR 以 `Bun.SQL` 直接實作最小 migration runner，拆為三個模組：

| 檔案 | 職責 |
|------|------|
| `backend/scripts/lib/migration-files.ts` | 檔案排序、Up/Down 區段切分等純邏輯（不碰資料庫，可單元測試） |
| `backend/scripts/lib/migration-runner.ts` | 資料庫端的套用、版本記錄、交易與 advisory lock |
| `backend/scripts/lib/create-migration.ts` | 產生新的遷移檔 |
| `backend/scripts/migrate.ts` | CLI 進入點（`up` / `down` / `create`） |

並移除 `node-pg-migrate`、`pg`、`@types/pg` 三個相依，重新產生 lockfile（減少 262 行）。

### 與既有資料庫的契約完全保留

這是本次最關鍵的約束：既有環境的 `pgmigrations` 已經以名稱記錄了 24 筆遷移，任何排序或命名上的差異都會導致重跑或漏跑。因此以下全部沿用 `node-pg-migrate@9` 的行為：

- 同一張 `pgmigrations` 表與同樣的欄位定義（`id SERIAL PRIMARY KEY, name varchar(255) NOT NULL, run_on timestamp NOT NULL`）
- 同樣的記錄名稱（檔名去除副檔名）
- 同樣的檔名排序規則（數字前綴優先，17 位數視為 UTC timestamp，相同前綴以 numeric locale compare 決勝負 — 本 repo 的 `2026053000000` 有一對同前綴檔案）
- 同樣的 `-- Up Migration` / `-- Down Migration` 區段切分正則
- 同一個 advisory lock id（`7241865325823964`）— rolling deployment 期間新舊工具才會互相搶同一把鎖
- 單次執行包在一個交易內，失敗即整批 rollback

### 行為調整（刻意不對齊舊工具的部分）

- **`migrate:create` 改為產生 `.sql` 而非 `.js`。** 舊 CLI 的 `--migration-file-language` 預設為 `js`，產出的檔案在本專案從來無法套用。
- **`migrate:create` 的檔名前綴改為 `YYYYMMDD` + 五位序號**，並保證大於既有最大前綴。舊的 `Date.now()` 前綴（今天約 `1786…`）會排在既有的 `2026…` 之前，導致下一次 `migrate:up` 直接以 `Not run migration … is preceding …` 失敗。
- **`migrations/` 出現非 `.sql` 檔案時直接失敗**，而不是靜默略過導致該遷移永遠不會被套用。
- **遷移失敗時錯誤訊息會指出失敗的檔案名稱**（driver 的錯誤只說 PostgreSQL 拒絕了什麼，不會說來自哪一個檔案）。
- **`MIGRATE_VERBOSE=1` 才印出 SQL 內容**，預設只印檔名。

### Dockerfile

`COPY --from=node:24-slim` 予以**保留**。pnpm 11 需要 `node:sqlite`，而 bun 未實作，因此 package manager 仍是移除 node 的唯一阻礙。此結論已於 `backend/Dockerfile` 與 `backend/Dockerfile.prod` 中明確記錄（可隨 #416 一併移除）。

另於 `Dockerfile.prod` 的 builder 階段加入 `COPY backend/scripts`，讓 runner 也納入 image build 的 `tsc --noEmit` — runner 階段啟動時就會執行 `migrate:up`，型別錯誤不應該等到容器啟動失敗才發現。

### 其他

- `scripts/` 納入 `tsc` 與 `eslint` 覆蓋範圍（`backend/tsconfig.json` 的 `include`、`eslint.config.mjs` 的 `files`、`lint` script）。
- 同步更新 `docs/DEVELOPMENT.md`、`docs/ZH-TW/DEVELOPMENT.md` 第 3 節，並清掉 `CLAUDE.md`、`backend/CLAUDE.md`、`README.md`、`README.zh-TW.md`、`CONTRIBUTING.md`、`CONTRIBUTING.zh-TW.md`、`.github/workflows/ci-database.yml` 與 `pnpm-workspace.yaml` 中已失效的 `node-pg-migrate` 敘述。`docs/reports/` 屬歷史報告，未修改。

## 相關的 Issue (Related Issue)

Closes #421

## 變更類型 (Type of Change)

- [x] `feat`: 新增功能 (Feature)
- [ ] `fix`: 修復 Bug
- [x] `refactor`: 重構代碼
- [x] `docs`: 修改文件
- [x] `test`: 新增或修正測試案例
- [x] `chore`: 建置流程或輔助工具變更
- [ ] `perf`: 效能優化
- [ ] `ci`: CI 設定變更

## 驗證與測試計畫 (Verification & Test Plan)

### 本地測試 (Local Tests)

- [x] 後端型別檢查（`tsc --noEmit`，現已含 `scripts/`）
- [x] 前端型別檢查（`tsc --noEmit`）
- [x] 後端 Linter 檢查（`eslint src scripts`）
- [x] 單元測試：**478/478**（含本 PR 新增的 24 個）
- [x] 整合測試：**36/36**
- [x] E2E 測試：**76/76**

整合與 E2E 測試所使用的資料庫，完全由新 runner 從零遷移而成。

### 手動測試 (Manual Verification)

在本機 PostgreSQL 16 上以 `node-pg-migrate` 建立對照資料庫，再逐項比對：

1. **乾淨資料庫的等價性**：新 runner 在乾淨資料庫上套用 24 個遷移後，`pgmigrations` 的 `id|name` 與對照組**逐列相同**，`pg_dump --schema-only` 與對照組**逐行相同**（僅 pg_dump 自己的隨機 `\restrict` nonce 不同）。
2. **雙向 interop**：以 `node-pg-migrate` 套用前 12 個、新 runner 接續其餘 12 個 → schema 與版本表與完整對照組相同；反向（新 runner `down` 一個、舊工具再 `up`）亦相同。
3. **冪等**：已套用完畢的資料庫再次 `migrate:up` → `No migrations to run!`，結束碼 0，不重複套用。
4. **交易性**：中途失敗的遷移會整批 rollback（schema 與 `pgmigrations` 皆為 0 筆），錯誤訊息指出失敗檔名。
5. **亂序偵測**：加入一個排在已套用遷移之前的檔案 → 錯誤訊息與舊工具**逐字相同**：`Not run migration … is preceding already run migration …`。
6. **Advisory lock**：兩個並行的 `migrate:up`，一個完成 24 個遷移，另一個以 `Another migration is already running.` 結束碼 1 退出。
7. **`create` 往返**：`migrate:create` 產生的檔案可直接 `up` 再 `down`，且前綴排在既有遷移之後；同日第二次 `create` 會遞增序號。
8. **相依確實移除**：`pnpm install --frozen-lockfile` 後 `backend/node_modules` 已無 `pg`，完整遷移仍成功且結果與對照組相同。

未執行：`docker compose` 相關驗證（本環境無 docker daemon，僅 `docker compose config` 通過）。

## 資料庫變更 (Database Changes)

* 此變更是否包含資料庫 Schema 修改？ **否**
* 若為是，請寫明 Migration 檔案名稱：`—`（未新增或修改任何 migration 檔）
* 是否已確認遷移與 [docs/database-design.md](../docs/database-design.md) 設計一致？ **是**（schema dump 與舊工具逐行相同）

## API 與 WebSocket 協定一致性 (API & WebSocket Contract Check)

* 此變更是否涉及 API 路由或 WebSocket 事件的資料結構變更？ **否**
* 是否已確認與 [docs/api-documentation.md](../docs/api-documentation.md) 規範完全一致？ **是**（未觸及 `src/`）

---

> [!NOTE]
> 本 PR 疊在 #551 之上（base 為 `claude/pr-542-check-failed-dr3y7r`），屬 #542 → #551 → 本 PR 這條 stack。合併順序需由下而上。

---
_Generated by [Claude Code](https://claude.ai/code/session_01DFiCLiBxtHG7WdtMPTeyqB)_