### PR TITLE
feat: 新增 users.is_admin 欄位與管理員授權中間件 (#565)

### DIFF
--- a/backend/migrations/2026081100002_add_user_is_admin.sql
+++ b/backend/migrations/2026081100002_add_user_is_admin.sql
@@ -1,0 +1,17 @@
+--- Up migration
+-- Authorization flag for the admin monitoring backend (#280). This column is
+-- the sole authority `adminMiddleware` reads; there is no environment
+-- allow-list beside it, and no HTTP endpoint sets it (`is_admin` is absent
+-- from the repository's `update` allow-list). Promotion is a deliberate DB
+-- write, documented in docs/DEVELOPMENT.md.
+--
+-- NOT NULL DEFAULT false backfills every existing row as a non-admin, so no
+-- separate backfill statement is needed and no account gains privilege by
+-- being migrated. Rolling this back drops the flags themselves, not just the
+-- column, so a re-applied migration starts from zero admins.
+ALTER TABLE users
+  ADD COLUMN is_admin BOOLEAN NOT NULL DEFAULT false;
+
+--- Down migration
+ALTER TABLE users
+  DROP COLUMN is_admin;

--- a/backend/src/bootstrap/httpApp.ts
+++ b/backend/src/bootstrap/httpApp.ts
@@ -14,6 +14,7 @@ import { makeSyncRoutes } from '../routes/syncRoutes';
 import { makeFolderRoutes } from '../routes/folderRoutes';
 import { makeAttachmentRoutes } from '../routes/attachmentRoutes';
 import { makeFriendRoutes, makeBlockRoutes, makeFriendRequestRoutes } from '../routes/friendRoutes';
+import { makeAdminRoutes } from '../routes/adminRoutes';
 import { AVATARS_UPLOAD_DIR, ensureUploadDirectories } from '../utils/uploads';
 import { avatarContentType } from '../utils/avatarUpload';
 
@@ -89,6 +90,10 @@ export const createHttpApp = ({ services, config }: CreateHttpAppDeps): Hono => 
   honoApp.route('/api/v1/friends', makeFriendRoutes(services.friend));
   honoApp.route('/api/v1/friend-requests', makeFriendRequestRoutes(services.friend));
   honoApp.route('/api/v1/blocks', makeBlockRoutes(services.friend));
+
+  // Auth and the admin gate are bound inside `makeAdminRoutes`, not here, so
+  // every route added to this namespace inherits both.
+  honoApp.route('/api/v1/admin', makeAdminRoutes());
 
   honoApp.onError(errorHandler);
 

--- a/backend/src/bootstrap/httpApp.ts
+++ b/backend/src/bootstrap/httpApp.ts
@@ -104,8 +104,9 @@ export const createHttpApp = ({ services, config }: CreateHttpAppDeps): Hono => 
   honoApp.route('/api/v1/blocks', makeBlockRoutes(services.friend));
 
   // Auth and the admin gate are bound inside `makeAdminRoutes`, not here, so
-  // every route added to this namespace inherits both.
-  honoApp.route('/api/v1/admin', makeAdminRoutes());
+  // every route added to this namespace inherits both. The gate's authorization
+  // check comes from the user service, like every other permission check.
+  honoApp.route('/api/v1/admin', makeAdminRoutes(services.user));
 
   honoApp.onError(errorHandler);
 

--- a/backend/src/middlewares/adminMiddleware.ts
+++ b/backend/src/middlewares/adminMiddleware.ts
@@ -1,30 +1,29 @@
 import type { MiddlewareHandler } from 'hono';
 import { AppError, ForbiddenError } from '../utils/AppError';
-import pool from '../models/db';
-import { UserRepository } from '../models/userRepository';
+import { logger } from '../utils/logger';
 
 /**
- * The single question this middleware asks the database.
+ * The service-layer authorization check this gate consumes.
  *
- * Injected rather than imported so tests can pass a stub: `mock.module()` is
- * process-global within a tier and cannot be undone, which is what made
- * `avatarUpload.test.ts` order-dependent (issue #467). Same
- * implementation/default-parameter split as `AvatarStore` / `defaultAvatarStore`.
+ * Structurally satisfied by `userService`, which is what the composition root
+ * injects. Declared as a one-method interface rather than importing the service
+ * type so the middleware depends on the capability it needs, and so a unit test
+ * can pass a plain object — `mock.module()` is process-global within a tier and
+ * cannot be undone, which is what made `avatarUpload.test.ts` order-dependent
+ * (issue #467).
  */
 export interface AdminChecker {
   isAdmin(userId: string): Promise<boolean>;
 }
 
-const defaultAdminChecker = (): AdminChecker => new UserRepository(pool);
-
 /**
  * Gate for `/api/v1/admin/*`, the authorization base for the admin monitoring
  * backend (#280).
  *
- * Authority is `users.is_admin`, read fresh from the database on every request.
- * The JWT is deliberately not involved: `JwtPayload` carries only `{ userId,
- * name }`, and putting the flag in the token would mean a revoked admin keeps
- * their access until the token expires.
+ * A pure HTTP adapter: it resolves the caller, asks the service layer one
+ * question, and maps the answer onto a status code. It holds no repository and
+ * opens no database handle of its own — the decision, and the freshness
+ * guarantee behind it, belong to `userService.isAdmin`.
  *
  * There is intentionally no `SYSTEM_ADMIN_EMAILS` env allow-list, which #565
  * originally proposed. `PATCH /api/v1/users/me` lets any authenticated user
@@ -35,9 +34,7 @@ const defaultAdminChecker = (): AdminChecker => new UserRepository(pool);
  * privilege escalation. Bootstrapping is a DB operation instead; see
  * docs/DEVELOPMENT.md.
  */
-export const makeAdminMiddleware = (
-  checker: AdminChecker = defaultAdminChecker(),
-): MiddlewareHandler => async (c, next) => {
+export const makeAdminMiddleware = (checker: AdminChecker): MiddlewareHandler => async (c, next) => {
   // Defence in depth against a mis-mount. `ContextVariableMap.user` is declared
   // non-optional, so TypeScript believes this is always set; if `authMiddleware`
   // did not actually run, the unchecked read would surface as a 500 rather than
@@ -48,9 +45,10 @@ export const makeAdminMiddleware = (
   }
 
   if (!(await checker.isAdmin(authUser.userId))) {
-    // The denial itself is a signal #280's monitoring backend will want. userId
-    // and path only — never the email or the token.
-    console.warn(`ADMIN DENIED: userId=${authUser.userId} path=${c.req.path}`);
+    // The denial itself is a signal #280's monitoring backend will want, and it
+    // reaches the recent-log buffer #566 added. userId and path only — never the
+    // email or the token.
+    logger.warn({ userId: authUser.userId, path: c.req.path }, 'admin access denied');
     throw new ForbiddenError();
   }
 

--- a/backend/src/middlewares/adminMiddleware.ts
+++ b/backend/src/middlewares/adminMiddleware.ts
@@ -1,0 +1,58 @@
+import type { MiddlewareHandler } from 'hono';
+import { AppError, ForbiddenError } from '../utils/AppError';
+import pool from '../models/db';
+import { UserRepository } from '../models/userRepository';
+
+/**
+ * The single question this middleware asks the database.
+ *
+ * Injected rather than imported so tests can pass a stub: `mock.module()` is
+ * process-global within a tier and cannot be undone, which is what made
+ * `avatarUpload.test.ts` order-dependent (issue #467). Same
+ * implementation/default-parameter split as `AvatarStore` / `defaultAvatarStore`.
+ */
+export interface AdminChecker {
+  isAdmin(userId: string): Promise<boolean>;
+}
+
+const defaultAdminChecker = (): AdminChecker => new UserRepository(pool);
+
+/**
+ * Gate for `/api/v1/admin/*`, the authorization base for the admin monitoring
+ * backend (#280).
+ *
+ * Authority is `users.is_admin`, read fresh from the database on every request.
+ * The JWT is deliberately not involved: `JwtPayload` carries only `{ userId,
+ * name }`, and putting the flag in the token would mean a revoked admin keeps
+ * their access until the token expires.
+ *
+ * There is intentionally no `SYSTEM_ADMIN_EMAILS` env allow-list, which #565
+ * originally proposed. `PATCH /api/v1/users/me` lets any authenticated user
+ * change their own email with only a uniqueness check — no current-password
+ * confirmation, unlike a password change — and `users.email` is a plain
+ * case-sensitive UNIQUE column, so `Ops@company.com` inserts happily next to
+ * `ops@company.com`. An email allow-list would therefore be self-service
+ * privilege escalation. Bootstrapping is a DB operation instead; see
+ * docs/DEVELOPMENT.md.
+ */
+export const makeAdminMiddleware = (
+  checker: AdminChecker = defaultAdminChecker(),
+): MiddlewareHandler => async (c, next) => {
+  // Defence in depth against a mis-mount. `ContextVariableMap.user` is declared
+  // non-optional, so TypeScript believes this is always set; if `authMiddleware`
+  // did not actually run, the unchecked read would surface as a 500 rather than
+  // the 401 the caller deserves.
+  const authUser = c.get('user');
+  if (!authUser?.userId) {
+    throw new AppError(401, 'Unauthorized: Missing authentication token');
+  }
+
+  if (!(await checker.isAdmin(authUser.userId))) {
+    // The denial itself is a signal #280's monitoring backend will want. userId
+    // and path only — never the email or the token.
+    console.warn(`ADMIN DENIED: userId=${authUser.userId} path=${c.req.path}`);
+    throw new ForbiddenError();
+  }
+
+  await next();
+};

--- a/backend/src/models/IUserRepository.ts
+++ b/backend/src/models/IUserRepository.ts
@@ -14,4 +14,15 @@ export interface IUserRepository {
   ): Promise<User>;
   delete(userId: string): Promise<void>;
   findAllWarningEnabled(): Promise<{ userId: string; lastActivity: Date; warningDays: number }[]>;
+  /**
+   * Admin flag only. Deliberately not `findById`, which is `SELECT *` and would
+   * pull `password_hash` and the `room_order` JSONB into a middleware that only
+   * needs one boolean. A missing or soft-deleted user is `false`, never a throw:
+   * the gate has to fail closed.
+   *
+   * There is no matching setter — `is_admin` is absent from `update`'s allow-list
+   * above, so the flag cannot be changed over HTTP. Promoting an admin is a
+   * deliberate DB operation; see docs/DEVELOPMENT.md.
+   */
+  isAdmin(userId: string): Promise<boolean>;
 }

--- a/backend/src/models/userRepository.ts
+++ b/backend/src/models/userRepository.ts
@@ -20,6 +20,7 @@ export interface UserRow {
   created_at: Date;
   deleted_at?: Date | null;
   room_order?: Record<string, string[]> | null;
+  is_admin: boolean;
 }
 
 function mapRowToUser(row: UserRow): User {
@@ -40,6 +41,7 @@ function mapRowToUser(row: UserRow): User {
     createdAt: row.created_at,
     deletedAt: row.deleted_at ?? null,
     roomOrder: row.room_order ?? undefined,
+    isAdmin: row.is_admin ?? false,
   };
 }
 
@@ -87,6 +89,13 @@ export class UserRepository implements IUserRepository {
       `;
     }
     return rows.map(mapRowToUser);
+  }
+
+  async isAdmin(userId: string): Promise<boolean> {
+    const rows = await this.sql<{ is_admin: boolean }[]>`
+      SELECT is_admin FROM users WHERE user_id = ${userId} AND deleted_at IS NULL
+    `;
+    return rows[0]?.is_admin === true;
   }
 
   async findAllWarningEnabled(): Promise<{ userId: string; lastActivity: Date; warningDays: number }[]> {

--- a/backend/src/routes/adminRoutes.ts
+++ b/backend/src/routes/adminRoutes.ts
@@ -15,8 +15,12 @@ import { type AdminChecker, makeAdminMiddleware } from '../middlewares/adminMidd
  * guard is reachable end to end today — Hono runs matched middleware before it
  * falls through to the not-found handler, so an empty sub-app would still
  * enforce 401/403, but nothing would prove the allowed path returns 200.
+ *
+ * `checker` is required, not defaulted: the authorization check is a service the
+ * composition root owns and hands down, so this module never reaches for a
+ * repository or a database handle of its own.
  */
-export const makeAdminRoutes = (checker?: AdminChecker) => {
+export const makeAdminRoutes = (checker: AdminChecker) => {
   const app = new Hono();
 
   app.use('*', authMiddleware);

--- a/backend/src/routes/adminRoutes.ts
+++ b/backend/src/routes/adminRoutes.ts
@@ -1,0 +1,28 @@
+import { Hono } from 'hono';
+import { authMiddleware } from '../middlewares/authMiddleware';
+import { type AdminChecker, makeAdminMiddleware } from '../middlewares/adminMiddleware';
+
+/**
+ * The `/api/v1/admin` namespace, and the only supported way to mount the admin
+ * gate.
+ *
+ * Both middlewares are bound here rather than exported for the composition root
+ * to sequence, so a future admin route cannot be added behind a half-applied
+ * guard: `httpApp` only ever writes `honoApp.route('/api/v1/admin', ...)`, the
+ * same sub-app shape already used for rooms and sync.
+ *
+ * Handlers land under #280's follow-ups (#566-#570). `GET /health` exists so the
+ * guard is reachable end to end today — Hono runs matched middleware before it
+ * falls through to the not-found handler, so an empty sub-app would still
+ * enforce 401/403, but nothing would prove the allowed path returns 200.
+ */
+export const makeAdminRoutes = (checker?: AdminChecker) => {
+  const app = new Hono();
+
+  app.use('*', authMiddleware);
+  app.use('*', makeAdminMiddleware(checker));
+
+  app.get('/health', (c) => c.json({ status: 'ok' }, 200));
+
+  return app;
+};

--- a/backend/src/services/userService.ts
+++ b/backend/src/services/userService.ts
@@ -150,6 +150,22 @@ export const makeUserService = (
   };
 
   return {
+    /**
+     * Whether the user may reach `/api/v1/admin/*`.
+     *
+     * The authorization rule lives here rather than in `adminMiddleware` so the
+     * gate goes through the same service layer as every other permission check
+     * (see backend/AGENTS.md). The middleware stays a pure HTTP adapter: it
+     * turns `false` into a 403 and knows nothing about how the answer is found.
+     *
+     * Answered from the database on every call, deliberately — not from the JWT,
+     * so revoking an admin takes effect on their next request. A missing or
+     * soft-deleted account is `false`, never a throw: the gate fails closed.
+     */
+    async isAdmin(userId: string): Promise<boolean> {
+      return repo.isAdmin(userId);
+    },
+
     async register(data: RegisterRequest): Promise<AuthResponse & { refreshToken: string }> {
       const existingUser = await repo.findByEmail(data.email);
       if (existingUser) {

--- a/backend/tests/e2e/routes/admin.e2e.test.ts
+++ b/backend/tests/e2e/routes/admin.e2e.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeAll, beforeEach } from 'bun:test';
+import request from 'supertest';
+import { resetDb } from '../../helpers/resetDb';
+import { testPool } from '../../helpers/testPool';
+
+let app: any;
+
+beforeAll(async () => {
+  process.env.DATABASE_URL = process.env.DATABASE_URL_TEST;
+  const indexModule = await import('../../../src/index');
+  app = indexModule.app;
+});
+
+const registerUser = async (email: string): Promise<{ token: string; userId: string }> => {
+  const res = await request(app).post('/api/v1/auth/register').send({
+    name: 'Admin Gate User',
+    email,
+    password: 'Password123!',
+  });
+  if (res.status !== 201) throw new Error('REGISTER FAILED: ' + JSON.stringify(res.body));
+  return { token: res.body.token, userId: res.body.user.userId };
+};
+
+/**
+ * Promotion is a direct DB write on purpose: `is_admin` is absent from the
+ * repository's `update` allow-list, so there is no HTTP path that grants it.
+ * This mirrors the documented bootstrap in docs/DEVELOPMENT.md.
+ */
+const promote = async (userId: string): Promise<void> => {
+  await testPool`UPDATE users SET is_admin = true WHERE user_id = ${userId}`;
+};
+
+describe('Admin gate E2E', () => {
+  beforeEach(async () => {
+    await resetDb();
+  });
+
+  it('rejects an unauthenticated request with 401', async () => {
+    const res = await request(app).get('/api/v1/admin/health');
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects an authenticated non-admin with 403', async () => {
+    const { token } = await registerUser('plain@example.com');
+
+    const res = await request(app)
+      .get('/api/v1/admin/health')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('FORBIDDEN');
+  });
+
+  it('allows a user whose row has is_admin = true', async () => {
+    const { token, userId } = await registerUser('admin@example.com');
+    await promote(userId);
+
+    const res = await request(app)
+      .get('/api/v1/admin/health')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'ok' });
+  });
+
+  it('newly registered accounts are not admins', async () => {
+    const { userId } = await registerUser('default@example.com');
+
+    const [row] = await testPool`SELECT is_admin FROM users WHERE user_id = ${userId}`;
+
+    expect(row.is_admin).toBe(false);
+  });
+
+  it('revoking is_admin takes effect on the very next request, without a new token', async () => {
+    const { token, userId } = await registerUser('revoked@example.com');
+    await promote(userId);
+
+    const allowed = await request(app)
+      .get('/api/v1/admin/health')
+      .set('Authorization', `Bearer ${token}`);
+    expect(allowed.status).toBe(200);
+
+    await testPool`UPDATE users SET is_admin = false WHERE user_id = ${userId}`;
+
+    const denied = await request(app)
+      .get('/api/v1/admin/health')
+      .set('Authorization', `Bearer ${token}`);
+    expect(denied.status).toBe(403);
+  });
+
+  it('does not let a soft-deleted admin through', async () => {
+    const { token, userId } = await registerUser('deleted@example.com');
+    await promote(userId);
+    await testPool`UPDATE users SET deleted_at = NOW() WHERE user_id = ${userId}`;
+
+    const res = await request(app)
+      .get('/api/v1/admin/health')
+      .set('Authorization', `Bearer ${token}`);
+
+    // authMiddleware rejects the deleted account first; the admin gate is a
+    // second, independent soft-delete filter behind it.
+    expect(res.status).toBe(401);
+  });
+});

--- a/backend/tests/unit/middlewares/adminMiddleware.test.ts
+++ b/backend/tests/unit/middlewares/adminMiddleware.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, mock } from 'bun:test';
+import type { Context } from 'hono';
+import { type AdminChecker, makeAdminMiddleware } from '../../../src/middlewares/adminMiddleware';
+import type { JwtPayload } from '@shared/types';
+
+// No `mock.module` here on purpose — it is process-global within a tier and
+// cannot be undone (see backend/tests/CLAUDE.md and issue #467). The middleware
+// takes its collaborator as a parameter, so a plain object is enough.
+const makeHonoContext = (authUser?: JwtPayload, path = '/api/v1/admin/health') => {
+  const vars = new Map<string, unknown>();
+  if (authUser) vars.set('user', authUser);
+  return {
+    req: { path },
+    set: (key: string, val: unknown) => {
+      vars.set(key, val);
+    },
+    get: (key: string) => vars.get(key),
+  } as unknown as Context;
+};
+
+const adminUser: JwtPayload = { userId: 'admin-1', name: 'Admin' };
+const plainUser: JwtPayload = { userId: 'user-1', name: 'Plain' };
+
+describe('adminMiddleware', () => {
+  let checker: AdminChecker & { isAdmin: ReturnType<typeof mock> };
+  let nextFunction: ReturnType<typeof mock>;
+
+  beforeEach(() => {
+    checker = { isAdmin: mock().mockResolvedValue(false) };
+    nextFunction = mock();
+  });
+
+  it('calls next() when the user row has is_admin = true', async () => {
+    checker.isAdmin.mockResolvedValue(true);
+    const c = makeHonoContext(adminUser);
+
+    await makeAdminMiddleware(checker)(c, nextFunction);
+
+    expect(checker.isAdmin).toHaveBeenCalledWith('admin-1');
+    expect(nextFunction).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws 403 when the user row has is_admin = false', async () => {
+    checker.isAdmin.mockResolvedValue(false);
+    const c = makeHonoContext(plainUser);
+
+    const promise = makeAdminMiddleware(checker)(c, nextFunction);
+
+    await expect(promise).rejects.toMatchObject({ statusCode: 403, code: 'FORBIDDEN' });
+    expect(nextFunction).not.toHaveBeenCalled();
+  });
+
+  it('throws 401 when authMiddleware did not run, rather than dereferencing undefined', async () => {
+    const c = makeHonoContext(undefined);
+
+    const promise = makeAdminMiddleware(checker)(c, nextFunction);
+
+    await expect(promise).rejects.toMatchObject({ statusCode: 401 });
+    expect(checker.isAdmin).not.toHaveBeenCalled();
+    expect(nextFunction).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when the account was deleted between auth and the admin check', async () => {
+    // The repository reports a missing or soft-deleted row as false, never a throw.
+    checker.isAdmin.mockResolvedValue(false);
+    const c = makeHonoContext(adminUser);
+
+    await expect(makeAdminMiddleware(checker)(c, nextFunction)).rejects.toMatchObject({
+      statusCode: 403,
+    });
+  });
+
+  it('does not leak whether the caller exists in the 403 message', async () => {
+    const c = makeHonoContext(plainUser);
+
+    await expect(makeAdminMiddleware(checker)(c, nextFunction)).rejects.toThrow('Forbidden');
+  });
+
+  it('re-reads the flag on every request so a revoked admin loses access immediately', async () => {
+    const middleware = makeAdminMiddleware(checker);
+    checker.isAdmin.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+
+    await middleware(makeHonoContext(adminUser), nextFunction);
+    await expect(middleware(makeHonoContext(adminUser), nextFunction)).rejects.toMatchObject({
+      statusCode: 403,
+    });
+
+    expect(checker.isAdmin).toHaveBeenCalledTimes(2);
+    expect(nextFunction).toHaveBeenCalledTimes(1);
+  });
+});

--- a/backend/tests/unit/models/migrateRunner.test.ts
+++ b/backend/tests/unit/models/migrateRunner.test.ts
@@ -158,6 +158,7 @@ describe('loadMigrationFiles', () => {
     '2026081000006_enforce_blocked_private_room_state',
     '2026081100000_record_noop_command_receipts',
     '2026081100001_record_emergency_alert_deliveries',
+    '2026081100002_add_user_is_admin',
   ];
 
   it('reproduces the migration order node-pg-migrate recorded', async () => {

--- a/backend/tests/unit/services/userService.test.ts
+++ b/backend/tests/unit/services/userService.test.ts
@@ -36,6 +36,7 @@ describe('userService', () => {
     lastActivity: new Date('2026-01-01T00:00:00.000Z'),
     createdAt: new Date('2026-01-01T00:00:00.000Z'),
     deletedAt: null,
+    isAdmin: false,
   });
 
   beforeEach(() => {

--- a/backend/tests/unit/services/userService.test.ts
+++ b/backend/tests/unit/services/userService.test.ts
@@ -48,6 +48,7 @@ describe('userService', () => {
       update: mock(),
       delete: mock(),
       findAllWarningEnabled: mock(),
+      isAdmin: mock(),
     };
     emergencyContactRepo = {
       findByUserId: mock(),
@@ -485,6 +486,22 @@ describe('userService', () => {
     it('keeps login schema validation intact', () => {
       expect(loginSchema.safeParse({ email: 'valid@example.com', password: 'password123' }).success).toBe(true);
       expect(loginSchema.safeParse({ email: 'invalid', password: 'password123' }).success).toBe(false);
+    });
+  });
+
+  describe('isAdmin', () => {
+    it('reports the flag the repository returns', async () => {
+      mockRepo.isAdmin.mockResolvedValue(true);
+
+      expect(await userService.isAdmin('u1')).toBe(true);
+      expect(mockRepo.isAdmin).toHaveBeenCalledWith('u1');
+    });
+
+    it('reports false for a non-admin, a missing account, or a soft-deleted one', async () => {
+      // The repository collapses all three into `false` so the gate fails closed.
+      mockRepo.isAdmin.mockResolvedValue(false);
+
+      expect(await userService.isAdmin('u1')).toBe(false);
     });
   });
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -199,6 +199,37 @@ docker compose exec backend bun run db:seed
 - **Rollback migrations**: `docker compose exec backend bun run migrate:down` (rolls back the single most recent migration; pass a count to undo more, e.g. `migrate:down 3`)
 - **Seed database**: `docker compose exec backend bun run db:seed`
 
+### Granting Admin Access
+
+`/api/v1/admin/*` is gated by the `users.is_admin` column. Every account starts
+with `is_admin = false`, including seeded ones, and there is deliberately **no
+HTTP endpoint that sets the flag** — `is_admin` is absent from the repository's
+`update` allow-list, so it cannot be reached through `PATCH /api/v1/users/me`.
+
+Promote an account with a direct database write:
+
+```bash
+docker compose exec db psql -U chatuser -d chatdb \
+  -c "UPDATE users SET is_admin = true WHERE email = 'alice@test.com';"
+```
+
+Verify the gate (a non-admin gets 403, an admin gets 200):
+
+```bash
+curl -i -s http://localhost:4005/api/v1/admin/health -H "Authorization: Bearer <token>" | head -1
+```
+
+Revoke by setting the column back to `false`; it takes effect on the caller's
+next request, because the flag is read from the database per request rather than
+carried in the JWT.
+
+There is intentionally no `SYSTEM_ADMIN_EMAILS`-style environment allow-list.
+`PATCH /api/v1/users/me` lets any authenticated user change their own email with
+only a uniqueness check — no current-password confirmation, unlike a password
+change — and `users.email` is a plain case-sensitive `UNIQUE` column, so
+`Ops@company.com` can be inserted alongside `ops@company.com`. Matching admins by
+email would therefore be self-service privilege escalation.
+
 ### About the Migration Runner
 Migrations are applied by `backend/src/models/migrate.ts`, a small runner built on
 `Bun.SQL`. It replaced `node-pg-migrate` in #421 so the backend depends on Bun

--- a/docs/ZH-TW/DEVELOPMENT.md
+++ b/docs/ZH-TW/DEVELOPMENT.md
@@ -185,6 +185,35 @@ docker compose exec backend bun run db:seed
 - **回滾資料庫遷移**：`docker compose exec backend bun run migrate:down`（預設只回滾最近一筆遷移；可加上數量回滾更多筆，例如 `migrate:down 3`）
 - **寫入種子資料**：`docker compose exec backend bun run db:seed`
 
+### 授予管理員權限
+
+`/api/v1/admin/*` 由 `users.is_admin` 欄位控管。所有帳號（含種子資料）建立時
+都是 `is_admin = false`，且刻意**不提供任何可設定此欄位的 HTTP endpoint** ——
+`is_admin` 不在 repository `update` 的允許清單內，因此無法透過
+`PATCH /api/v1/users/me` 變更。
+
+請直接以資料庫寫入提升權限：
+
+```bash
+docker compose exec db psql -U chatuser -d chatdb \
+  -c "UPDATE users SET is_admin = true WHERE email = 'alice@test.com';"
+```
+
+驗證守門機制（非管理員回 403，管理員回 200）：
+
+```bash
+curl -i -s http://localhost:4005/api/v1/admin/health -H "Authorization: Bearer <token>" | head -1
+```
+
+要撤銷權限，將欄位改回 `false` 即可；由於此旗標是每次請求都從資料庫讀取，
+而非存放於 JWT 中，因此下一個請求就會立即生效。
+
+此處刻意不提供 `SYSTEM_ADMIN_EMAILS` 這類環境變數允許清單。
+`PATCH /api/v1/users/me` 只做唯一性檢查就允許任何已登入使用者修改自己的
+email —— 不像修改密碼需要 `currentPassword` 確認 —— 且 `users.email` 是
+區分大小寫的一般 `UNIQUE` 欄位，`Ops@company.com` 可以與 `ops@company.com`
+並存。因此以 email 比對管理員等同於開放使用者自助提權。
+
 ### 關於 Migration Runner
 遷移由 `backend/src/models/migrate.ts` 執行，這是一個以 `Bun.SQL` 實作的最小 runner。
 它在 #421 取代了 `node-pg-migrate`，讓後端只依賴 Bun — 不再需要 Node 執行環境，也不再需要 `pg` driver。

--- a/docs/ZH-TW/api-documentation.md
+++ b/docs/ZH-TW/api-documentation.md
@@ -54,6 +54,7 @@
 | | `POST` | [`/users/me/emergency-contacts`](#post-usersmeemergency-contacts) | 需驗證 | 新增或更新緊急聯絡人設定 |
 | | `DELETE` | [`/users/me/emergency-contacts/:contactId`](#delete-usersmeemergency-contactscontactid) | 需驗證 | 刪除緊急聯絡人設定 |
 | | `POST` | [`/users/me/emergency-alert/check-inactivity`](#post-usersmeemergency-alertcheck-inactivity) | 需驗證 | 檢查不活躍狀態以判定是否發送警報 |
+| **管理員** | `GET` | [`/admin/health`](#get-adminhealth) | 需驗證（管理員） | 管理員守門機制後方的存活探測 |
 
 ### Socket.io 即時通訊
 
@@ -1421,6 +1422,29 @@ NEXT_PUBLIC_API_URL=http://localhost:4005
   ```
 - **回應**:
   - `200 OK`: 檢查完成。
+
+---
+
+### H. 管理員
+
+`/api/v1/admin/*` 下的所有路由都由 `makeAdminRoutes` 內綁定的兩層 middleware 守門：
+先是一般身分驗證，接著是每次請求都從資料庫讀取 `users.is_admin` 的管理員檢查。
+此旗標不放進 JWT，因此撤銷權限會在該呼叫端的下一個請求立即生效。
+沒有任何 endpoint 可以設定此旗標，初始化流程請見 `docs/DEVELOPMENT.md`。
+
+#### `GET /admin/health`
+- **說明**: 管理員命名空間的存活探測。用途是讓管理員守門機制能被端到端驗證；實際的監控 endpoint 位於 #566-#570。
+- **驗證與授權**: 需驗證，且呼叫者的 `users.is_admin` 必須為 `true`。
+- **回應**:
+  - `200 OK`: 呼叫者為管理員。
+  - `401 Unauthorized`: 缺少 token、token 無效，或帳號已刪除。
+  - `403 Forbidden`: 已驗證但非管理員（`code: "FORBIDDEN"`）。
+- **回應範例**:
+  ```json
+  {
+    "status": "ok"
+  }
+  ```
 
 ---
 

--- a/docs/ZH-TW/database-design.md
+++ b/docs/ZH-TW/database-design.md
@@ -24,6 +24,8 @@
 | `app_theme` | VARCHAR(10)| UI 主題偏好設定 | NOT NULL, 預設值: 'light', CHECK (app_theme IN ('light', 'dark')) |
 | `notify_desktop` | BOOLEAN | 是否啟用桌面通知 | NOT NULL, 預設值: TRUE |
 | `notify_sound` | BOOLEAN | 是否啟用聲音通知 | NOT NULL, 預設值: TRUE |
+| `room_order` | JSONB | 各資料夾內的聊天室排序（API 欄位：`roomOrder`） | NOT NULL, 預設值: `'{}'` |
+| `is_admin` | BOOLEAN | 是否可存取 `/api/v1/admin/*`；無法經由 HTTP 設定 | NOT NULL, 預設值: FALSE |
 
 #### `chat_rooms` (聊天室)
 | 欄位名稱 | 類型 | 說明 | 條件約束 |

--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -54,6 +54,7 @@ This document defines the RESTful API and Socket.IO real-time communication inte
 | | `POST` | [`/users/me/emergency-contacts`](#post-usersmeemergency-contacts) | Yes | Add or update emergency contact |
 | | `DELETE` | [`/users/me/emergency-contacts/:contactId`](#delete-usersmeemergency-contactscontactid) | Yes | Delete emergency contact |
 | | `POST` | [`/users/me/emergency-alert/check-inactivity`](#post-usersmeemergency-alertcheck-inactivity) | Yes | Check inactivity to trigger alert automatically |
+| **Admin** | `GET` | [`/admin/health`](#get-adminhealth) | Yes (admin) | Liveness probe behind the admin gate |
 
 ### Socket.IO Real-Time Communication
 
@@ -1422,6 +1423,30 @@ All errors return the following JSON structure:
   ```
 - **Response**:
   - `200 OK`: Check completed.
+
+---
+
+### H. Admin
+
+Every route under `/api/v1/admin/*` sits behind two middlewares bound inside
+`makeAdminRoutes`: standard authentication, then an admin check that reads
+`users.is_admin` from the database on each request. The flag is not carried in
+the JWT, so revoking it takes effect on the caller's very next request. No
+endpoint sets the flag; see `docs/DEVELOPMENT.md` for the bootstrap procedure.
+
+#### `GET /admin/health`
+- **Description**: Liveness probe for the admin namespace. Its purpose is to make the admin gate reachable end to end; the monitoring endpoints themselves land in #566-#570.
+- **Authentication & Authorization**: Authentication required, and the caller's `users.is_admin` must be `true`.
+- **Response**:
+  - `200 OK`: Caller is an admin.
+  - `401 Unauthorized`: Missing, invalid, or deleted-account token.
+  - `403 Forbidden`: Authenticated, but not an admin (`code: "FORBIDDEN"`).
+- **Response Example**:
+  ```json
+  {
+    "status": "ok"
+  }
+  ```
 
 ---
 

--- a/docs/database-design.md
+++ b/docs/database-design.md
@@ -24,6 +24,8 @@ This document defines the relational schema for the real-time group chat applica
 | `app_theme` | VARCHAR(10)| UI theme preference (API field: `theme`) | NOT NULL, DEFAULT 'light', CHECK (app_theme IN ('light', 'dark')) |
 | `notify_desktop` | BOOLEAN | Desktop notifications preference | NOT NULL, DEFAULT TRUE |
 | `notify_sound` | BOOLEAN | Sound notification preference | NOT NULL, DEFAULT TRUE |
+| `room_order` | JSONB | Per-folder room ordering (API field: `roomOrder`) | NOT NULL, DEFAULT `'{}'` |
+| `is_admin` | BOOLEAN | Grants access to `/api/v1/admin/*`; not settable over HTTP | NOT NULL, DEFAULT FALSE |
 
 #### `chat_rooms`
 | Column Name | Type | Description | Constraints |

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -34,6 +34,8 @@ export interface User {
   createdAt: Date;
   deletedAt?: Date | null;
   roomOrder?: Record<string, string[]>;
+  /** Grants access to `/api/v1/admin/*`; never included in API responses. */
+  isAdmin: boolean;
 }
 
 /** Safe public projection of a user — no credentials. */


### PR DESCRIPTION
## 變更描述 (Description)

為 #280 的管理員監控後台建立授權基礎，也就是 #568-#570 依賴的前置守門機制（#566、#567 已分別由 #578、#585 合併）：

1. **`users.is_admin` 欄位**（migration `2026081100002_add_user_is_admin.sql`）：`BOOLEAN NOT NULL DEFAULT false`，既有列一律回填為非管理員。
2. **`userService.isAdmin(userId)`**：授權判斷位於 Service 層，每次呼叫都從資料庫讀取。**未更動 `JwtPayload` 與 `signToken`**（符合 issue 的明確排除項），因此撤銷管理員權限會在下一個請求立即生效，不需等 token 刷新。
3. **`adminMiddleware`**：純 HTTP adapter，取出呼叫者、向 Service 問一個問題、把答案對應成狀態碼。
4. **`makeAdminRoutes`**：`/api/v1/admin` 命名空間，內含一個 `GET /health`。

### 兩項與 issue 原始描述不同的決定

**（一）不實作 `SYSTEM_ADMIN_EMAILS`（重要，請 reviewer 特別確認）**

Issue 原本提議可比對 `SYSTEM_ADMIN_EMAILS` 作為 fallback。本次盤點後判定**這是一條可被利用的提權路徑**，因此未實作。兩項前提都已對 `main` 驗證：

- `backend/src/services/userService.ts`：`PATCH /api/v1/users/me` 修改 email **只做唯一性檢查**，不需要 `currentPassword`；相對地，同一函式中修改密碼卻要求 `currentPassword`。也就是說任何已登入使用者都能把自己的 email 改成任意未被占用的位址。
- `backend/migrations/` 全域搜尋 `citext` 與 `lower(email)` **無任何命中**，`users.email` 是一般區分大小寫的 `UNIQUE` 欄位（`1716300000000_init.sql:10`）。因此 `Ops@company.com` 可與 `ops@company.com` 並存 —— 若允許清單改用不分大小寫比對，「管理員信箱已被註冊」這個保護就完全失效。

兩者合併的結果：以 email 比對管理員等同開放使用者自助提權（未被占用時直接改 email 命中；已被占用時用不同大小寫繞過）。

要正確修好需要為 `users.email` 建立不分大小寫的唯一性（去重 migration + `lower(email)` unique index + 正規化 `findByEmail`、`updateMe`、`register`），這是獨立且風險較高的工作，超出 #565 範圍。

**改採的做法**：`is_admin` 為唯一權威來源，初始化以資料庫寫入完成（已寫入 `docs/DEVELOPMENT.md`）。若仍需要 break-glass 機制，建議另開 issue 改用 `SYSTEM_ADMIN_USER_IDS`（`user_id` 由伺服器端 `gen_random_uuid()` 產生，且不在 `update` 允許清單內，無法被搶占）。**若 reviewer 認為仍應保留 email 允許清單，請告知，我再調整。**

**（二）本 PR 直接掛載 `/api/v1/admin` 並附一個 `GET /health`**

未掛載的 middleware 是 CI 無法端到端驗證的死碼，而 issue 的驗收標準要求「管理員回 200」，需要真實 handler 才能驗證。此 endpoint 同時成為 #569 的掛載點。

### 其他實作決定

- **授權判斷位於 Service 層**：`backend/AGENTS.md:33-39` 明文將 authorization checks 歸屬 Services，並要求不得繞過分層。因此 `userService.isAdmin` 擁有決策，composition root 於 `httpApp.ts` 注入 `services.user`，middleware 本身不持有任何 repository 或 DB handle。`AdminChecker` 維持單一方法的 interface，讓 middleware 只依賴它真正需要的能力，單元測試也能傳入單純物件，不需動用 `mock.module`（`backend/tests/CLAUDE.md` 明文禁止，見 #467）。
- **`UserRepository.isAdmin` 是獨立的窄查詢**，而非重用 `findById`：後者是 `SELECT *`，會把 `password_hash` 與 `room_order` JSONB 拉進只需要一個 boolean 的路徑。查無資料或已軟刪除一律回傳 `false`（fail closed），不拋錯。
- **`is_admin` 無法經由 HTTP 設定**：它不在 `IUserRepository.update` 的欄位允許清單內（該參數型別以 `Partial` 搭配 `Pick` 明確列舉可寫欄位），`userRepository.ts` 也是逐欄位列舉，因此 `PATCH /users/me` 無法觸及。已於介面加上註解說明，避免後人「補齊」欄位清單。
- **auth 與 admin 兩層 middleware 綁在 `makeAdminRoutes` 內**，不交由 composition root 自行排列，讓未來新增的 admin route 不可能掛在只套一半的守門後面。`adminMiddleware` 仍保留 runtime 的 401 檢查：`ContextVariableMap.user` 宣告為非 optional，若真的漏掛 `authMiddleware`，沒有這個檢查會變成 500 而非 401。
- **拒絕時經由 #566 導入的 structured logger 輸出 warn**（只含 `userId` 與 path，不含 email），使該事件會進入 recent-log buffer；這正是 #280 監控後台會需要的資料。
- Migration 檔名 `2026081100002` 是 `migrate:create` 產生器實際會選的前綴（`Math.max(Date.now(), highestPrefix + 1)`，目前 `Date.now()` 約 `1.787e12`，小於 `2026081100001`）。刻意不用手挑的未來日期：若併行分支也產生 `2026081100002`，會是**明顯的檔名衝突**，而不是靜默的排序錯誤 —— 後者會讓 `assertMigrationOrder` 在 `Dockerfile.prod` 的 CMD 中中止，導致容器無法啟動。

## 相關的 Issue (Related Issue)

Closes #565

Parent: #280 ／ 後續：#568、#569、#570

## 變更類型 (Type of Change)
請勾選適用的選項：
- [x] `feat`: 新增功能 (Feature)
- [ ] `fix`: 修復 Bug
- [ ] `refactor`: 重構代碼
- [x] `docs`: 修改文件
- [x] `test`: 新增或修正測試案例
- [ ] `chore`: 建置流程或輔助工具變更
- [ ] `perf`: 效能優化
- [ ] `ci`: CI 設定變更

## 驗證與測試計畫 (Verification & Test Plan)

本次執行環境**沒有 Docker daemon**，因此改以本機 PostgreSQL 16 建立臨時 cluster（port 5436，等同 `docker-compose.test.yml` 的 `db-test`）實際執行下列驗證。指令形式與下方勾選項等價，但不是透過 `docker compose exec` 執行。

註：專案正式目標為 PostgreSQL 18，本地驗證跑在 PG 16 上；本 migration 只用到 `ALTER TABLE ... ADD COLUMN BOOLEAN NOT NULL DEFAULT false`，在兩版行為一致（PG 11+ 皆免 table rewrite）。**GitHub Actions 的 `database / database-tests` 已在真實 PostgreSQL 18 上跑過全套後端測試並通過**，因此 PG 18 的行為已由 CI 覆蓋。

### 本地測試 (Local Tests)
- [x] 後端型別檢查 —— `bun run lint`（即 `eslint src && tsc --noEmit`）exit 0
- [x] 前端型別檢查 —— `bun x tsc --noEmit` exit 0（因本 PR 動到 `shared/types.ts`）
- [ ] 前端 Linter 檢查 —— 本地未執行（本 PR 無前端程式碼變更）；CI 的 `frontend / lint` 已通過
- [x] 單元測試 —— `bun test tests/unit`：**546 pass / 0 fail**（41 檔）
- [x] 整合測試 —— `bun test tests/integration`：**38 pass / 0 fail**（8 檔）
- [x] E2E 測試 —— `bun test tests/e2e`：**85 pass / 0 fail**（15 檔）

CI 狀態：17 項檢查全綠（含 `database / database-tests`、`backend / release compose boots on the production image`、`required-checks`）。

新增測試：
- `backend/tests/unit/middlewares/adminMiddleware.test.ts`（6 項）：allow／deny／漏掛 auth 回 401／帳號消失時 fail closed／403 訊息不洩漏帳號是否存在／逐請求重讀旗標。
- `backend/tests/unit/services/userService.test.ts` 新增 2 項：`isAdmin` 的 true／false 兩路徑。
- `backend/tests/e2e/routes/admin.e2e.test.ts`（6 項）：未帶 token 回 401／非管理員回 403（`code: "FORBIDDEN"`）／`is_admin = true` 回 200／新註冊帳號預設非管理員／撤銷後下一個請求即回 403（不需換 token）／軟刪除的管理員被擋。

同時修正兩處既有測試（新增欄位所必需）：
- `tests/unit/services/userService.test.ts`：`baseUser()` 是標註為 `User` 的物件實字，補上 `isAdmin: false`，否則 `tsc --noEmit` 會失敗。
- `tests/unit/models/migrateRunner.test.ts`：`expectedOrder` 補上新 migration（該清單註解本就寫明「Adding a migration is expected to extend this list」）。

### 手動測試 (Manual Verification)

於臨時 PostgreSQL 實際跑過完整 migration 鏈：

```
bun src/models/migrate.ts up     # 全部套用成功，含 2026081100002_add_user_is_admin
psql -c "\d users"               # is_admin | boolean | not null | false
bun src/models/migrate.ts down 1 # 乾淨回滾
psql -c "\d users"               # is_admin 已消失（grep 計數 0）
bun src/models/migrate.ts up     # 再次套用成功
```

E2E 已涵蓋 401／403／200 三條路徑，故未另行手動 curl。無前端 UI 變更。

## 資料庫變更 (Database Changes)
* 此變更是否包含資料庫 Schema 修改？ **是**
* 若為是，請寫明 Migration 檔案名稱：`backend/migrations/2026081100002_add_user_is_admin.sql`
* 是否已確認遷移與 [docs/database-design.md](../docs/database-design.md) 設計一致？ **是** —— 已在 `users` 表補上 `is_admin`（EN 與 ZH-TW 兩份）。順帶補上該表遺漏已久的 `room_order`（於 `2026061600000_add_room_order_field.sql` 新增，但文件從未同步）；這是在同一張表上順手修正的文件準確度問題，非本 issue 範圍內的行為變更。

## API 與 WebSocket 協定一致性 (API & WebSocket Contract Check)
* 此變更是否涉及 API 路由或 WebSocket 事件的資料結構變更？ **是**（新增 `GET /api/v1/admin/health`；無 WebSocket 事件變更）
* 是否已確認與 [docs/api-documentation.md](../docs/api-documentation.md) 規範完全一致？ **是** —— 已於 EN 與 ZH-TW 兩份新增「Admin／管理員」章節與總表列。

已確認 `is_admin` **不會外洩至任何 API 回應**：`userService.ts` 的 `toPublicUser`、`toUserProfile`、`toMyProfile`、`toUserSettings` 皆為 `Pick` 式投影，且 `backend/src` 全域無 user 物件展開（spread）。

## Review 後續處理

- **Codex review（P1，`adminMiddleware.ts`）**：指出 middleware 內自行 `new UserRepository(pool)` 會繞過 Service 層與 bootstrap wiring。經對 `backend/AGENTS.md:33-39` 複驗成立，已於 `c691302` 修正 —— 授權判斷移入 `userService.isAdmin`，由 composition root 注入，middleware 不再持有 repository。該 thread 已回覆並標記 resolved。
- **分支落後 `main`**：已合併 `main`（無衝突），順帶納入 #566 的 structured logger 與 #567 的 request timing。

## Advisor 重點意見

實作前經 architect sub-agent（opus）審查計畫，其提出並經我逐項對 code 複驗後採納的重點：

1. `SYSTEM_ADMIN_EMAILS` 是實際可利用的提權路徑（上述兩項前提已獨立驗證）→ 已移除該設計。
2. 不要把 `authMiddleware` 已載入的 user row 塞進 context 共用：`findById` 回傳含 `passwordHash`，而 `ContextVariableMap` 是全域 declaration merge，等於把 bcrypt hash 放進幾乎所有 route 的 request context → 維持獨立的窄查詢。
3. Migration 檔名應使用產生器實際會給的號碼，而非手挑未來日期（理由如上）→ 已從 `2026082300000` 改為 `2026081100002`。
4. `isAdmin` 設為必填欄位會使 `userService.test.ts` 的 `User` 實字編譯失敗，而 `lint` script 含 `tsc --noEmit` → 已一併修正。
5. 漏掛 `authMiddleware` 無法用型別擋下（`c.get('user')` 在 bare `MiddlewareHandler` 下為 `any`）→ 保留 runtime 檢查，並改以 sub-app 綁定使誤用在結構上不可能發生。
6. 存取控制回 403 而非偽裝 404：`/api/v1/admin` 的存在本就公開於 issue tracker，偽裝 404 需額外複雜度且無實質收益。

Generated with Claude Code (https://claude.com/claude-code)