### PR TITLE
feat(backend): 新增請求計時中間件與效能指標彙整 (#567)

### DIFF
--- a/backend/src/bootstrap/httpApp.ts
+++ b/backend/src/bootstrap/httpApp.ts
@@ -27,15 +27,24 @@ export interface CreateHttpAppDeps {
  * The Hono application: middleware, static uploads and every API route.
  *
  * Middleware order is load-bearing and preserved as it was — security headers
- * and CORS wrap everything, request timing sits just inside them so it measures
- * the whole handling of a request, the global limiter covers `/api/*`, and the
- * auth limiter is mounted on `/api/v1/auth/*` ahead of the auth routes
+ * and CORS wrap everything, request timing sits between them so it measures
+ * every request CORS answers by itself, the global limiter covers `/api/*`, and
+ * the auth limiter is mounted on `/api/v1/auth/*` ahead of the auth routes
  * themselves.
  */
 export const createHttpApp = ({ services, config }: CreateHttpAppDeps): Hono => {
   const honoApp = new Hono();
 
   honoApp.use('*', securityHeaders);
+
+  // Outside CORS, not inside it: `cors()` answers an `OPTIONS` preflight by
+  // returning a 204 itself and never calling `next()`, so a timer mounted after
+  // it would silently miss every preflight — real traffic this backend serves,
+  // and traffic whose volume is worth seeing. Outside the rate limiter for the
+  // same reason: a burst of 429s is a signal, not something to hide from the
+  // metrics.
+  honoApp.use('*', requestTiming);
+
   honoApp.use(
     '*',
     cors({
@@ -43,11 +52,6 @@ export const createHttpApp = ({ services, config }: CreateHttpAppDeps): Hono => 
       credentials: true,
     }),
   );
-
-  // Inside CORS so a preflight is measured as the cheap request it is, and
-  // outside the rate limiter so requests it rejects are still counted — a burst
-  // of 429s is a signal, not something to hide from the metrics.
-  honoApp.use('*', requestTiming);
 
   honoApp.use('/api/*', makeGlobalRateLimiter());
 

--- a/backend/src/bootstrap/httpApp.ts
+++ b/backend/src/bootstrap/httpApp.ts
@@ -6,6 +6,7 @@ import type { Services } from './services';
 import { errorHandler } from '../middlewares/errorHandler';
 import { authMiddleware } from '../middlewares/authMiddleware';
 import { makeAuthRateLimiter, makeGlobalRateLimiter, securityHeaders } from '../middlewares/securityMiddleware';
+import { requestTiming } from '../middlewares/requestTiming';
 import { makeAuthRoutes } from '../routes/authRoutes';
 import { makeUserRoutes } from '../routes/userRoutes';
 import { makeRoomRoutes } from '../routes/roomRoutes';
@@ -26,8 +27,10 @@ export interface CreateHttpAppDeps {
  * The Hono application: middleware, static uploads and every API route.
  *
  * Middleware order is load-bearing and preserved as it was — security headers
- * and CORS wrap everything, the global limiter covers `/api/*`, and the auth
- * limiter is mounted on `/api/v1/auth/*` ahead of the auth routes themselves.
+ * and CORS wrap everything, request timing sits just inside them so it measures
+ * the whole handling of a request, the global limiter covers `/api/*`, and the
+ * auth limiter is mounted on `/api/v1/auth/*` ahead of the auth routes
+ * themselves.
  */
 export const createHttpApp = ({ services, config }: CreateHttpAppDeps): Hono => {
   const honoApp = new Hono();
@@ -40,6 +43,11 @@ export const createHttpApp = ({ services, config }: CreateHttpAppDeps): Hono => 
       credentials: true,
     }),
   );
+
+  // Inside CORS so a preflight is measured as the cheap request it is, and
+  // outside the rate limiter so requests it rejects are still counted — a burst
+  // of 429s is a signal, not something to hide from the metrics.
+  honoApp.use('*', requestTiming);
 
   honoApp.use('/api/*', makeGlobalRateLimiter());
 

--- a/backend/src/middlewares/requestTiming.ts
+++ b/backend/src/middlewares/requestTiming.ts
@@ -1,0 +1,79 @@
+import type { Context, MiddlewareHandler } from 'hono';
+import type { Logger } from 'pino';
+import { logger as defaultLogger } from '../utils/logger';
+import { requestMetrics, type RequestMetricsStore } from '../utils/performanceMetrics';
+import { AppError } from '../utils/AppError';
+
+export interface RequestTimingOptions {
+  logger?: Logger;
+  metrics?: RequestMetricsStore;
+  /** Monotonic clock in milliseconds. Overridable so tests can assert exact durations. */
+  now?: () => number;
+  /** Requests this returns `true` for are neither logged nor counted. */
+  skip?: (c: Context) => boolean;
+}
+
+/**
+ * The status the client will actually receive for a request that threw.
+ *
+ * `errorHandler` only builds the response *after* this middleware unwinds, so
+ * `c.res.status` is not yet meaningful on the throwing path. `AppError` already
+ * carries the status the handler decided on, and anything else becomes the 500
+ * that `mapErrorToApiShape` will produce — keeping the recorded status class in
+ * step with what the caller sees.
+ */
+const statusForError = (error: unknown): number =>
+  error instanceof AppError && Number.isFinite(error.statusCode) ? error.statusCode : 500;
+
+/**
+ * Time every request and feed the result to the logger and the metrics store.
+ *
+ * `performance.now()` rather than `Date.now()`: it is monotonic and
+ * sub-millisecond, so a clock adjustment mid-request cannot produce a negative
+ * duration and a fast handler does not round to a flat `0`.
+ *
+ * Timing lives in a `finally` so a thrown handler is recorded too — those are
+ * the requests whose latency an operator most wants to see, and a middleware
+ * that only measures the happy path quietly under-reports exactly when the
+ * service is unhealthy. The error itself is re-thrown untouched; reporting it
+ * remains `errorHandler`'s job.
+ */
+export const makeRequestTiming = (options: RequestTimingOptions = {}): MiddlewareHandler => {
+  const {
+    logger = defaultLogger,
+    metrics = requestMetrics,
+    now = () => performance.now(),
+    skip,
+  } = options;
+
+  return async (c, next) => {
+    if (skip?.(c)) return next();
+
+    const startedAt = now();
+    // `c.req.path` is read up front: the request object is the one thing here
+    // guaranteed to be intact on both the success and the throwing path.
+    const method = c.req.method;
+    const path = c.req.path;
+    let status = 500;
+
+    try {
+      await next();
+      status = c.res.status;
+    } catch (error) {
+      status = statusForError(error);
+      throw error;
+    } finally {
+      const durationMs = Math.round((now() - startedAt) * 1000) / 1000;
+      metrics.record({ method, path, status, durationMs });
+
+      // 5xx is the service's own fault and belongs above the info floor a
+      // production deployment usually runs at; 4xx is the caller's and stays at
+      // info so a scanner cannot flood the warn stream.
+      const level = status >= 500 ? 'warn' : 'info';
+      logger[level]({ method, path, status, durationMs }, 'request completed');
+    }
+  };
+};
+
+/** The instance mounted by `bootstrap/httpApp.ts`. */
+export const requestTiming: MiddlewareHandler = makeRequestTiming();

--- a/backend/src/utils/performanceMetrics.ts
+++ b/backend/src/utils/performanceMetrics.ts
@@ -1,0 +1,268 @@
+/**
+ * In-process aggregation of request timings and process resource usage.
+ *
+ * This is the data source the admin `GET /api/v1/admin/metrics` endpoint will
+ * read from, which is why both halves are exposed as small interfaces rather
+ * than as loose module state: the endpoint only needs `snapshot()` / `sample()`,
+ * so either can later be swapped for a cross-process store without touching the
+ * route. Everything here is per-process and resets on restart — a deliberate
+ * trade-off matching the recent-log buffer in `logger.ts`.
+ */
+
+/** One completed request, as the timing middleware observed it. */
+export interface RequestSample {
+  method: string;
+  path: string;
+  status: number;
+  durationMs: number;
+}
+
+export type StatusClass = '1xx' | '2xx' | '3xx' | '4xx' | '5xx' | 'other';
+
+/**
+ * Latency over the retained window, not over all time.
+ *
+ * Percentiles need the individual observations, and keeping every one of them
+ * for the life of the process is precisely the unbounded growth this module has
+ * to avoid — so the summary describes the most recent `sampleCapacity`
+ * requests. `totalRequests` on the snapshot remains a lifetime counter.
+ */
+export interface LatencySummary {
+  count: number;
+  avgMs: number;
+  p50Ms: number;
+  p95Ms: number;
+  p99Ms: number;
+  maxMs: number;
+}
+
+export interface RequestMetricsSnapshot {
+  /** Lifetime count, unaffected by the sampling window. */
+  totalRequests: number;
+  /** Lifetime counts per status class. */
+  statusClasses: Record<StatusClass, number>;
+  latency: LatencySummary;
+  sampleSize: number;
+  sampleCapacity: number;
+}
+
+export interface RequestMetricsStore {
+  record(sample: RequestSample): void;
+  snapshot(): RequestMetricsSnapshot;
+  reset(): void;
+  readonly sampleCapacity: number;
+}
+
+/**
+ * How many recent durations are retained for percentile maths.
+ *
+ * 1000 doubles is ~8 KB, and `snapshot()` sorts a copy of them — negligible for
+ * an endpoint an operator polls every few seconds, while giving p99 enough
+ * observations to mean something.
+ */
+export const DEFAULT_LATENCY_SAMPLE_CAPACITY = 1000;
+
+const EMPTY_LATENCY: LatencySummary = {
+  count: 0,
+  avgMs: 0,
+  p50Ms: 0,
+  p95Ms: 0,
+  p99Ms: 0,
+  maxMs: 0,
+};
+
+const statusClassOf = (status: number): StatusClass => {
+  if (!Number.isFinite(status) || status < 100 || status >= 600) return 'other';
+  return (`${Math.floor(status / 100)}xx`) as StatusClass;
+};
+
+/** Nearest-rank percentile over an ascending array; `sorted` must be non-empty. */
+const percentile = (sorted: number[], fraction: number): number => {
+  const rank = Math.ceil(fraction * sorted.length);
+  const index = Math.min(Math.max(rank, 1), sorted.length) - 1;
+  return sorted[index];
+};
+
+/** Keeps float noise (0.30000000000000004) out of a JSON response. */
+const round = (value: number, decimals = 3): number => {
+  const factor = 10 ** decimals;
+  return Math.round(value * factor) / factor;
+};
+
+export interface CreateRequestMetricsStoreOptions {
+  sampleCapacity?: number;
+}
+
+/**
+ * Counters plus a fixed-size ring of recent durations.
+ *
+ * `record()` stays O(1) — it only bumps counters and overwrites one slot — so
+ * the timing middleware adds nothing measurable to the request path. The
+ * sorting cost is paid in `snapshot()`, which only an admin poll triggers.
+ */
+export const createRequestMetricsStore = (
+  options: CreateRequestMetricsStoreOptions = {},
+): RequestMetricsStore => {
+  const { sampleCapacity = DEFAULT_LATENCY_SAMPLE_CAPACITY } = options;
+
+  if (!Number.isInteger(sampleCapacity) || sampleCapacity <= 0) {
+    throw new RangeError(
+      `RequestMetricsStore sampleCapacity must be a positive integer, received ${String(sampleCapacity)}`,
+    );
+  }
+
+  const durations = new Float64Array(sampleCapacity);
+  let written = 0;
+  let totalRequests = 0;
+  let statusClasses: Record<StatusClass, number>;
+
+  const emptyStatusClasses = (): Record<StatusClass, number> => ({
+    '1xx': 0,
+    '2xx': 0,
+    '3xx': 0,
+    '4xx': 0,
+    '5xx': 0,
+    other: 0,
+  });
+
+  statusClasses = emptyStatusClasses();
+
+  return {
+    sampleCapacity,
+
+    record({ status, durationMs }: RequestSample): void {
+      totalRequests += 1;
+      statusClasses[statusClassOf(status)] += 1;
+
+      // A non-finite duration would poison every percentile from here on, so it
+      // is counted as a request but never enters the latency window.
+      if (!Number.isFinite(durationMs)) return;
+      durations[written % sampleCapacity] = Math.max(durationMs, 0);
+      written += 1;
+    },
+
+    snapshot(): RequestMetricsSnapshot {
+      const sampleSize = Math.min(written, sampleCapacity);
+      if (sampleSize === 0) {
+        return {
+          totalRequests,
+          statusClasses: { ...statusClasses },
+          latency: { ...EMPTY_LATENCY },
+          sampleSize,
+          sampleCapacity,
+        };
+      }
+
+      const sorted = Array.from(durations.subarray(0, sampleSize)).sort((a, b) => a - b);
+      const sum = sorted.reduce((total, value) => total + value, 0);
+
+      return {
+        totalRequests,
+        statusClasses: { ...statusClasses },
+        latency: {
+          count: sampleSize,
+          avgMs: round(sum / sampleSize),
+          p50Ms: round(percentile(sorted, 0.5)),
+          p95Ms: round(percentile(sorted, 0.95)),
+          p99Ms: round(percentile(sorted, 0.99)),
+          maxMs: round(sorted[sampleSize - 1]),
+        },
+        sampleSize,
+        sampleCapacity,
+      };
+    },
+
+    reset(): void {
+      durations.fill(0);
+      written = 0;
+      totalRequests = 0;
+      statusClasses = emptyStatusClasses();
+    },
+  };
+};
+
+export interface ProcessMetricsSnapshot {
+  uptimeSeconds: number;
+  cpu: {
+    userMs: number;
+    systemMs: number;
+    /**
+     * CPU time consumed since the previous `sample()` call, as a percentage of
+     * one core's wall-clock time. `null` on the first sample, which has no
+     * earlier point to difference against. Values above 100 are expected and
+     * correct on a multi-core host: Bun's runtime is multi-threaded.
+     */
+    percent: number | null;
+  };
+  memory: {
+    rssBytes: number;
+    heapUsedBytes: number;
+    heapTotalBytes: number;
+    externalBytes: number;
+  };
+}
+
+export interface ProcessMetricsSampler {
+  sample(): ProcessMetricsSnapshot;
+}
+
+export interface CreateProcessMetricsSamplerOptions {
+  cpuUsage?: () => NodeJS.CpuUsage;
+  memoryUsage?: () => NodeJS.MemoryUsage;
+  uptime?: () => number;
+  /** Monotonic wall clock in milliseconds; only differences of it are used. */
+  now?: () => number;
+}
+
+/**
+ * Samples the process's own resource usage on demand.
+ *
+ * Nothing is collected on a timer: an operator polling `/metrics` is the only
+ * consumer, so sampling at read time avoids a background interval that would
+ * keep the process busy — and keep it alive — for data nobody is looking at.
+ */
+export const createProcessMetricsSampler = (
+  options: CreateProcessMetricsSamplerOptions = {},
+): ProcessMetricsSampler => {
+  const {
+    cpuUsage = () => process.cpuUsage(),
+    memoryUsage = () => process.memoryUsage(),
+    uptime = () => process.uptime(),
+    now = () => performance.now(),
+  } = options;
+
+  let previous: { cpu: NodeJS.CpuUsage; at: number } | null = null;
+
+  return {
+    sample(): ProcessMetricsSnapshot {
+      const cpu = cpuUsage();
+      const memory = memoryUsage();
+      const at = now();
+
+      let percent: number | null = null;
+      if (previous) {
+        const elapsedMs = at - previous.at;
+        if (elapsedMs > 0) {
+          const usedMs = (cpu.user - previous.cpu.user + (cpu.system - previous.cpu.system)) / 1000;
+          percent = round(Math.max((usedMs / elapsedMs) * 100, 0), 2);
+        }
+      }
+      previous = { cpu, at };
+
+      return {
+        uptimeSeconds: round(uptime(), 3),
+        cpu: { userMs: round(cpu.user / 1000), systemMs: round(cpu.system / 1000), percent },
+        memory: {
+          rssBytes: memory.rss,
+          heapUsedBytes: memory.heapUsed,
+          heapTotalBytes: memory.heapTotal,
+          externalBytes: memory.external,
+        },
+      };
+    },
+  };
+};
+
+/** The process-wide aggregates the timing middleware feeds and `/metrics` reads. */
+export const requestMetrics: RequestMetricsStore = createRequestMetricsStore();
+export const processMetrics: ProcessMetricsSampler = createProcessMetricsSampler();

--- a/backend/tests/unit/middlewares/requestTiming.test.ts
+++ b/backend/tests/unit/middlewares/requestTiming.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'bun:test';
 import { Hono } from 'hono';
+import { cors } from 'hono/cors';
 import { makeRequestTiming } from '../../../src/middlewares/requestTiming';
 import { errorHandler } from '../../../src/middlewares/errorHandler';
 import { createLogger, createRecentLogStore, type RecentLogEntry } from '../../../src/utils/logger';
@@ -134,6 +135,35 @@ describe('requestTiming middleware', () => {
 
     expect(requests()).toHaveLength(1);
     expect(requests()[0]?.path).toBe('/api/v1/rooms');
+    expect(metrics.snapshot().totalRequests).toBe(1);
+  });
+
+  /**
+   * `cors()` answers an `OPTIONS` preflight with its own 204 and never calls
+   * `next()`, so this is the ordering that decides whether preflight traffic
+   * appears in the metrics at all. Exercised against the real CORS middleware
+   * rather than a stand-in: the behaviour under test is Hono's, and a fake would
+   * keep passing if Hono ever changed it.
+   */
+  it('measures a CORS preflight that never reaches a route', async () => {
+    const { logger, requests } = createTestLogger();
+    const metrics = createRequestMetricsStore({ sampleCapacity: 10 });
+
+    const app = new Hono();
+    app.use('*', makeRequestTiming({ logger, metrics, now: stepClock(2) }));
+    app.use('*', cors({ origin: 'https://app.example', credentials: true }));
+    app.post('/api/v1/rooms', (c) => c.json({ ok: true }, 201));
+
+    const response = await app.request('/api/v1/rooms', {
+      method: 'OPTIONS',
+      headers: {
+        origin: 'https://app.example',
+        'Access-Control-Request-Method': 'POST',
+      },
+    });
+    expect(response.status).toBe(204);
+
+    expect(requests()[0]).toMatchObject({ method: 'OPTIONS', path: '/api/v1/rooms', status: 204 });
     expect(metrics.snapshot().totalRequests).toBe(1);
   });
 

--- a/backend/tests/unit/middlewares/requestTiming.test.ts
+++ b/backend/tests/unit/middlewares/requestTiming.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from 'bun:test';
+import { Hono } from 'hono';
+import { makeRequestTiming } from '../../../src/middlewares/requestTiming';
+import { errorHandler } from '../../../src/middlewares/errorHandler';
+import { createLogger, createRecentLogStore, type RecentLogEntry } from '../../../src/utils/logger';
+import { createRequestMetricsStore } from '../../../src/utils/performanceMetrics';
+import { AppError } from '../../../src/utils/AppError';
+
+/** A logger whose records land in a buffer instead of the test runner's output. */
+const createTestLogger = () => {
+  const store = createRecentLogStore({ capacity: 50 });
+  const logger = createLogger({
+    level: 'info',
+    pretty: false,
+    store,
+    stdout: { write: () => true } as unknown as NodeJS.WritableStream,
+  });
+  return {
+    logger,
+    requests: (): RecentLogEntry[] =>
+      store.recent().filter((entry) => entry.msg === 'request completed'),
+  };
+};
+
+/**
+ * A clock that advances by a fixed amount on every read, so a handler's measured
+ * duration is exact rather than whatever the machine happened to take.
+ */
+const stepClock = (stepMs: number) => {
+  let current = 0;
+  return () => {
+    const value = current;
+    current += stepMs;
+    return value;
+  };
+};
+
+describe('requestTiming middleware', () => {
+  it('logs method, path, status and a numeric duration for a served request', async () => {
+    const { logger, requests } = createTestLogger();
+    const metrics = createRequestMetricsStore({ sampleCapacity: 10 });
+
+    const app = new Hono();
+    app.use('*', makeRequestTiming({ logger, metrics, now: stepClock(12.5) }));
+    app.get('/api/v1/health', (c) => c.json({ status: 'ok' }, 200));
+
+    const response = await app.request('/api/v1/health');
+    expect(response.status).toBe(200);
+
+    const [entry] = requests();
+    expect(entry).toMatchObject({
+      method: 'GET',
+      path: '/api/v1/health',
+      status: 200,
+      durationMs: 12.5,
+    });
+    expect(typeof entry.durationMs).toBe('number');
+  });
+
+  it('updates the metrics aggregate with the observed request', async () => {
+    const { logger } = createTestLogger();
+    const metrics = createRequestMetricsStore({ sampleCapacity: 10 });
+
+    const app = new Hono();
+    app.use('*', makeRequestTiming({ logger, metrics, now: stepClock(4) }));
+    app.get('/api/v1/rooms', (c) => c.json([], 200));
+
+    await app.request('/api/v1/rooms');
+    await app.request('/api/v1/rooms');
+
+    const snapshot = metrics.snapshot();
+    expect(snapshot.totalRequests).toBe(2);
+    expect(snapshot.statusClasses['2xx']).toBe(2);
+    expect(snapshot.latency.count).toBe(2);
+    expect(snapshot.latency.maxMs).toBe(4);
+  });
+
+  it('records the status a thrown AppError will produce, and re-throws it', async () => {
+    const { logger, requests } = createTestLogger();
+    const metrics = createRequestMetricsStore({ sampleCapacity: 10 });
+
+    const app = new Hono();
+    app.onError(errorHandler);
+    app.use('*', makeRequestTiming({ logger, metrics, now: stepClock(7) }));
+    app.get('/api/v1/rooms/:id', () => {
+      throw new AppError(403, 'Forbidden', 'FORBIDDEN');
+    });
+
+    const response = await app.request('/api/v1/rooms/1');
+    expect(response.status).toBe(403);
+
+    expect(requests()[0]).toMatchObject({ status: 403, durationMs: 7, level: 30 });
+    expect(metrics.snapshot().statusClasses['4xx']).toBe(1);
+  });
+
+  it('records an unexpected throw as the 500 the caller receives, at warn level', async () => {
+    const { logger, requests } = createTestLogger();
+    const metrics = createRequestMetricsStore({ sampleCapacity: 10 });
+
+    const app = new Hono();
+    app.onError(errorHandler);
+    app.use('*', makeRequestTiming({ logger, metrics, now: stepClock(3) }));
+    app.get('/boom', () => {
+      throw new Error('kaboom');
+    });
+
+    const response = await app.request('/boom');
+    expect(response.status).toBe(500);
+
+    // pino's numeric levels: 40 is warn, so a 5xx rises above the info floor.
+    expect(requests()[0]).toMatchObject({ status: 500, level: 40 });
+    expect(metrics.snapshot().statusClasses['5xx']).toBe(1);
+  });
+
+  it('leaves skipped requests out of both the log and the aggregate', async () => {
+    const { logger, requests } = createTestLogger();
+    const metrics = createRequestMetricsStore({ sampleCapacity: 10 });
+
+    const app = new Hono();
+    app.use(
+      '*',
+      makeRequestTiming({
+        logger,
+        metrics,
+        now: stepClock(1),
+        skip: (c) => c.req.path === '/api/v1/health',
+      }),
+    );
+    app.get('/api/v1/health', (c) => c.json({ status: 'ok' }, 200));
+    app.get('/api/v1/rooms', (c) => c.json([], 200));
+
+    await app.request('/api/v1/health');
+    await app.request('/api/v1/rooms');
+
+    expect(requests()).toHaveLength(1);
+    expect(requests()[0]?.path).toBe('/api/v1/rooms');
+    expect(metrics.snapshot().totalRequests).toBe(1);
+  });
+
+  it('does not log credentials carried on the timed request', async () => {
+    const { logger, requests } = createTestLogger();
+    const metrics = createRequestMetricsStore({ sampleCapacity: 10 });
+
+    const app = new Hono();
+    app.use('*', makeRequestTiming({ logger, metrics, now: stepClock(1) }));
+    app.get('/api/v1/users/me', (c) => c.json({ ok: true }, 200));
+
+    await app.request('/api/v1/users/me', {
+      headers: { authorization: 'Bearer super-secret-token', cookie: 'access_token=secret' },
+    });
+
+    expect(JSON.stringify(requests())).not.toContain('secret');
+  });
+});

--- a/backend/tests/unit/utils/performanceMetrics.test.ts
+++ b/backend/tests/unit/utils/performanceMetrics.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from 'bun:test';
+import {
+  DEFAULT_LATENCY_SAMPLE_CAPACITY,
+  createProcessMetricsSampler,
+  createRequestMetricsStore,
+  type RequestMetricsStore,
+} from '../../../src/utils/performanceMetrics';
+
+const recordDurations = (store: RequestMetricsStore, durations: number[], status = 200): void => {
+  for (const durationMs of durations) {
+    store.record({ method: 'GET', path: '/api/v1/health', status, durationMs });
+  }
+};
+
+describe('createRequestMetricsStore', () => {
+  it('rejects a capacity that could not bound anything', () => {
+    for (const sampleCapacity of [0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(() => createRequestMetricsStore({ sampleCapacity })).toThrow(RangeError);
+    }
+  });
+
+  it('reports zeroed latency before anything is recorded', () => {
+    const snapshot = createRequestMetricsStore({ sampleCapacity: 4 }).snapshot();
+
+    expect(snapshot.totalRequests).toBe(0);
+    expect(snapshot.sampleSize).toBe(0);
+    expect(snapshot.sampleCapacity).toBe(4);
+    expect(snapshot.latency).toEqual({ count: 0, avgMs: 0, p50Ms: 0, p95Ms: 0, p99Ms: 0, maxMs: 0 });
+  });
+
+  it('defaults to the documented sample capacity', () => {
+    expect(createRequestMetricsStore().sampleCapacity).toBe(DEFAULT_LATENCY_SAMPLE_CAPACITY);
+  });
+
+  it('summarises latency over the recorded requests', () => {
+    const store = createRequestMetricsStore({ sampleCapacity: 100 });
+    recordDurations(
+      store,
+      Array.from({ length: 100 }, (_, index) => index + 1),
+    );
+
+    const { latency, totalRequests } = store.snapshot();
+    expect(totalRequests).toBe(100);
+    expect(latency.count).toBe(100);
+    expect(latency.avgMs).toBe(50.5);
+    expect(latency.p50Ms).toBe(50);
+    expect(latency.p95Ms).toBe(95);
+    expect(latency.p99Ms).toBe(99);
+    expect(latency.maxMs).toBe(100);
+  });
+
+  it('counts every request but summarises only the most recent window', () => {
+    const store = createRequestMetricsStore({ sampleCapacity: 3 });
+    recordDurations(store, [1000, 1000, 5, 6, 7]);
+
+    const snapshot = store.snapshot();
+    expect(snapshot.totalRequests).toBe(5);
+    expect(snapshot.sampleSize).toBe(3);
+    expect(snapshot.latency.maxMs).toBe(7);
+    expect(snapshot.latency.avgMs).toBe(6);
+  });
+
+  it('classifies statuses and keeps unknown ones out of the real classes', () => {
+    const store = createRequestMetricsStore({ sampleCapacity: 10 });
+    for (const status of [200, 201, 304, 404, 429, 500, 503, 0, 999]) {
+      store.record({ method: 'GET', path: '/x', status, durationMs: 1 });
+    }
+
+    expect(store.snapshot().statusClasses).toEqual({
+      '1xx': 0,
+      '2xx': 2,
+      '3xx': 1,
+      '4xx': 2,
+      '5xx': 2,
+      other: 2,
+    });
+  });
+
+  it('counts a non-finite duration without letting it poison the percentiles', () => {
+    const store = createRequestMetricsStore({ sampleCapacity: 5 });
+    recordDurations(store, [10, 20]);
+    store.record({ method: 'GET', path: '/x', status: 200, durationMs: Number.NaN });
+
+    const snapshot = store.snapshot();
+    expect(snapshot.totalRequests).toBe(3);
+    expect(snapshot.sampleSize).toBe(2);
+    expect(snapshot.latency.avgMs).toBe(15);
+    expect(snapshot.latency.maxMs).toBe(20);
+  });
+
+  it('clamps a negative duration rather than recording time running backwards', () => {
+    const store = createRequestMetricsStore({ sampleCapacity: 5 });
+    recordDurations(store, [-3]);
+
+    expect(store.snapshot().latency.maxMs).toBe(0);
+  });
+
+  it('hands out a copy of the status counts, not the live object', () => {
+    const store = createRequestMetricsStore({ sampleCapacity: 5 });
+    recordDurations(store, [1]);
+
+    const first = store.snapshot();
+    first.statusClasses['2xx'] = 999;
+
+    expect(store.snapshot().statusClasses['2xx']).toBe(1);
+  });
+
+  it('clears counters and the latency window on reset', () => {
+    const store = createRequestMetricsStore({ sampleCapacity: 5 });
+    recordDurations(store, [10, 20], 500);
+    store.reset();
+
+    const snapshot = store.snapshot();
+    expect(snapshot.totalRequests).toBe(0);
+    expect(snapshot.sampleSize).toBe(0);
+    expect(snapshot.statusClasses['5xx']).toBe(0);
+    expect(snapshot.latency.maxMs).toBe(0);
+  });
+});
+
+describe('createProcessMetricsSampler', () => {
+  const fixedMemory = (): NodeJS.MemoryUsage => ({
+    rss: 100,
+    heapTotal: 80,
+    heapUsed: 60,
+    external: 40,
+    arrayBuffers: 20,
+  });
+
+  it('reports process usage and no CPU percentage on the first sample', () => {
+    const sampler = createProcessMetricsSampler({
+      cpuUsage: () => ({ user: 2_000, system: 1_000 }),
+      memoryUsage: fixedMemory,
+      uptime: () => 12.5,
+      now: () => 0,
+    });
+
+    const snapshot = sampler.sample();
+    expect(snapshot.uptimeSeconds).toBe(12.5);
+    expect(snapshot.cpu).toEqual({ userMs: 2, systemMs: 1, percent: null });
+    expect(snapshot.memory).toEqual({
+      rssBytes: 100,
+      heapUsedBytes: 60,
+      heapTotalBytes: 80,
+      externalBytes: 40,
+    });
+  });
+
+  it('derives CPU percentage from the delta since the previous sample', () => {
+    let cpu: NodeJS.CpuUsage = { user: 0, system: 0 };
+    let clock = 0;
+    const sampler = createProcessMetricsSampler({
+      cpuUsage: () => cpu,
+      memoryUsage: fixedMemory,
+      uptime: () => 1,
+      now: () => clock,
+    });
+
+    sampler.sample();
+    // 50 ms of CPU (30 ms user + 20 ms system) over 100 ms of wall clock.
+    cpu = { user: 30_000, system: 20_000 };
+    clock = 100;
+
+    expect(sampler.sample().cpu.percent).toBe(50);
+  });
+
+  it('leaves the percentage unknown when no wall-clock time has passed', () => {
+    const sampler = createProcessMetricsSampler({
+      cpuUsage: () => ({ user: 1_000, system: 0 }),
+      memoryUsage: fixedMemory,
+      uptime: () => 1,
+      now: () => 42,
+    });
+
+    sampler.sample();
+    expect(sampler.sample().cpu.percent).toBeNull();
+  });
+});


### PR DESCRIPTION
## 變更描述 (Description)

以高解析度計時記錄每個 API 請求耗時，並彙整為可供後續 admin `GET /api/v1/admin/metrics`（#569）讀取的即時指標。本 PR 為 #280 拆解後的第三個 sub-issue，依賴已合併的 #566（pino 結構化日誌）。

### 核心變更

1. **`backend/src/middlewares/requestTiming.ts`** — 以 `performance.now()`（單調且具次毫秒精度，避免系統時鐘調整造成負值、也不會讓快速 handler 一律進位為 `0`）量測每個請求，並以結構化欄位 `method` / `path` / `status` / `durationMs` 寫入 #566 的 logger。
   - 計時放在 `finally`，因此**拋錯的請求同樣會被記錄**——只量測 happy path 的中間件，恰好會在服務不健康時低估延遲。
   - 錯誤路徑的 status 由 `AppError.statusCode` 推導（其餘視為 500）：`errorHandler` 是 `onError`，要等中間件退棧後才建立回應，此時 `c.res.status` 尚無意義；此做法讓記錄的狀態與呼叫端實際收到的一致。錯誤本身原樣重拋，回報仍由 `errorHandler` 負責。
   - 5xx 以 `warn` 記錄（服務自身的問題，應高於正式環境常用的 info 門檻）；4xx 維持 `info`，避免掃描器灌爆 warn 串流。
   - 支援 `skip` 選項（例如健康檢查），以及可注入的 `logger` / `metrics` / `now` 以利測試。

2. **`backend/src/utils/performanceMetrics.ts`** — 兩個以介面封裝的指標來源，讓 #569 的端點不綁定 in-memory 實作：
   - `RequestMetricsStore`：終身請求計數與 status class 計數（1xx–5xx、other），加上有界的最近 1000 筆耗時環形緩衝，計算 avg / p50 / p95 / p99 / max。`record()` 為 O(1)（僅更新計數器與覆寫一個槽位），排序成本只在 `snapshot()` 支付，而該方法僅由管理員輪詢觸發。
   - `ProcessMetricsSampler`：於呼叫時才取樣 CPU（user/system）、記憶體（RSS / heap / external）與 uptime。CPU 百分比由與前次取樣的差分得出（首次為 `null`，因為沒有可差分的基準點）；刻意不使用背景計時器，以免在無人查看指標時仍讓 process 保持忙碌與存活。

3. **`backend/src/bootstrap/httpApp.ts`** — 將 `requestTiming` 掛在**安全標頭之後、`cors()` 與全域 rate limiter 之前**。

### 掛載位置：與 #567 原文的一項刻意偏離

#567 原文寫的是「置於 CORS/安全標頭之後」，但那正是會漏量的位置：`hono/cors` 對 `OPTIONS` preflight 是 `return new Response(null, { status: 204 })` 而**不呼叫 `next()`**，因此掛在其後的計時中間件對 preflight 完全不會執行，`totalRequests`、2xx 計數與延遲樣本會持續漏掉所有 preflight 流量（由 Codex review 指出，已驗證屬實）。

因此改掛在 `cors()` 之前，讓它包住這個短路回應；同理也掛在 rate limiter 之外——被限流擋下的 429 仍應計入，429 突增本身就是訊號，不該從指標中隱藏。此行為由回歸測試鎖定（直接驅動真實的 `cors()`，而非替身）。

### 刻意的取捨

- 指標為 per-process、重啟即失，與 #566 的 recent-log buffer 相同取捨；跨 process 匯整待 Redis（#472 / #283）落地後可單點替換，admin API 不需改動。
- 非有限（NaN / Infinity）耗時會計入請求總數但不進入延遲窗口，以免污染此後所有百分位數；負值耗時則夾到 0。
- 延遲摘要涵蓋「最近 `sampleCapacity` 筆」而非全時段（百分位需保留個別觀測值，全時段保留正是本模組要避免的無界成長）；`totalRequests` 仍為終身計數。

## 相關的 Issue (Related Issue)

Closes #567

Parent: #280 ／ Depends on: #566（已合併）

## 變更類型 (Type of Change)
- [x] `feat`: 新增功能 (Feature)
- [x] `test`: 新增或修正測試案例

## 驗證與測試計畫 (Verification & Test Plan)

### 本地測試 (Local Tests)
- [x] 後端型別檢查 (`pnpm exec tsc --noEmit`)
- [x] 單元測試 (`pnpm run test:unit`) — 538 pass / 0 fail（含本 PR 新增的 20 個測試）
- [x] 後端 Linter (`pnpm exec eslint src`)
- [ ] 前端型別檢查／Linter — 本 PR 未變更前端
- [ ] 整合測試 — 本 PR 未觸及 repository／schema，整合測試範圍不受影響

新增測試：

- `backend/tests/unit/utils/performanceMetrics.test.ts`：百分位數計算、視窗溢位後仍保留終身計數、status class 分類（含超出範圍的 `other`）、非有限值不污染統計、負值夾持、`snapshot()` 回傳副本而非活物件、`reset()`；process sampler 的首次 `null`、差分百分比、零時距時維持未知。
- `backend/tests/unit/middlewares/requestTiming.test.ts`：以假 handler 驗證日誌含數值 `durationMs` 與 `method`/`path`/`status`、彙整計數更新、`AppError` 拋錯記錄 403 且原樣重拋、未預期例外記為 500 且為 warn 等級、`skip` 同時排除日誌與彙整、請求攜帶的 `authorization`/`cookie` 憑證不會出現在日誌中、**CORS preflight（未進入任何路由）仍被記為 204 並計入彙整**。

### 手動驗證 (Manual Verification)

啟動後端後對任一 API 發出請求，stdout 會出現含 `method` / `path` / `status` / `durationMs` 的結構化日誌行（符合 #567 驗收標準）。

## 資料庫變更 (Database Changes)
* 此變更是否包含資料庫 Schema 修改？ **否**

## API 與 WebSocket 協定一致性 (API & WebSocket Contract Check)
* 此變更是否涉及 API 路由或 WebSocket 事件的資料結構變更？ **否**（本 PR 只新增中間件與行內彙整，未新增或修改任何端點；`/admin/metrics` 端點由 #569 負責，屆時再同步 `docs/api-documentation.md`）