### PR TITLE
feat: 導入 pino 結構化日誌與近期日誌緩衝 (#566)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,10 @@ DATABASE_URL=postgresql://chatuser:chatpassword@db:5432/chatdb
 PORT=4000
 JWT_SECRET=dev_secret_key
 JWT_EXPIRES_IN=15m
+# 後端結構化日誌等級：fatal / error / warn / info / debug / trace / silent。
+# 留空即為 info（測試執行時自動為 silent）。無法辨識的值會退回 info，不會讓
+# 後端在啟動時因為一個拼錯的等級而崩潰。
+# LOG_LEVEL=info
 # 關閉速率限制（開發 / 測試用，正式環境請移除）
 RATE_LIMIT_DISABLED=true
 # 後端前方有幾層「我們自己維運」的反向代理。限流會取 X-Forwarded-For 由右

--- a/backend/package.json
+++ b/backend/package.json
@@ -27,6 +27,7 @@
     "@socket.io/bun-engine": "^0.1.1",
     "hono": "^4.13.2",
     "hono-rate-limiter": "^0.5.3",
+    "pino": "^10.3.1",
     "sharp": "^0.35.3",
     "socket.io": "^4.8.3",
     "zod": "^4.4.3"
@@ -39,6 +40,7 @@
     "@typescript-eslint/parser": "^8.67.0",
     "bun-types": "^1.3.14",
     "eslint": "^10.8.0",
+    "pino-pretty": "^13.1.3",
     "socket.io-client": "^4.8.3",
     "supertest": "^7.2.2",
     "typescript": "^6.0.3"

--- a/backend/src/bootstrap/start.ts
+++ b/backend/src/bootstrap/start.ts
@@ -1,6 +1,8 @@
 import path from 'path';
+import type pino from 'pino';
 import type { AppConfig } from './config';
 import type { BunRuntimeServer } from './realtime';
+import { logger as defaultLogger } from '../utils/logger';
 
 /**
  * The running version, for the startup log line only.
@@ -23,13 +25,23 @@ const resolveVersion = async (): Promise<string> => {
 export interface StartServerDeps {
   server: BunRuntimeServer;
   config: AppConfig;
+  /** Injectable so the startup line is assertable; defaults to the shared logger. */
+  logger?: pino.Logger;
 }
 
-export const startServer = async ({ server, config }: StartServerDeps): Promise<void> => {
+export const startServer = async ({
+  server,
+  config,
+  logger = defaultLogger,
+}: StartServerDeps): Promise<void> => {
   const version = await resolveVersion();
 
   server.listen(config.port, '0.0.0.0', () =>
-    console.log(
+    // The message text is unchanged from the `console.log` this replaced, so
+    // anything tailing container logs for it keeps matching; the structured
+    // fields are additive.
+    logger.info(
+      { version, port: config.port, address: '0.0.0.0' },
       `Backend server (v${version}) successfully listening on port ${config.port} (0.0.0.0)`,
     ),
   );

--- a/backend/src/utils/logger.ts
+++ b/backend/src/utils/logger.ts
@@ -1,0 +1,292 @@
+import pino from 'pino';
+
+/**
+ * How many records the in-memory buffer keeps before it starts overwriting the
+ * oldest. Small enough to stay negligible next to the process's own footprint,
+ * large enough to cover a burst around an incident.
+ */
+export const DEFAULT_RECENT_LOG_CAPACITY = 200;
+
+/**
+ * Per-record ceiling for the buffer, in `String.length` units.
+ *
+ * The entry count alone does not bound memory: one `logger.info(hugeObject)`
+ * would park a multi-megabyte string in the ring until 200 more records push it
+ * out. Anything larger is replaced by a stand-in, so the buffer's footprint is
+ * bounded by size and not merely by record count.
+ *
+ * Measured in UTF-16 code units rather than encoded bytes: that is what a
+ * retained JS string actually costs in memory, and it avoids re-encoding every
+ * record on the logging hot path just to measure it.
+ */
+export const DEFAULT_MAX_LOG_ENTRY_CHARS = 8 * 1024;
+
+/**
+ * One structured record, as pino serialized it.
+ *
+ * `level` is pino's numeric severity (30 = info, 50 = error) and `time` an
+ * epoch-millisecond stamp. The index signature keeps whatever context the call
+ * site merged in — `logger.info({ roomId }, '...')` — without this type having
+ * to enumerate it.
+ */
+export interface RecentLogEntry {
+  level: number;
+  time: number;
+  msg?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * A bounded window over the most recent log records.
+ *
+ * This is the data source the admin `GET /api/v1/admin/logs` endpoint will read
+ * from, which is why it is an interface rather than a bare array: the endpoint
+ * only needs `recent()`, so the buffer can later be swapped for a Redis-backed,
+ * cross-process store without touching the route.
+ */
+export interface RecentLogStore {
+  /** Accepts one serialized NDJSON record, exactly as pino emits it. */
+  push(line: string): void;
+  /** The newest `limit` records, oldest first. Defaults to everything held. */
+  recent(limit?: number): RecentLogEntry[];
+  readonly capacity: number;
+  size(): number;
+}
+
+export interface CreateRecentLogStoreOptions {
+  capacity?: number;
+  maxEntryChars?: number;
+}
+
+/** Level 0 sits below pino's own `trace` (10), marking a record this layer synthesized. */
+const SYNTHETIC_LEVEL = 0;
+
+/**
+ * A fixed-size ring buffer of serialized log records.
+ *
+ * A write overwrites the oldest slot rather than appending, so a process that
+ * logs for a week still holds at most `capacity` records and this can never be
+ * the reason the backend runs out of memory. A plain array with `shift()` bounds
+ * the length too, but re-indexes the whole array on every log line.
+ *
+ * Records are kept as strings and parsed in `recent()` rather than on the way
+ * in. That keeps `JSON.parse` off the logging hot path, and — more importantly —
+ * means the buffer never retains a reference to whatever object the caller
+ * logged, which would otherwise keep that whole object graph alive for the next
+ * 200 records.
+ */
+export const createRecentLogStore = (
+  options: CreateRecentLogStoreOptions = {},
+): RecentLogStore => {
+  const { capacity = DEFAULT_RECENT_LOG_CAPACITY, maxEntryChars = DEFAULT_MAX_LOG_ENTRY_CHARS } =
+    options;
+
+  if (!Number.isInteger(capacity) || capacity <= 0) {
+    throw new RangeError(
+      `RecentLogStore capacity must be a positive integer, received ${String(capacity)}`,
+    );
+  }
+  if (!Number.isInteger(maxEntryChars) || maxEntryChars <= 0) {
+    throw new RangeError(
+      `RecentLogStore maxEntryChars must be a positive integer, received ${String(maxEntryChars)}`,
+    );
+  }
+
+  const slots: string[] = [];
+  // Counts every push ever made, not the number retained. The read path needs it
+  // to locate the oldest surviving record after wraparound.
+  let written = 0;
+
+  const size = (): number => Math.min(written, capacity);
+
+  const parse = (line: string): RecentLogEntry => {
+    try {
+      return JSON.parse(line) as RecentLogEntry;
+    } catch {
+      // Surfaced rather than dropped: a record this layer cannot parse is
+      // exactly what an operator reading /logs needs to see. `time: 0` is an
+      // honest "unknown" — the real stamp lived inside the unparsable payload.
+      return { level: SYNTHETIC_LEVEL, time: 0, msg: line };
+    }
+  };
+
+  return {
+    capacity,
+    size,
+
+    push(line: string): void {
+      const record =
+        line.length > maxEntryChars
+          ? JSON.stringify({
+              level: SYNTHETIC_LEVEL,
+              time: Date.now(),
+              msg: 'log record dropped from the recent-log buffer: too large to retain',
+              droppedChars: line.length,
+              maxEntryChars,
+            })
+          : line;
+
+      slots[written % capacity] = record;
+      written += 1;
+    },
+
+    recent(limit: number = capacity): RecentLogEntry[] {
+      const available = size();
+      const requested = Number.isFinite(limit) ? Math.max(Math.trunc(limit), 0) : available;
+      const wanted = Math.min(requested, available);
+
+      // Walk forward from the oldest retained record, so the caller gets a
+      // chronological feed and never a reference to the backing array.
+      const entries: RecentLogEntry[] = [];
+      for (let cursor = written - wanted; cursor < written; cursor += 1) {
+        entries.push(parse(slots[cursor % capacity]));
+      }
+      return entries;
+    },
+  };
+};
+
+type LogLevel = pino.LevelWithSilent;
+
+const LOG_LEVELS: readonly string[] = [
+  'fatal',
+  'error',
+  'warn',
+  'info',
+  'debug',
+  'trace',
+  'silent',
+];
+
+/**
+ * `LOG_LEVEL` wins when it names a real level.
+ *
+ * An unrecognised value falls back instead of reaching pino, which throws on an
+ * unknown level — a typo in a deployment's environment would otherwise take the
+ * process down at import time, since this module builds a logger eagerly.
+ * Tests default to `silent` so `bun test` output stays readable; the logger's
+ * own tests pass an explicit level rather than relying on this.
+ */
+export const resolveLogLevel = (env: NodeJS.ProcessEnv = process.env): LogLevel => {
+  const requested = env.LOG_LEVEL?.trim().toLowerCase();
+  if (requested && LOG_LEVELS.includes(requested)) return requested as LogLevel;
+  if (env.NODE_ENV === 'test') return 'silent';
+  return 'info';
+};
+
+/**
+ * Pretty output is opt-in by exact environment name, never "anything that is not
+ * production".
+ *
+ * docker-compose.prod.yml passes `NODE_ENV=${NODE_ENV}`, and Compose turns an
+ * unset variable into the empty string — which *overrides* the image's
+ * `ENV NODE_ENV=production`. A `!== 'production'` test would then select the
+ * pretty path in production, where `pino-pretty` is not installed. Same class of
+ * Compose interpolation trap as the `TRUST_PROXY_HOPS` note in .env.example.
+ */
+export const shouldPrettyPrint = (env: NodeJS.ProcessEnv = process.env): boolean =>
+  env.NODE_ENV === 'development';
+
+type PrettyStreamFactory = (options: Record<string, unknown>) => NodeJS.WritableStream;
+
+/**
+ * The human-facing half of the output.
+ *
+ * `pino-pretty` is a devDependency and the production image installs with
+ * `--prod` (backend/Dockerfile.prod), so it is required lazily and its absence
+ * falls back to raw JSON — which is what production wants anyway. A static
+ * import would turn that missing devDependency into a boot crash.
+ */
+const createStdoutStream = (pretty: boolean): NodeJS.WritableStream => {
+  if (!pretty) return process.stdout;
+
+  try {
+    const prettyFactory = require('pino-pretty') as PrettyStreamFactory;
+    return prettyFactory({ colorize: true, translateTime: 'SYS:standard', ignore: 'pid,hostname' });
+  } catch {
+    return process.stdout;
+  }
+};
+
+/**
+ * Fields scrubbed before a record is written anywhere.
+ *
+ * The recent-log buffer is about to be served over HTTP by the admin `/logs`
+ * endpoint, so a credential that reaches a log line becomes a credential an
+ * endpoint hands out. `describeDatabaseTarget.ts` exists for the same reason on
+ * the connection-string path; this is the general case.
+ */
+const REDACTED_PATHS = [
+  'password',
+  'newPassword',
+  'currentPassword',
+  'token',
+  'accessToken',
+  'refreshToken',
+  'connectionString',
+  'req.headers.authorization',
+  'req.headers.cookie',
+  'headers.authorization',
+  'headers.cookie',
+];
+
+export interface CreateLoggerOptions {
+  level?: LogLevel;
+  pretty?: boolean;
+  store?: RecentLogStore;
+  /** Overrides the human-facing destination. Tests use it to stay quiet. */
+  stdout?: NodeJS.WritableStream;
+}
+
+/**
+ * The process-wide buffer of recent records.
+ *
+ * Exported separately so the future admin route can read the window without
+ * importing the logger that feeds it.
+ */
+export const recentLogs: RecentLogStore = createRecentLogStore();
+
+/**
+ * Build a logger that writes every record to stdout and to a recent-log buffer.
+ *
+ * The destination is a plain tee rather than `pino.multistream`, for two
+ * reasons. Multistream applies a *second*, per-stream level filter that
+ * defaults to `info`, so a logger built at `debug` silently drops every debug
+ * record at both destinations unless each entry re-declares the level — a trap
+ * with no upside here, since both destinations always want the same records.
+ * And the buffer has to live in this process for the admin route to read it,
+ * which rules out the other option, a `pino.transport` worker thread.
+ *
+ * pino calls `write()` once per record with one complete newline-terminated
+ * line, so no reassembly is needed; only the trailing newline is trimmed.
+ */
+export const createLogger = (options: CreateLoggerOptions = {}): pino.Logger => {
+  const {
+    level = resolveLogLevel(),
+    pretty = shouldPrettyPrint(),
+    store = recentLogs,
+    stdout,
+  } = options;
+
+  const humanReadable = stdout ?? createStdoutStream(pretty);
+
+  const destination = {
+    write(line: string): void {
+      humanReadable.write(line);
+      // pino invokes this synchronously from inside logger.info(); a throw here
+      // would turn a log statement into an application error, so the buffer must
+      // never be able to fail the caller.
+      try {
+        store.push(line.endsWith('\n') ? line.slice(0, -1) : line);
+      } catch {
+        // Losing a buffered record is strictly better than losing the request.
+      }
+    },
+  };
+
+  return pino({ level, redact: { paths: REDACTED_PATHS, censor: '[redacted]' } }, destination);
+};
+
+export const logger: pino.Logger = createLogger();
+
+export default logger;

--- a/backend/tests/unit/utils/logger.test.ts
+++ b/backend/tests/unit/utils/logger.test.ts
@@ -1,0 +1,316 @@
+import { describe, it, expect } from 'bun:test';
+import { Writable } from 'node:stream';
+import {
+  DEFAULT_RECENT_LOG_CAPACITY,
+  createLogger,
+  createRecentLogStore,
+  resolveLogLevel,
+  shouldPrettyPrint,
+  type RecentLogStore,
+} from '../../../src/utils/logger';
+
+/**
+ * Stands in for stdout so the logger under test writes into an array instead of
+ * the test runner's output.
+ */
+const createCapturingStream = () => {
+  const lines: string[] = [];
+  const stream = new Writable({
+    write(chunk, _encoding, callback) {
+      lines.push(String(chunk));
+      callback();
+    },
+  });
+  return { stream, lines };
+};
+
+/** `n` serialized records, numbered so ordering and eviction are checkable. */
+const pushRecords = (store: RecentLogStore, from: number, to: number): void => {
+  for (let n = from; n <= to; n += 1) {
+    store.push(JSON.stringify({ level: 30, time: 1_700_000_000_000 + n, msg: `record-${n}` }));
+  }
+};
+
+const messages = (store: RecentLogStore, limit?: number): (string | undefined)[] =>
+  store.recent(limit).map((entry) => entry.msg);
+
+describe('createRecentLogStore', () => {
+  it('rejects a capacity that could not bound anything', () => {
+    for (const capacity of [0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(() => createRecentLogStore({ capacity })).toThrow(RangeError);
+    }
+  });
+
+  it('rejects a non-positive-integer maxEntryChars', () => {
+    for (const maxEntryChars of [0, -1, 2.5, Number.NaN]) {
+      expect(() => createRecentLogStore({ maxEntryChars })).toThrow(RangeError);
+    }
+  });
+
+  it('returns nothing when empty', () => {
+    const store = createRecentLogStore({ capacity: 3 });
+    expect(store.recent()).toEqual([]);
+    expect(store.size()).toBe(0);
+    expect(store.capacity).toBe(3);
+  });
+
+  it('keeps every record while below capacity, oldest first', () => {
+    const store = createRecentLogStore({ capacity: 5 });
+    pushRecords(store, 1, 3);
+
+    expect(store.size()).toBe(3);
+    expect(messages(store)).toEqual(['record-1', 'record-2', 'record-3']);
+  });
+
+  it('keeps exactly the newest N once capacity is reached and then exceeded', () => {
+    const store = createRecentLogStore({ capacity: 3 });
+
+    pushRecords(store, 1, 3);
+    expect(messages(store)).toEqual(['record-1', 'record-2', 'record-3']);
+
+    // One past capacity evicts exactly one record: the oldest.
+    pushRecords(store, 4, 4);
+    expect(store.size()).toBe(3);
+    expect(messages(store)).toEqual(['record-2', 'record-3', 'record-4']);
+  });
+
+  it('stays ordered after several wraparound laps that do not land on a multiple of capacity', () => {
+    // 17 writes over a capacity of 5 is three full laps plus two — ordering bugs
+    // in the modulo read path survive lap one and exact multiples, not this.
+    const store = createRecentLogStore({ capacity: 5 });
+    pushRecords(store, 1, 17);
+
+    expect(store.size()).toBe(5);
+    expect(messages(store)).toEqual([
+      'record-13',
+      'record-14',
+      'record-15',
+      'record-16',
+      'record-17',
+    ]);
+  });
+
+  it('does not grow unbounded: 10x capacity of writes still yields only the newest capacity records', () => {
+    const capacity = DEFAULT_RECENT_LOG_CAPACITY;
+    const store = createRecentLogStore({ capacity });
+    const total = capacity * 10;
+
+    pushRecords(store, 1, total);
+
+    const entries = store.recent();
+    expect(entries).toHaveLength(capacity);
+    expect(store.size()).toBe(capacity);
+    // The window is the last `capacity` records, in order...
+    expect(entries[0].msg).toBe(`record-${total - capacity + 1}`);
+    expect(entries[entries.length - 1].msg).toBe(`record-${total}`);
+    // ...and the very first record is provably gone.
+    expect(entries.some((entry) => entry.msg === 'record-1')).toBe(false);
+  });
+
+  it('never reports a size above its capacity', () => {
+    const store = createRecentLogStore({ capacity: 4 });
+    for (let n = 1; n <= 40; n += 1) {
+      pushRecords(store, n, n);
+      expect(store.size()).toBeLessThanOrEqual(4);
+    }
+    expect(store.size()).toBe(4);
+  });
+
+  it('honours a limit smaller than, equal to, and larger than what it holds', () => {
+    const store = createRecentLogStore({ capacity: 5 });
+    pushRecords(store, 1, 5);
+
+    expect(messages(store, 2)).toEqual(['record-4', 'record-5']);
+    expect(messages(store, 5)).toEqual(['record-1', 'record-2', 'record-3', 'record-4', 'record-5']);
+    // Asking for more than exists yields what exists rather than padding.
+    expect(messages(store, 500)).toHaveLength(5);
+  });
+
+  it('treats a zero, negative or fractional limit as a request for that many at most', () => {
+    const store = createRecentLogStore({ capacity: 5 });
+    pushRecords(store, 1, 5);
+
+    expect(store.recent(0)).toEqual([]);
+    expect(store.recent(-3)).toEqual([]);
+    expect(messages(store, 2.9)).toEqual(['record-4', 'record-5']);
+    expect(store.recent(Number.NaN)).toHaveLength(5);
+  });
+
+  it('hands back a fresh array and fresh entries each call', () => {
+    const store = createRecentLogStore({ capacity: 3 });
+    pushRecords(store, 1, 2);
+
+    const first = store.recent();
+    first.push({ level: 30, time: 0, msg: 'injected' });
+    (first[0] as { msg: string }).msg = 'mutated';
+
+    // Neither the array nor the entry the caller mutated is the buffer's own.
+    expect(messages(store)).toEqual(['record-1', 'record-2']);
+  });
+
+  it('replaces an oversized record with a bounded stand-in', () => {
+    const store = createRecentLogStore({ capacity: 2, maxEntryChars: 128 });
+    store.push(JSON.stringify({ level: 30, time: 1, msg: 'x'.repeat(500) }));
+
+    const [entry] = store.recent();
+    expect(entry.level).toBe(0);
+    expect(entry.msg).toContain('too large to retain');
+    expect(entry.maxEntryChars).toBe(128);
+    expect(entry.droppedChars).toBeGreaterThan(128);
+  });
+
+  it('surfaces an unparsable record instead of dropping or throwing on it', () => {
+    const store = createRecentLogStore({ capacity: 2 });
+    store.push('this is not json');
+
+    const [entry] = store.recent();
+    expect(entry.level).toBe(0);
+    expect(entry.time).toBe(0);
+    expect(entry.msg).toBe('this is not json');
+  });
+});
+
+describe('resolveLogLevel', () => {
+  it('uses LOG_LEVEL when it names a real level, case- and space-insensitively', () => {
+    expect(resolveLogLevel({ LOG_LEVEL: 'debug' })).toBe('debug');
+    expect(resolveLogLevel({ LOG_LEVEL: '  WARN ' })).toBe('warn');
+    expect(resolveLogLevel({ LOG_LEVEL: 'silent' })).toBe('silent');
+  });
+
+  it('falls back rather than handing pino a level it would throw on', () => {
+    // pino throws on an unknown level, and this module builds a logger at import
+    // time, so a typo here would otherwise be a boot crash.
+    for (const value of ['verbose', 'INFOO', '30', '']) {
+      expect(resolveLogLevel({ LOG_LEVEL: value })).toBe('info');
+    }
+    expect(() => createLogger({ level: resolveLogLevel({ LOG_LEVEL: 'verbose' }) })).not.toThrow();
+  });
+
+  it('defaults to silent under the test runner and info elsewhere', () => {
+    expect(resolveLogLevel({ NODE_ENV: 'test' })).toBe('silent');
+    expect(resolveLogLevel({ NODE_ENV: 'production' })).toBe('info');
+    expect(resolveLogLevel({})).toBe('info');
+    // An explicit LOG_LEVEL still wins under test.
+    expect(resolveLogLevel({ NODE_ENV: 'test', LOG_LEVEL: 'error' })).toBe('error');
+  });
+});
+
+describe('shouldPrettyPrint', () => {
+  it('opts in only for development, never by excluding production', () => {
+    expect(shouldPrettyPrint({ NODE_ENV: 'development' })).toBe(true);
+    expect(shouldPrettyPrint({ NODE_ENV: 'production' })).toBe(false);
+    expect(shouldPrettyPrint({ NODE_ENV: 'test' })).toBe(false);
+    // docker-compose.prod.yml passes `NODE_ENV=${NODE_ENV}`, and Compose turns an
+    // unset variable into the empty string, overriding the image's own value.
+    // A `!== 'production'` test would select the pretty path there and reach for
+    // a devDependency the production image does not install.
+    expect(shouldPrettyPrint({ NODE_ENV: '' })).toBe(false);
+    expect(shouldPrettyPrint({})).toBe(false);
+  });
+});
+
+describe('createLogger', () => {
+  it('writes each record to stdout and to the recent-log buffer', () => {
+    const store = createRecentLogStore({ capacity: 10 });
+    const { stream, lines } = createCapturingStream();
+    const logger = createLogger({ level: 'info', store, stdout: stream });
+
+    logger.info({ roomId: 'room-1' }, 'message stored');
+
+    expect(lines).toHaveLength(1);
+    const [entry] = store.recent();
+    expect(entry.msg).toBe('message stored');
+    expect(entry.roomId).toBe('room-1');
+    expect(entry.level).toBe(30);
+    expect(typeof entry.time).toBe('number');
+    expect(entry.time).toBeGreaterThan(0);
+    // Both destinations saw the same record.
+    expect(JSON.parse(lines[0]).msg).toBe(entry.msg);
+  });
+
+  it('delivers debug records to both destinations when built at debug', () => {
+    // Regression guard: pino.multistream applies its own per-stream level filter
+    // that defaults to `info`, so the obvious multistream wiring silently drops
+    // every debug record even with the logger at `debug`. The tee destination
+    // this module uses leaves the pino instance's level as the only filter.
+    const store = createRecentLogStore({ capacity: 10 });
+    const { stream, lines } = createCapturingStream();
+    const logger = createLogger({ level: 'debug', store, stdout: stream });
+
+    logger.debug('debug reaches both');
+
+    expect(lines).toHaveLength(1);
+    expect(messages(store)).toEqual(['debug reaches both']);
+  });
+
+  it('stores nothing for records below the configured level', () => {
+    const store = createRecentLogStore({ capacity: 10 });
+    const { stream, lines } = createCapturingStream();
+    const logger = createLogger({ level: 'warn', store, stdout: stream });
+
+    logger.info('filtered out');
+    logger.debug('filtered out too');
+    logger.warn('kept');
+
+    expect(lines).toHaveLength(1);
+    expect(messages(store)).toEqual(['kept']);
+  });
+
+  it('redacts credentials before they reach either destination', () => {
+    const store = createRecentLogStore({ capacity: 10 });
+    const { stream, lines } = createCapturingStream();
+    const logger = createLogger({ level: 'info', store, stdout: stream });
+
+    logger.info(
+      {
+        password: 'hunter2',
+        refreshToken: 'refresh-secret',
+        req: { headers: { authorization: 'Bearer token-secret' } },
+        userId: 'user-1',
+      },
+      'login attempt',
+    );
+
+    const [entry] = store.recent();
+    expect(entry.password).toBe('[redacted]');
+    expect(entry.refreshToken).toBe('[redacted]');
+    expect((entry.req as { headers: { authorization: string } }).headers.authorization).toBe(
+      '[redacted]',
+    );
+    // Non-sensitive context survives.
+    expect(entry.userId).toBe('user-1');
+    expect(lines[0]).not.toContain('hunter2');
+    expect(lines[0]).not.toContain('refresh-secret');
+    expect(lines[0]).not.toContain('token-secret');
+  });
+
+  it('keeps logging a circular payload instead of throwing', () => {
+    const store = createRecentLogStore({ capacity: 10 });
+    const { stream } = createCapturingStream();
+    const logger = createLogger({ level: 'info', store, stdout: stream });
+
+    const circular: Record<string, unknown> = { name: 'circular' };
+    circular.self = circular;
+
+    expect(() => logger.info({ circular }, 'circular payload')).not.toThrow();
+    expect(messages(store)).toEqual(['circular payload']);
+  });
+
+  it('never lets a failing buffer break the caller that logged', () => {
+    // pino calls the destination synchronously from inside logger.info(), so a
+    // throwing buffer would surface as an application error at the call site.
+    const failing: RecentLogStore = {
+      capacity: 1,
+      size: () => 0,
+      recent: () => [],
+      push: () => {
+        throw new Error('buffer unavailable');
+      },
+    };
+    const { stream, lines } = createCapturingStream();
+    const logger = createLogger({ level: 'info', store: failing, stdout: stream });
+
+    expect(() => logger.info('still delivered to stdout')).not.toThrow();
+    expect(lines).toHaveLength(1);
+  });
+});

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -37,6 +37,8 @@ services:
       - JWT_SECRET=${JWT_SECRET}
       - JWT_EXPIRES_IN=${JWT_EXPIRES_IN}
       - RATE_LIMIT_DISABLED=${RATE_LIMIT_DISABLED}
+      # Pass-through only; the logger defaults to info when this is unset.
+      - LOG_LEVEL
       # One trusted hop: cloudflared, which appends the caller's address to
       # X-Forwarded-For. Without it every request through the tunnel is attributed
       # to the tunnel container, so a single caller exhausting the auth limiter

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,10 @@ services:
       - JWT_SECRET=${JWT_SECRET}
       - JWT_EXPIRES_IN=${JWT_EXPIRES_IN}
       - RATE_LIMIT_DISABLED=${RATE_LIMIT_DISABLED}
+      # Pass-through only, deliberately not `${LOG_LEVEL:-info}`: the logger
+      # already defaults to info, and a bare name keeps an unset host variable
+      # unset in the container instead of setting it to the empty string.
+      - LOG_LEVEL
       # The dev stack is reached directly on the published ports, with nothing in
       # front to write X-Forwarded-For, so no hop is trusted here. Both names are
       # pass-through only: set TRUST_PROXY_HOPS on the host if you put a proxy

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,6 +31,9 @@ importers:
       hono-rate-limiter:
         specifier: ^0.5.3
         version: 0.5.3(hono@4.13.2)
+      pino:
+        specifier: ^10.3.1
+        version: 10.3.1
       sharp:
         specifier: ^0.35.3
         version: 0.35.3(@types/node@26.2.0)
@@ -62,6 +65,9 @@ importers:
       eslint:
         specifier: ^10.8.0
         version: 10.8.0(jiti@2.7.0)(supports-color@7.2.0)
+      pino-pretty:
+        specifier: ^13.1.3
+        version: 13.1.3
       socket.io-client:
         specifier: ^4.8.3
         version: 4.8.3(supports-color@7.2.0)
@@ -724,6 +730,9 @@ packages:
   '@paralleldrive/cuid2@2.3.1':
     resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
 
+  '@pinojs/redact@0.4.0':
+    resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
+
   '@playwright/test@1.62.1':
     resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
     engines: {node: '>=20'}
@@ -1316,6 +1325,10 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
+  atomic-sleep@1.0.0:
+    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
+    engines: {node: '>=8.0.0'}
+
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
@@ -1410,6 +1423,9 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  colorette@2.0.20:
+    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
@@ -1467,6 +1483,9 @@ packages:
   data-view-byte-offset@1.0.1:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
+
+  dateformat@4.6.3:
+    resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
 
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
@@ -1530,6 +1549,9 @@ packages:
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   engine.io-client@6.6.6:
     resolution: {integrity: sha512-iY6QdftLQ9pyiPoX082bpf/u1UewnOaJrtJIF9T0++QB34lZrj0uP+Q/bj8AlUsAxqhnkTV2BS8SBZSxOmoV5Q==}
@@ -1710,6 +1732,7 @@ packages:
   eslint@9.39.5:
     resolution: {integrity: sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -1747,6 +1770,9 @@ packages:
   expect-type@1.4.0:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
+
+  fast-copy@4.0.4:
+    resolution: {integrity: sha512-eVAiWVNPSEGIzDl5yPuLrx8fNMogScXvD9xp1Kzd41FjRIz2I3sSIcxsFeM5EzFfHAfobdvs8ZySffUopljvIA==}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -1903,6 +1929,9 @@ packages:
   hasown@2.0.4:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
+
+  help-me@5.0.0:
+    resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
 
   hermes-estree@0.25.1:
     resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
@@ -2070,6 +2099,10 @@ packages:
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
+
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -2358,6 +2391,10 @@ packages:
     resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
     engines: {node: '>=12.20.0'}
 
+  on-exit-leak-free@2.1.2:
+    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
+    engines: {node: '>=14.0.0'}
+
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
@@ -2413,6 +2450,20 @@ packages:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
+  pino-abstract-transport@3.0.0:
+    resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
+
+  pino-pretty@13.1.3:
+    resolution: {integrity: sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==}
+    hasBin: true
+
+  pino-std-serializers@7.1.0:
+    resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
+
+  pino@10.3.1:
+    resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
+    hasBin: true
+
   playwright-core@1.62.1:
     resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
     engines: {node: '>=20'}
@@ -2443,8 +2494,14 @@ packages:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
+  process-warning@5.1.0:
+    resolution: {integrity: sha512-jQSaVHsPgtyw60e1rQ/A+/ArPEj/S8pS/vFnyGa/gYFXrKk/6RuDkoqVDQ5NI5MmS01698ltlAk0NoDBNLujRw==}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -2456,6 +2513,9 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  quick-format-unescaped@4.0.4:
+    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
 
   react-dom@19.2.8:
     resolution: {integrity: sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==}
@@ -2471,6 +2531,13 @@ packages:
   react@19.2.8:
     resolution: {integrity: sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==}
     engines: {node: '>=0.10.0'}
+
+  real-require@0.2.0:
+    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
+    engines: {node: '>= 12.13.0'}
+
+  real-require@1.0.0:
+    resolution: {integrity: sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -2520,12 +2587,19 @@ packages:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
 
+  safe-stable-stringify@2.5.0:
+    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
+    engines: {node: '>=10'}
+
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  secure-json-parse@4.1.0:
+    resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -2599,9 +2673,16 @@ packages:
     resolution: {integrity: sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A==}
     engines: {node: '>=10.2.0'}
 
+  sonic-boom@4.2.1:
+    resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
 
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
@@ -2647,6 +2728,10 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  strip-json-comments@5.0.3:
+    resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
+    engines: {node: '>=14.16'}
+
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
     engines: {node: '>= 12.0.0'}
@@ -2688,6 +2773,10 @@ packages:
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
+
+  thread-stream@4.2.0:
+    resolution: {integrity: sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==}
+    engines: {node: '>=20'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -3543,6 +3632,8 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.8.0
 
+  '@pinojs/redact@0.4.0': {}
+
   '@playwright/test@1.62.1':
     dependencies:
       playwright: 1.62.1
@@ -4145,6 +4236,8 @@ snapshots:
 
   asynckit@0.4.0: {}
 
+  atomic-sleep@1.0.0: {}
+
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
@@ -4232,6 +4325,8 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  colorette@2.0.20: {}
+
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
@@ -4293,6 +4388,8 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
+  dateformat@4.6.3: {}
+
   debug@3.2.7(supports-color@7.2.0):
     dependencies:
       ms: 2.1.3
@@ -4347,6 +4444,10 @@ snapshots:
   electron-to-chromium@1.5.403: {}
 
   emoji-regex@9.2.2: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
 
   engine.io-client@6.6.6(supports-color@7.2.0):
     dependencies:
@@ -4776,6 +4877,8 @@ snapshots:
 
   expect-type@1.4.0: {}
 
+  fast-copy@4.0.4: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.1:
@@ -4934,6 +5037,8 @@ snapshots:
   hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
+
+  help-me@5.0.0: {}
 
   hermes-estree@0.25.1: {}
 
@@ -5102,6 +5207,8 @@ snapshots:
       set-function-name: 2.0.2
 
   jiti@2.7.0: {}
+
+  joycon@3.1.1: {}
 
   js-tokens@4.0.0: {}
 
@@ -5367,6 +5474,8 @@ snapshots:
 
   obug@2.1.4: {}
 
+  on-exit-leak-free@2.1.2: {}
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
@@ -5419,6 +5528,42 @@ snapshots:
 
   picomatch@4.0.5: {}
 
+  pino-abstract-transport@3.0.0:
+    dependencies:
+      split2: 4.2.0
+
+  pino-pretty@13.1.3:
+    dependencies:
+      colorette: 2.0.20
+      dateformat: 4.6.3
+      fast-copy: 4.0.4
+      fast-safe-stringify: 2.1.1
+      help-me: 5.0.0
+      joycon: 3.1.1
+      minimist: 1.2.8
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 3.0.0
+      pump: 3.0.4
+      secure-json-parse: 4.1.0
+      sonic-boom: 4.2.1
+      strip-json-comments: 5.0.3
+
+  pino-std-serializers@7.1.0: {}
+
+  pino@10.3.1:
+    dependencies:
+      '@pinojs/redact': 0.4.0
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 3.0.0
+      pino-std-serializers: 7.1.0
+      process-warning: 5.1.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.1
+      thread-stream: 4.2.0
+
   playwright-core@1.62.1: {}
 
   playwright@1.62.1:
@@ -5449,11 +5594,18 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
+  process-warning@5.1.0: {}
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
 
   punycode@2.3.1: {}
 
@@ -5463,6 +5615,8 @@ snapshots:
       side-channel: 1.1.1
 
   queue-microtask@1.2.3: {}
+
+  quick-format-unescaped@4.0.4: {}
 
   react-dom@19.2.8(react@19.2.8):
     dependencies:
@@ -5474,6 +5628,10 @@ snapshots:
   react-is@17.0.2: {}
 
   react@19.2.8: {}
+
+  real-require@0.2.0: {}
+
+  real-require@1.0.0: {}
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -5556,11 +5714,15 @@ snapshots:
       es-errors: 1.3.0
       is-regex: 1.2.1
 
+  safe-stable-stringify@2.5.0: {}
+
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
+
+  secure-json-parse@4.1.0: {}
 
   semver@6.3.1: {}
 
@@ -5698,7 +5860,13 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  sonic-boom@4.2.1:
+    dependencies:
+      atomic-sleep: 1.0.0
+
   source-map-js@1.2.1: {}
+
+  split2@4.2.0: {}
 
   stable-hash@0.0.5: {}
 
@@ -5766,6 +5934,8 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  strip-json-comments@5.0.3: {}
+
   styled-jsx@5.1.6(@babel/core@7.29.7(supports-color@7.2.0))(react@19.2.8):
     dependencies:
       client-only: 0.0.1
@@ -5808,6 +5978,10 @@ snapshots:
   tailwindcss@4.3.3: {}
 
   tapable@2.3.3: {}
+
+  thread-stream@4.2.0:
+    dependencies:
+      real-require: 1.0.0
 
   tinybench@2.9.0: {}
 


### PR DESCRIPTION
## 變更描述 (Description)

以 `pino` 建立後端結構化日誌基礎，並提供一個有界的「近期日誌」記憶體緩衝，作為後續 admin `GET /api/v1/admin/logs`（#569）的資料來源。

### 新增 `backend/src/utils/logger.ts`

- `createRecentLogStore({ capacity, maxEntryChars })`：固定長度的 ring buffer（預設 200 筆）。寫入時覆蓋最舊的 slot 而非 append，因此長時間執行的 process 最多只保留 `capacity` 筆。
- `createLogger({ level, pretty, store, stdout })`：pino 的 destination 是一個 tee，把每一筆記錄同時寫到 stdout 與上述 store。
- `resolveLogLevel()` / `shouldPrettyPrint()`：純函式，接受 env 參數、不自行讀取 `process.env`；模組層再匯出 `logger` / `recentLogs` 兩個讀取 env 的 singleton。此分層沿用 `src/utils/accessTokenTtl.ts`（`parseDurationSeconds` 與 `getAccessTokenTtlSeconds`）既有的寫法。

### 幾個關鍵設計決定與原因

1. **用 tee destination 而不是 `pino.multistream`。** `pino.multistream` 會在 logger 本身的 level 之外，再套用一層 per-stream level filter，且該 filter 預設為 `info`。這代表 `pino({ level: 'debug' }, pino.multistream([...]))` 會靜默丟掉所有 `debug` 記錄。本次已實測確認此行為（level `debug` 下發出一筆 `debug` 與一筆 `info`，stream 只收到 1 筆）。tee 讓 pino instance 的 level 成為唯一的過濾點，並已加上 regression test。
2. **不用 `pino.transport` worker thread。** 緩衝必須與 Hono handler 在同一個 process，worker thread 有獨立的位址空間，admin route 讀不到。
3. **緩衝內存放序列化後的字串，於 `recent()` 時才 parse。** 這讓 `JSON.parse` 離開 logging hot path，更重要的是緩衝不會持有呼叫端物件的 reference（否則 `logger.info({ req })` 會讓整個物件圖多存活 200 筆記錄的時間）。
4. **`pino-pretty` 放在 devDependencies、lazy require，且只在 `NODE_ENV` 恰好等於 `development` 時啟用。** production image 以 `pnpm deploy --prod` 安裝（`backend/Dockerfile.prod:45`），不含 `pino-pretty`；而 `docker-compose.prod.yml:34` 是 `NODE_ENV=${NODE_ENV}`，Compose 在變數未設定時會填入空字串並覆蓋 image 的 `ENV NODE_ENV=production`。若採用 `!== 'production'` 判斷，production 就會走 pretty 分支並 `MODULE_NOT_FOUND`。改用 allowlist 並保留 try/catch fallback，兩層都安全。
5. **加入 redact。** 此緩衝即將透過 HTTP 對外提供，凡是進到 log 的憑證等同 endpoint 會發出去的憑證，因此 `password` / `token` / `refreshToken` / `authorization` / `cookie` 等路徑在寫入任一 destination 前先遮蔽。
6. **單筆大小上限。** 只限制筆數並不能限制記憶體，一筆 `logger.info(hugeObject)` 會在緩衝裡佔用數 MB。超過上限者以一筆合法 JSON 的 stand-in 取代。

### 範圍控制

- 依 Issue 要求，**不**在本 PR 大規模替換 `console.*`。本次重新確認目前 `backend/src` 共有 **41 處** `console.log/error/warn/info/debug`（Issue 內文記錄為 37 處，以本次實際 grep 為準），保留為獨立的低風險 follow-up。
- 僅轉換 `backend/src/bootstrap/start.ts` 既有的那一行啟動訊息，以滿足驗收標準第 3 點；訊息文字維持不變，只是額外附上結構化欄位。`StartServerDeps` 新增可選的 `logger`，沿用 `bootstrap/` 既有的 deps-object 慣例，讓這行變成可測試。
- **已知且刻意保留**：`backend/src/models/db.ts:24` 的 `DB INIT:` 是 module 層級的 `console.log`，執行順序早於 `start.ts`，因此 stdout 會先出現一行純文字、再出現結構化那行（見下方實測輸出）。轉換它會讓 `models/db.ts` 在 import 時就相依於 logger singleton，屬於上述 follow-up 的範圍。
- 檔案輸出依 Issue 指示不在本次範圍內。

### 設定串接

`LOG_LEVEL` 已加入 `docker-compose.yml`、`docker-compose.prod.yml` 的 `environment` 允許清單與 `.env.example`。兩個 compose 都使用明確的 allowlist，若不加這一項，`LOG_LEVEL` 在容器內會是永遠讀不到的死設定。採 bare pass-through（`- LOG_LEVEL`）而非 `${LOG_LEVEL:-info}`，避免未設定時被填入空字串。無法辨識的 `LOG_LEVEL` 會退回 `info`，因為 pino 遇到未知 level 會直接 throw，而本模組在 import 時就會建立 logger。

## 相關的 Issue (Related Issue)

Closes #566

Parent: #280

## 變更類型 (Type of Change)

請勾選適用的選項：
- [x] `feat`: 新增功能 (Feature)
- [ ] `fix`: 修復 Bug
- [ ] `refactor`: 重構代碼
- [ ] `docs`: 修改文件
- [x] `test`: 新增或修正測試案例
- [ ] `chore`: 建置流程或輔助工具變更
- [ ] `perf`: 效能優化
- [ ] `ci`: CI 設定變更

## 驗證與測試計畫 (Verification & Test Plan)

### 本地測試 (Local Tests)

本次 session 的環境**沒有可用的 Docker daemon**（`docker` CLI 存在但 `docker info` 失敗），因此下列以 `docker compose exec` 為前綴的項目**無法在此環境執行，未勾選**，需由 reviewer 在 Docker 內補跑：

- [ ] 後端型別檢查 (`docker compose exec backend pnpm exec tsc --noEmit`)
- [ ] 前端型別檢查 (`docker compose exec frontend pnpm exec tsc --noEmit`)
- [ ] 前端 Linter 檢查 (`docker compose exec frontend pnpm run lint`)
- [ ] 單元測試 (`docker compose exec backend pnpm run test:unit`)
- [ ] 整合測試 (`docker compose exec backend pnpm run test:integration` 已通過，含 ephemeral db-test）

補充：由於 `docker-compose.yml` 以 anonymous volume 遮蔽 `/workspace/backend/node_modules`，容器內的 `node_modules` 屬於 image 內容。本次新增了 dependency，reviewer 需先 `docker compose up -d --build backend` 再執行上列指令，否則容器內不會有 `pino`。

**實際在 host 上執行並通過的等價檢查**（Bun 1.3.11、workspace 自身的 node_modules）：

```
$ pnpm exec tsc --noEmit          # backend/，無輸出，exit 0
$ pnpm exec eslint src            # backend/，無輸出，exit 0
$ bun test tests/unit             # 507 pass / 0 fail（base 為 484 pass，本 PR 新增 23 筆）
$ pnpm install --frozen-lockfile --filter near-chat-backend...
  Lockfile passes supply-chain policies
  Lockfile is up to date, resolution step is skipped
```

最後一項即兩個 Dockerfile 使用的安裝指令，可確認新的 root `pnpm-lock.yaml` 不會讓 image build 失敗。

**未能驗證的項目**：`security-scan` 使用的 `cve-lite ... --fail-on high --ratchet` 在此環境無法執行，OSV API（`api.osv.dev`）被本環境的網路政策擋下並回傳 403。`pino-pretty` 帶入 `dateformat`、`help-me`、`pump`、`secure-json-parse` 等 transitive dependency，需由 PR 上的 `security-scan` CI job 把關。lockfile 差異為純新增 174 行、未變更任何既有套件版本。

### 手動測試 (Manual Verification)

實際啟動後端，確認驗收標準第 3 點（stdout 出現結構化日誌行），兩種模式皆已驗證：

`NODE_ENV=development`（pretty）：

```
DB INIT: env=development target=localhost:5999/none
[2026-08-23 14:41:40.119 +0000] INFO: Backend server (v2.1.1) successfully listening on port ... (0.0.0.0)
    version: "2.1.1"
    port: "..."
    address: "0.0.0.0"
```

`NODE_ENV=production`（JSON）：

```
DB INIT: env=production target=localhost:5999/none
{"level":30,"time":1787496108115,"pid":23873,"hostname":"vm","version":"2.1.1","port":"...","address":"0.0.0.0","msg":"Backend server (v2.1.1) successfully listening on port ... (0.0.0.0)"}
```

第一行即上面提到、刻意保留的 `db.ts` 純文字輸出。

新增的 23 筆單元測試涵蓋：空 store、未達上限、剛好等於上限、超過上限一筆、**跨兩圈以上且寫入次數非 capacity 倍數**的順序（17 筆 / capacity 5，這是 modulo 讀取路徑最容易出錯而第一圈與整數倍都測不出來的情境）、驗收標準要求的 10 倍 capacity 寫入後只回傳最新 N 筆且第 1 筆確實消失、`recent(limit)` 在小於 / 等於 / 大於 size 與 0 / 負數 / 非整數 / NaN 下的行為、回傳陣列與元素皆為 caller 無法污染的副本、非法 capacity 拋出 `RangeError`、`size()` 永不超過 capacity、超長記錄以 stand-in 取代、無法 parse 的記錄被保留而非丟棄、debug 記錄同時抵達兩個 destination（上述 multistream 陷阱的 regression test）、低於 level 的記錄不入緩衝、redact 生效、circular payload 不 throw、以及 store 拋錯時 `logger.info()` 不會把錯誤丟回呼叫端。

## 資料庫變更 (Database Changes)

- 此變更是否包含資料庫 Schema 修改？ **否**
- 若為是，請寫明 Migration 檔案名稱：`不適用`
- 是否已確認遷移與 [docs/database-design.md](../docs/database-design.md) 設計一致？ **不適用**

## API 與 WebSocket 協定一致性 (API & WebSocket Contract Check)

- 此變更是否涉及 API 路由或 WebSocket 事件的資料結構變更？ **否**
- 是否已確認與 [docs/api-documentation.md](../docs/api-documentation.md) 規範完全一致？ **不適用**（本 PR 未新增任何 route，admin `/logs` 端點屬於 #569）

## Advisor 重點意見

實作前先以 architect sub-agent 做了一次 advisor pass，採納的重點：

- **`pino.multistream` 的 per-stream level filter 預設為 `info`** — 這是本次最可能踩到的 bug，已實測確認並改用 tee destination，另附 regression test。
- **`docker-compose.prod.yml` 的 `NODE_ENV=${NODE_ENV}` 覆蓋風險** — 已改為 allowlist 判斷並保留 fallback。
- **`LOG_LEVEL` 會是死設定** — 已補上兩個 compose 的 allowlist 與 `.env.example`。
- **sink 絕不能 throw** — pino 是在 `logger.info()` 內同步呼叫 destination 的，已加上 try/catch 並附測試。
- **建議加 redact** — 已採納，理由如上。
- **緩衝應以大小而非僅以筆數設限** — 已採納，加入單筆上限。
- **純函式核心 + 讀 env 的薄 singleton 分層**，並且**先不要新增 `bootstrap/logger.ts`** — 已採納；目前只有一個消費者，等 console.* follow-up 產生實際需求再說。

**未採納的一項**：advisor 指出 `index.ts` 的 `process.exit(0)` 搭配 async 的 pipe stdout 可能在結束時遺失日誌行，建議改用 `pino.destination({ dest: 1, sync: true })`。本次實測**在 Bun 1.3.11 下無法重現**：以 pipe 承接 stdout、寫入一行後立即 `process.exit(0)`，`process.stdout` 與 sync destination 兩種寫法該行都完整輸出。因此維持較單純的 `process.stdout`，不額外引入對 sonic-boom 在 Bun 下 `fs.writeSync` 行為的相依。

Generated with Claude Code (https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFfcLmfqd8eHENX6fsKDWE)_