### PR TITLE
test(ci): add realtime smoke test suite for issue #536

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -146,6 +146,7 @@ jobs:
       - name: Run the realtime smoke suite against the production image
         env:
           SMOKE_API_URL: http://localhost:4005
+          SMOKE_STATE_FILE: ${{ runner.temp }}/smoke-state.json
         run: cd backend && bun run smoke
 
       - name: Gracefully restart the backend container
@@ -170,6 +171,7 @@ jobs:
       - name: Re-run the realtime smoke suite after the restart
         env:
           SMOKE_API_URL: http://localhost:4005
+          SMOKE_STATE_FILE: ${{ runner.temp }}/smoke-state.json
         run: cd backend && bun run smoke
 
       - name: Assert re-applying the bundle is a no-op
@@ -251,6 +253,7 @@ jobs:
       - name: Run the realtime smoke suite against the development image
         env:
           SMOKE_API_URL: http://localhost:4005
+          SMOKE_STATE_FILE: ${{ runner.temp }}/smoke-state.json
         run: cd backend && bun run smoke
 
       - name: Gracefully restart the backend container
@@ -275,6 +278,7 @@ jobs:
       - name: Re-run the realtime smoke suite after the restart
         env:
           SMOKE_API_URL: http://localhost:4005
+          SMOKE_STATE_FILE: ${{ runner.temp }}/smoke-state.json
         run: cd backend && bun run smoke
 
       - name: Collect service logs

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -231,23 +231,33 @@ jobs:
           RATE_LIMIT_DISABLED=false
           EOF
 
+      # `--wait` here is deliberate rather than incidental: it is the command
+      # docs/DEVELOPMENT.md tells developers to run, and it only means anything
+      # because the backend service defines a healthcheck. Running it in CI is
+      # what keeps that healthcheck honest — if it ever stops reporting
+      # readiness correctly, this step fails instead of developers silently
+      # getting a connection refused right after `up --wait` returns.
       - name: Build and start db, redis and backend from the dev compose
         run: |
           set -euo pipefail
           docker compose --env-file "$RUNNER_TEMP/dev.env" \
-            -f docker-compose.yml up -d --build db redis backend
+            -f docker-compose.yml up -d --build --wait --wait-timeout 300 db redis backend
 
-      - name: Wait for the backend to serve health
+      # Not redundant with `--wait` above: the healthcheck probes 127.0.0.1
+      # from inside the container, so it says nothing about the published
+      # port. This asserts the backend is reachable the way the smoke suite
+      # and a developer's browser actually reach it.
+      - name: Assert the backend is reachable on the published port
         run: |
           set -euo pipefail
-          for attempt in {1..60}; do
+          for attempt in {1..30}; do
             if curl -sS --max-time 5 -o /dev/null "http://localhost:4005/api/v1/health" 2>/dev/null; then
-              echo "backend answered on attempt ${attempt}"
+              echo "backend answered on the published port on attempt ${attempt}"
               exit 0
             fi
             sleep 1
           done
-          echo "::error::backend did not serve /api/v1/health on :4005 within 60s" >&2
+          echo "::error::backend is healthy in-container but not reachable on :4005 — check the port mapping" >&2
           exit 1
 
       - name: Run the realtime smoke suite against the development image

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -67,6 +67,13 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # Only needed to run backend/scripts/smoke.ts from the runner below —
+      # the compose stack itself is unaffected by this.
+      - uses: ./.github/actions/setup-workspace
+        with:
+          package: near-chat-backend
+          bun: 'true'
+
       # ~2-4 min cold. Left uncached on purpose: a stale layer cache is exactly
       # what would hide a runtime/layout drift from this job.
       - name: Build the production backend image
@@ -114,10 +121,11 @@ jobs:
       - name: Assert the backend serves HTTP
         run: |
           set -euo pipefail
-          # No healthcheck and no health route, so probe any path. A response
-          # carrying the security headers proves the Hono middleware chain ran,
-          # not merely that something is holding the port. The status itself is
-          # deliberately not asserted: an unmatched path is a 404 by design.
+          # No healthcheck on this compose service. Probes an unmatched path
+          # rather than /api/v1/health so the response carrying the security
+          # headers proves the Hono middleware chain ran, not merely that
+          # something is holding the port. The status itself is deliberately
+          # not asserted: an unmatched path is a 404 by design.
           for attempt in {1..30}; do
             if curl -sS --max-time 5 -o /dev/null -D "$RUNNER_TEMP/probe.headers" \
               http://localhost:4005/api/v1/ci-startup-probe 2>/dev/null \
@@ -130,6 +138,39 @@ jobs:
           done
           echo "::error::backend did not serve an HTTP response on :4005 within 30s"
           exit 1
+
+      # Covers the remaining issue #536 acceptance criteria not exercised
+      # above: connect, reliable send, sync-cursor repair and over-limit
+      # handling against the real production image, then the same checks
+      # again after a graceful restart to prove recovery holds.
+      - name: Run the realtime smoke suite against the production image
+        env:
+          SMOKE_API_URL: http://localhost:4005
+        run: cd backend && bun run smoke
+
+      - name: Gracefully restart the backend container
+        run: |
+          set -euo pipefail
+          docker compose --env-file "$RUNNER_TEMP/release.env" \
+            -f docker-compose.release.yml restart backend
+
+      - name: Wait for the backend to answer again after restart
+        run: |
+          set -euo pipefail
+          for attempt in {1..30}; do
+            if curl -sS --max-time 5 -o /dev/null "http://localhost:4005/api/v1/health" 2>/dev/null; then
+              echo "backend answered again on attempt ${attempt}"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::backend did not recover on :4005 within 30s of a graceful restart" >&2
+          exit 1
+
+      - name: Re-run the realtime smoke suite after the restart
+        env:
+          SMOKE_API_URL: http://localhost:4005
+        run: cd backend && bun run smoke
 
       - name: Assert re-applying the bundle is a no-op
         run: |
@@ -150,3 +191,100 @@ jobs:
         run: |
           docker compose --env-file "$RUNNER_TEMP/release.env" \
             -f docker-compose.release.yml down -v --remove-orphans
+
+  # Mirrors release-compose above, but against the development image
+  # (docker-compose.yml, backend/Dockerfile) rather than the production one.
+  # Issue #536 requires both images to build and pass the same realtime smoke
+  # suite, and a bug specific to the dev Dockerfile or dev compose wiring
+  # (e.g. the bind-mounted node_modules setup) would not show up in
+  # release-compose at all.
+  dev-compose-smoke:
+    name: dev compose boots on the development image
+    if: inputs.run-build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: ./.github/actions/setup-workspace
+        with:
+          package: near-chat-backend
+          bun: 'true'
+
+      - name: Write a throwaway dev env file
+        run: |
+          set -euo pipefail
+          # docker-compose.yml runs `pnpm run migrate:up && pnpm run dev` as its
+          # own command, so migration happens as part of `up` here, unlike the
+          # release compose's separate `migrate` service.
+          cat > "$RUNNER_TEMP/dev.env" <<'EOF'
+          NODE_ENV=development
+          POSTGRES_USER=near
+          POSTGRES_PASSWORD=near
+          POSTGRES_DB=near_chat
+          DATABASE_URL=postgresql://near:near@db:5432/near_chat
+          PORT=4000
+          JWT_SECRET=ci-only-value-not-a-real-secret
+          JWT_EXPIRES_IN=15m
+          CORS_ORIGINS=http://localhost:3005
+          RATE_LIMIT_DISABLED=false
+          EOF
+
+      - name: Build and start db, redis and backend from the dev compose
+        run: |
+          set -euo pipefail
+          docker compose --env-file "$RUNNER_TEMP/dev.env" \
+            -f docker-compose.yml up -d --build db redis backend
+
+      - name: Wait for the backend to serve health
+        run: |
+          set -euo pipefail
+          for attempt in {1..60}; do
+            if curl -sS --max-time 5 -o /dev/null "http://localhost:4005/api/v1/health" 2>/dev/null; then
+              echo "backend answered on attempt ${attempt}"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::backend did not serve /api/v1/health on :4005 within 60s" >&2
+          exit 1
+
+      - name: Run the realtime smoke suite against the development image
+        env:
+          SMOKE_API_URL: http://localhost:4005
+        run: cd backend && bun run smoke
+
+      - name: Gracefully restart the backend container
+        run: |
+          set -euo pipefail
+          docker compose --env-file "$RUNNER_TEMP/dev.env" \
+            -f docker-compose.yml restart backend
+
+      - name: Wait for the backend to answer again after restart
+        run: |
+          set -euo pipefail
+          for attempt in {1..60}; do
+            if curl -sS --max-time 5 -o /dev/null "http://localhost:4005/api/v1/health" 2>/dev/null; then
+              echo "backend answered again on attempt ${attempt}"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::backend did not recover on :4005 within 60s of a graceful restart" >&2
+          exit 1
+
+      - name: Re-run the realtime smoke suite after the restart
+        env:
+          SMOKE_API_URL: http://localhost:4005
+        run: cd backend && bun run smoke
+
+      - name: Collect service logs
+        if: failure()
+        run: |
+          docker compose --env-file "$RUNNER_TEMP/dev.env" \
+            -f docker-compose.yml logs --no-color db redis backend
+
+      - name: Tear the stack down
+        if: always()
+        run: |
+          docker compose --env-file "$RUNNER_TEMP/dev.env" \
+            -f docker-compose.yml down -v --remove-orphans

--- a/backend/package.json
+++ b/backend/package.json
@@ -20,7 +20,8 @@
     "test:db:up": "docker compose -f ../docker-compose.test.yml up -d --wait && pnpm run migrate:test",
     "test:db:down": "docker compose -f ../docker-compose.test.yml down",
     "migrate:test": "DATABASE_URL=postgresql://postgres:postgres@localhost:5436/ntnu_test bun src/models/migrate.ts up",
-    "lint": "eslint src && tsc --noEmit"
+    "lint": "eslint src && tsc --noEmit",
+    "smoke": "bun run scripts/smoke.ts"
   },
   "dependencies": {
     "@hono/zod-validator": "^0.9.0",

--- a/backend/scripts/smoke.ts
+++ b/backend/scripts/smoke.ts
@@ -1,0 +1,223 @@
+#!/usr/bin/env bun
+/**
+ * WebSocket/REST smoke test for a running near-chat stack (dev or
+ * production-like Docker Compose). Exercises exactly the acceptance criteria
+ * of issue #536: connect, reliable send, sync-cursor repair, over-limit
+ * handling. Graceful restart is exercised by the caller (see
+ * `scripts/smoke.sh`), which runs this script once before and once after
+ * restarting the backend container.
+ *
+ * Every check prints its own actionable diagnostic on failure and the script
+ * exits non-zero if any check failed, so it is safe to wire directly into a
+ * CI step without extra log-scraping.
+ */
+import { io as ioClient, type Socket } from 'socket.io-client';
+
+const BASE_URL = (process.env.SMOKE_API_URL ?? 'http://localhost:4005').replace(/\/$/, '');
+const RUN_ID = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+interface CheckResult {
+  name: string;
+  ok: boolean;
+  detail?: string;
+}
+
+const results: CheckResult[] = [];
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+async function run(name: string, fn: () => Promise<void>): Promise<void> {
+  process.stdout.write(`- ${name} ... `);
+  try {
+    await fn();
+    results.push({ name, ok: true });
+    console.log('OK');
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    results.push({ name, ok: false, detail });
+    console.log('FAIL');
+    console.error(`    ${detail.split('\n').join('\n    ')}`);
+  }
+}
+
+async function api(
+  path: string,
+  init: RequestInit & { token?: string } = {},
+): Promise<{ status: number; body: any }> {
+  const headers = new Headers(init.headers);
+  headers.set('Content-Type', 'application/json');
+  if (init.token) headers.set('Authorization', `Bearer ${init.token}`);
+  const res = await fetch(`${BASE_URL}${path}`, { ...init, headers });
+  const text = await res.text();
+  let body: any = text;
+  try {
+    body = text ? JSON.parse(text) : undefined;
+  } catch {
+    // non-JSON body (e.g. 204); leave as raw text
+  }
+  return { status: res.status, body };
+}
+
+async function register(email: string, name: string, password = 'Password123!') {
+  const res = await api('/api/v1/auth/register', {
+    method: 'POST',
+    body: JSON.stringify({ email, name, password }),
+  });
+  assert(
+    res.status === 201,
+    `expected 201 registering ${email}, got ${res.status}: ${JSON.stringify(res.body)}`,
+  );
+  return res.body.token as string;
+}
+
+async function createRoom(token: string, name: string): Promise<string> {
+  const res = await api('/api/v1/rooms', {
+    method: 'POST',
+    token,
+    body: JSON.stringify({ type: 'group', name }),
+  });
+  assert(res.status === 201, `expected 201 creating room, got ${res.status}: ${JSON.stringify(res.body)}`);
+  return res.body.roomId as string;
+}
+
+function connectSocket(token: string): Promise<Socket> {
+  return new Promise((resolve, reject) => {
+    const socket = ioClient(BASE_URL, {
+      auth: { token },
+      transports: ['websocket'],
+      reconnection: false,
+      timeout: 10_000,
+    });
+    const timer = setTimeout(() => {
+      socket.close();
+      reject(new Error('timed out waiting for realtime_ready within 10s'));
+    }, 10_000);
+    socket.once('realtime_ready', () => {
+      clearTimeout(timer);
+      resolve(socket);
+    });
+    socket.once('connect_error', (err) => {
+      clearTimeout(timer);
+      reject(new Error(`socket connect_error: ${err.message}`));
+    });
+  });
+}
+
+async function main() {
+  console.log(`near-chat realtime smoke test against ${BASE_URL}`);
+
+  await run('health endpoint responds', async () => {
+    const res = await api('/api/v1/health');
+    assert(res.status === 200, `expected 200, got ${res.status}: ${JSON.stringify(res.body)}`);
+    assert(res.body?.status === 'ok', `expected {status:"ok"}, got ${JSON.stringify(res.body)}`);
+  });
+
+  let token = '';
+  let roomId = '';
+  let socket: Socket | undefined;
+
+  await run('socket connects and reaches realtime_ready', async () => {
+    token = await register(`smoke-${RUN_ID}@example.com`, 'Smoke User');
+    roomId = await createRoom(token, `smoke-room-${RUN_ID}`);
+    socket = await connectSocket(token);
+  });
+
+  await run('reliable send is idempotent under a retried command', async () => {
+    assert(roomId, 'no room available from the previous check');
+    const key = `smoke-create-${RUN_ID}`;
+    const first = await api(`/api/v1/rooms/${roomId}/messages`, {
+      method: 'POST',
+      token,
+      headers: { 'Idempotency-Key': key },
+      body: JSON.stringify({ content: 'first attempt' }),
+    });
+    const retry = await api(`/api/v1/rooms/${roomId}/messages`, {
+      method: 'POST',
+      token,
+      headers: { 'Idempotency-Key': key },
+      body: JSON.stringify({ content: 'retried attempt' }),
+    });
+    assert(first.status === 201, `expected 201 on first send, got ${first.status}: ${JSON.stringify(first.body)}`);
+    assert(retry.status === 201, `expected 201 on retried send, got ${retry.status}: ${JSON.stringify(retry.body)}`);
+    assert(
+      retry.body.messageId === first.body.messageId,
+      `retry created a second message: first=${first.body.messageId} retry=${retry.body.messageId}`,
+    );
+    assert(
+      retry.body.content === 'first attempt',
+      `retry applied the retried body instead of replaying the first one: got "${retry.body.content}"`,
+    );
+  });
+
+  await run('sync cursor repairs a change missed while disconnected', async () => {
+    assert(socket, 'no socket available from the connect check');
+    socket.close();
+    const key = `smoke-offline-${RUN_ID}`;
+    const offline = await api(`/api/v1/rooms/${roomId}/messages`, {
+      method: 'POST',
+      token,
+      headers: { 'Idempotency-Key': key },
+      body: JSON.stringify({ content: 'sent while disconnected' }),
+    });
+    assert(
+      offline.status === 201,
+      `expected 201 sending while disconnected, got ${offline.status}: ${JSON.stringify(offline.body)}`,
+    );
+
+    const reconnected = await connectSocket(token);
+    reconnected.close();
+
+    const sync = await api('/api/v1/sync?cursor=0&limit=100', { token });
+    assert(sync.status === 200, `expected 200 from /sync, got ${sync.status}: ${JSON.stringify(sync.body)}`);
+    const changes: Array<{ message?: { messageId?: string } }> = sync.body.changes ?? [];
+    assert(
+      changes.some((change) => change.message?.messageId === offline.body.messageId),
+      `sync cursor did not return the message sent while disconnected (messageId=${offline.body.messageId}); got ${changes.length} change(s)`,
+    );
+  });
+
+  await run('over-limit auth requests are rejected with 429', async () => {
+    const email = `smoke-ratelimit-${RUN_ID}@example.com`;
+    await register(email, 'Smoke Ratelimit User');
+    let sawTooManyRequests = false;
+    const attempts = 15;
+    for (let attempt = 1; attempt <= attempts && !sawTooManyRequests; attempt += 1) {
+      const res = await api('/api/v1/auth/login', {
+        method: 'POST',
+        body: JSON.stringify({ email, password: 'wrong-password' }),
+      });
+      if (res.status === 429) {
+        sawTooManyRequests = true;
+        assert(
+          res.body?.code === 'TOO_MANY_REQUESTS',
+          `expected code TOO_MANY_REQUESTS on 429, got ${JSON.stringify(res.body)}`,
+        );
+      } else {
+        assert(
+          res.status === 401,
+          `expected 401 for a wrong-password login attempt (or 429 once over the limit), got ${res.status}: ${JSON.stringify(res.body)}`,
+        );
+      }
+    }
+    assert(
+      sawTooManyRequests,
+      `never received a 429 after ${attempts} failed login attempts — is RATE_LIMIT_DISABLED set on this stack?`,
+    );
+  });
+
+  const failed = results.filter((r) => !r.ok);
+  console.log('');
+  console.log(`${results.length - failed.length}/${results.length} checks passed`);
+  if (failed.length > 0) {
+    console.error('Failing checks:');
+    for (const f of failed) console.error(`  - ${f.name}: ${f.detail}`);
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error('smoke test crashed unexpectedly:', err);
+  process.exit(1);
+});

--- a/backend/scripts/smoke.ts
+++ b/backend/scripts/smoke.ts
@@ -196,8 +196,8 @@ async function main() {
         );
       } else {
         assert(
-          res.status === 401,
-          `expected 401 for a wrong-password login attempt (or 429 once over the limit), got ${res.status}: ${JSON.stringify(res.body)}`,
+          res.status === 400,
+          `expected 400 for a wrong-password login attempt (or 429 once over the limit), got ${res.status}: ${JSON.stringify(res.body)}`,
         );
       }
     }

--- a/backend/scripts/smoke.ts
+++ b/backend/scripts/smoke.ts
@@ -1,15 +1,22 @@
 #!/usr/bin/env bun
 /**
  * WebSocket/REST smoke test for a running near-chat stack (dev or
- * production-like Docker Compose). Exercises exactly the acceptance criteria
- * of issue #536: connect, reliable send, sync-cursor repair, over-limit
+ * production-like Docker Compose). Exercises the acceptance criteria of
+ * issue #536: connect, reliable send, sync-cursor repair, over-limit
  * handling. Graceful restart is exercised by the caller (see
- * `scripts/smoke.sh`), which runs this script once before and once after
- * restarting the backend container.
+ * `.github/workflows/ci-backend.yml`), which runs this script once before
+ * and once after restarting the backend container.
  *
  * Every check prints its own actionable diagnostic on failure and the script
  * exits non-zero if any check failed, so it is safe to wire directly into a
  * CI step without extra log-scraping.
+ *
+ * Set SMOKE_STATE_FILE to a shared path to also verify that state survives a
+ * restart: the first invocation (no file yet) writes a token/room/message
+ * triple to it after creating them; the second invocation (file already
+ * exists) reads it back and asserts /sync still has that message, so a
+ * restart that actually lost data — not just a rebuilt smoke run redoing its
+ * own setup — fails the check.
  */
 import { io as ioClient, type Socket } from 'socket.io-client';
 
@@ -116,6 +123,7 @@ async function main() {
 
   let token = '';
   let roomId = '';
+  let reliableMessageId = '';
   let socket: Socket | undefined;
 
   await run('socket connects and reaches realtime_ready', async () => {
@@ -149,7 +157,35 @@ async function main() {
       retry.body.content === 'first attempt',
       `retry applied the retried body instead of replaying the first one: got "${retry.body.content}"`,
     );
+    reliableMessageId = first.body.messageId as string;
   });
+
+  const stateFile = process.env.SMOKE_STATE_FILE;
+  if (stateFile) {
+    await run('durable state survives a backend restart', async () => {
+      assert(token && roomId && reliableMessageId, 'no durable state available from earlier checks');
+      const priorRunFile = Bun.file(stateFile);
+      if (await priorRunFile.exists()) {
+        const prior = JSON.parse(await priorRunFile.text()) as {
+          token: string;
+          roomId: string;
+          messageId: string;
+        };
+        const sync = await api('/api/v1/sync?cursor=0&limit=200', { token: prior.token });
+        assert(
+          sync.status === 200,
+          `expected 200 re-syncing with the pre-restart token, got ${sync.status}: ${JSON.stringify(sync.body)}`,
+        );
+        const changes: Array<{ message?: { messageId?: string; roomId?: string } }> = sync.body.changes ?? [];
+        assert(
+          changes.some((change) => change.message?.messageId === prior.messageId),
+          `message ${prior.messageId} (room ${prior.roomId}) created before the restart is missing from /sync — the restart lost durable state instead of just recovering the connection`,
+        );
+      } else {
+        await Bun.write(stateFile, JSON.stringify({ token, roomId, messageId: reliableMessageId }));
+      }
+    });
+  }
 
   await run('sync cursor repairs a change missed while disconnected', async () => {
     assert(socket, 'no socket available from the connect check');

--- a/backend/scripts/smoke.ts
+++ b/backend/scripts/smoke.ts
@@ -49,6 +49,14 @@ async function run(name: string, fn: () => Promise<void>): Promise<void> {
   }
 }
 
+/**
+ * A backend that accepts the connection but never answers — a deadlocked
+ * query, a wedged handler — would otherwise hang the whole suite on one
+ * request until the Actions job timeout, producing none of the per-check
+ * diagnostics this script promises. Every call therefore aborts on its own.
+ */
+const REQUEST_TIMEOUT_MS = Number(process.env.SMOKE_REQUEST_TIMEOUT_MS ?? 10_000);
+
 async function api(
   path: string,
   init: RequestInit & { token?: string } = {},
@@ -56,7 +64,22 @@ async function api(
   const headers = new Headers(init.headers);
   headers.set('Content-Type', 'application/json');
   if (init.token) headers.set('Authorization', `Bearer ${init.token}`);
-  const res = await fetch(`${BASE_URL}${path}`, { ...init, headers });
+  const method = init.method ?? 'GET';
+  let res: Response;
+  try {
+    res = await fetch(`${BASE_URL}${path}`, {
+      ...init,
+      headers,
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+  } catch (err) {
+    if (err instanceof Error && (err.name === 'TimeoutError' || err.name === 'AbortError')) {
+      throw new Error(
+        `${method} ${path} did not respond within ${REQUEST_TIMEOUT_MS}ms — the backend accepted the connection but never answered`,
+      );
+    }
+    throw err;
+  }
   const text = await res.text();
   let body: any = text;
   try {
@@ -189,6 +212,25 @@ async function main() {
 
   await run('sync cursor repairs a change missed while disconnected', async () => {
     assert(socket, 'no socket available from the connect check');
+
+    // Take the cursor the client would have held at disconnect time. Resuming
+    // from this non-zero value is the path a real client takes; querying
+    // cursor=0 instead is a full resync, which would still pass even if /sync
+    // ignored the cursor entirely or reported nextCursor wrongly.
+    const before = await api('/api/v1/sync?cursor=0&limit=200', { token });
+    assert(
+      before.status === 200,
+      `expected 200 taking the pre-disconnect cursor, got ${before.status}: ${JSON.stringify(before.body)}`,
+    );
+    const resumeCursor = before.body.nextCursor;
+    assert(
+      typeof resumeCursor === 'number' && resumeCursor > 0,
+      `expected a positive nextCursor after the earlier sends, got ${JSON.stringify(resumeCursor)}`,
+    );
+    const alreadyApplied: string[] = (before.body.changes ?? [])
+      .map((change: { message?: { messageId?: string } }) => change.message?.messageId)
+      .filter((id: string | undefined): id is string => Boolean(id));
+
     socket.close();
     const key = `smoke-offline-${RUN_ID}`;
     const offline = await api(`/api/v1/rooms/${roomId}/messages`, {
@@ -205,12 +247,20 @@ async function main() {
     const reconnected = await connectSocket(token);
     reconnected.close();
 
-    const sync = await api('/api/v1/sync?cursor=0&limit=100', { token });
+    const sync = await api(`/api/v1/sync?cursor=${resumeCursor}&limit=100`, { token });
     assert(sync.status === 200, `expected 200 from /sync, got ${sync.status}: ${JSON.stringify(sync.body)}`);
     const changes: Array<{ message?: { messageId?: string } }> = sync.body.changes ?? [];
     assert(
       changes.some((change) => change.message?.messageId === offline.body.messageId),
-      `sync cursor did not return the message sent while disconnected (messageId=${offline.body.messageId}); got ${changes.length} change(s)`,
+      `resuming from cursor ${resumeCursor} did not return the message sent while disconnected (messageId=${offline.body.messageId}); got ${changes.length} change(s)`,
+    );
+    // An incremental resume must not replay what the client already had.
+    const replayed = changes
+      .map((change) => change.message?.messageId)
+      .filter((id): id is string => Boolean(id) && alreadyApplied.includes(id!));
+    assert(
+      replayed.length === 0,
+      `resuming from cursor ${resumeCursor} replayed ${replayed.length} change(s) the client had already applied (${replayed.join(', ')}) — /sync is not honouring the cursor`,
     );
   });
 

--- a/backend/scripts/smoke.ts
+++ b/backend/scripts/smoke.ts
@@ -185,28 +185,35 @@ async function main() {
 
   const stateFile = process.env.SMOKE_STATE_FILE;
   if (stateFile) {
-    await run('durable state survives a backend restart', async () => {
+    // Named for what this invocation actually does, so the seeding run cannot
+    // read as though it had verified a restart it never saw.
+    const priorRunFile = Bun.file(stateFile);
+    const isVerifyingRun = await priorRunFile.exists();
+    const checkName = isVerifyingRun
+      ? 'durable state survives a backend restart'
+      : 'record durable state for the post-restart run';
+
+    await run(checkName, async () => {
       assert(token && roomId && reliableMessageId, 'no durable state available from earlier checks');
-      const priorRunFile = Bun.file(stateFile);
-      if (await priorRunFile.exists()) {
-        const prior = JSON.parse(await priorRunFile.text()) as {
-          token: string;
-          roomId: string;
-          messageId: string;
-        };
-        const sync = await api('/api/v1/sync?cursor=0&limit=200', { token: prior.token });
-        assert(
-          sync.status === 200,
-          `expected 200 re-syncing with the pre-restart token, got ${sync.status}: ${JSON.stringify(sync.body)}`,
-        );
-        const changes: Array<{ message?: { messageId?: string; roomId?: string } }> = sync.body.changes ?? [];
-        assert(
-          changes.some((change) => change.message?.messageId === prior.messageId),
-          `message ${prior.messageId} (room ${prior.roomId}) created before the restart is missing from /sync — the restart lost durable state instead of just recovering the connection`,
-        );
-      } else {
+      if (!isVerifyingRun) {
         await Bun.write(stateFile, JSON.stringify({ token, roomId, messageId: reliableMessageId }));
+        return;
       }
+      const prior = JSON.parse(await priorRunFile.text()) as {
+        token: string;
+        roomId: string;
+        messageId: string;
+      };
+      const sync = await api('/api/v1/sync?cursor=0&limit=200', { token: prior.token });
+      assert(
+        sync.status === 200,
+        `expected 200 re-syncing with the pre-restart token, got ${sync.status}: ${JSON.stringify(sync.body)}`,
+      );
+      const changes: Array<{ message?: { messageId?: string; roomId?: string } }> = sync.body.changes ?? [];
+      assert(
+        changes.some((change) => change.message?.messageId === prior.messageId),
+        `message ${prior.messageId} (room ${prior.roomId}) created before the restart is missing from /sync — the restart lost durable state instead of just recovering the connection`,
+      );
     });
   }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -117,6 +117,26 @@ services:
       redis:
         condition: service_healthy
     command: sh -c "pnpm run migrate:up && pnpm run dev"
+    # Without this, `up --wait` returns as soon as the container is *running* —
+    # which here is while `migrate:up` is still going and nothing is listening
+    # yet. Anything that starts working immediately after `--wait` (the smoke
+    # suite in docs/DEVELOPMENT.md, a script, a person) would then hit a
+    # connection refused. `bun` is the app runtime, so it is always present;
+    # there is deliberately no curl/wget in this image to depend on.
+    #
+    # start_period covers the migration: failures during it do not count toward
+    # `retries`, so a slow first-run migration delays readiness rather than
+    # marking the service unhealthy.
+    healthcheck:
+      test:
+        - CMD
+        - bun
+        - -e
+        - "const r = await fetch('http://127.0.0.1:4000/api/v1/health'); process.exit(r.ok ? 0 : 1)"
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 60s
 
   frontend:
     build:

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -108,20 +108,32 @@ connect (`realtime_ready`), a reliably-sent message (retried `Idempotency-Key`
 resolves to one message), sync-cursor repair after a disconnect, and
 over-limit auth requests (`429`/`TOO_MANY_REQUESTS`). It reads the target from
 `SMOKE_API_URL` (default `http://localhost:4005`) and exits non-zero with a
-per-check diagnostic on the first failure, so it needs a stack with
-`RATE_LIMIT_DISABLED` unset or `false` to exercise the last check. Run it
-against the dev stack with:
+per-check diagnostic on the first failure.
+
+The last check needs the rate limiter actually running, and `.env.example`
+ships `RATE_LIMIT_DISABLED=true` for everyday development — so override it for
+the smoke stack rather than running the default one:
 
 ```bash
-docker compose up -d --wait
+RATE_LIMIT_DISABLED=false docker compose up -d --wait --force-recreate backend
 SMOKE_API_URL=http://localhost:4005 pnpm --filter near-chat-backend run smoke
 ```
+
+`--force-recreate backend` is what makes the override take effect: Compose does
+not restart an already-running container just because an interpolated
+environment variable changed.
+
+Set `SMOKE_STATE_FILE` to a path to additionally verify that durable state
+survives a restart. The first run writes its token, room and message id there;
+a later run against the same file re-syncs with that saved token and asserts
+the pre-restart message is still returned, so a restart that dropped data fails
+rather than passing on freshly created state.
 
 CI runs this same script against both the development image
 (`docker-compose.yml`) and the production image (`docker-compose.release.yml`)
 in `ci-backend.yml`, once before and once after gracefully restarting the
-backend container, so a broken image or a restart that loses in-flight state
-fails the build.
+backend container, sharing one `SMOKE_STATE_FILE` across the pair — so a broken
+image, or a restart that loses committed state, fails the build.
 
 `MAX_SESSIONS_PER_USER`, `PRESENCE_GRACE_MS`, and `TYPING_TTL_MS` control local
 session, presence-reconnect, and typing-indication limits. Multi-node presence,

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -99,19 +99,29 @@ uses a 25-second ping interval and a 20-second ping timeout, so Bun's
 
 Durable message commands use REST and require an `Idempotency-Key`; edit and
 recall also require `If-Match`. After connecting, clients call `/api/v1/sync`
-with their last cursor. A minimal local smoke test is:
+with their last cursor.
+
+`backend/scripts/smoke.ts` (`pnpm --filter near-chat-backend run smoke`, or
+`bun run smoke` from `backend/`) is the automated realtime smoke test against
+a running stack. It registers a throwaway user and exercises health, socket
+connect (`realtime_ready`), a reliably-sent message (retried `Idempotency-Key`
+resolves to one message), sync-cursor repair after a disconnect, and
+over-limit auth requests (`429`/`TOO_MANY_REQUESTS`). It reads the target from
+`SMOKE_API_URL` (default `http://localhost:4005`) and exits non-zero with a
+per-check diagnostic on the first failure, so it needs a stack with
+`RATE_LIMIT_DISABLED` unset or `false` to exercise the last check. Run it
+against the dev stack with:
 
 ```bash
-curl -sS http://localhost:4005/api/v1/health
-# Register/login, then create a room and send a message with the same key twice:
-curl -sS -X POST http://localhost:4005/api/v1/rooms/<roomId>/messages \
-  -H "Authorization: Bearer <token>" \
-  -H "Idempotency-Key: smoke-create-1" \
-  -H 'Content-Type: application/json' \
-  -d '{"content":"smoke"}'
-curl -sS "http://localhost:4005/api/v1/sync?cursor=0&limit=100" \
-  -H "Authorization: Bearer <token>"
+docker compose up -d --wait
+SMOKE_API_URL=http://localhost:4005 pnpm --filter near-chat-backend run smoke
 ```
+
+CI runs this same script against both the development image
+(`docker-compose.yml`) and the production image (`docker-compose.release.yml`)
+in `ci-backend.yml`, once before and once after gracefully restarting the
+backend container, so a broken image or a restart that loses in-flight state
+fails the build.
 
 `MAX_SESSIONS_PER_USER`, `PRESENCE_GRACE_MS`, and `TYPING_TTL_MS` control local
 session, presence-reconnect, and typing-indication limits. Multi-node presence,

--- a/docs/ZH-TW/DEVELOPMENT.md
+++ b/docs/ZH-TW/DEVELOPMENT.md
@@ -99,19 +99,29 @@ supertest 相容測試使用。Socket.IO ping interval 為 25 秒、ping timeout
 `realtime_ready`、可靠發送（重送同一個 `Idempotency-Key` 只會產生一則訊息）、
 斷線後靠 sync cursor 補齊變更，以及超限的驗證請求會回傳
 `429`／`TOO_MANY_REQUESTS`。目標位址讀取自 `SMOKE_API_URL`（預設
-`http://localhost:4005`），任何一項失敗都會印出可行動的診斷訊息並以非零結束；
-最後一項檢查需要 stack 的 `RATE_LIMIT_DISABLED` 未設定或為 `false` 才能驗證。
-對 development stack 執行：
+`http://localhost:4005`），任何一項失敗都會印出可行動的診斷訊息並以非零結束。
+
+最後一項檢查需要限流器實際運作，而 `.env.example` 為了日常開發預設帶
+`RATE_LIMIT_DISABLED=true`，因此請覆寫該值再啟動 smoke 用的 stack，而不是直接
+跑預設的：
 
 ```bash
-docker compose up -d --wait
+RATE_LIMIT_DISABLED=false docker compose up -d --wait --force-recreate backend
 SMOKE_API_URL=http://localhost:4005 pnpm --filter near-chat-backend run smoke
 ```
 
+`--force-recreate backend` 是讓覆寫生效的關鍵：Compose 不會只因為插值後的環境
+變數改變，就重啟一個已在執行中的容器。
+
+另外可將 `SMOKE_STATE_FILE` 設為某個路徑，用以驗證持久狀態能否跨 restart 存活。
+第一次執行會把 token、room 與 message ID 寫入該檔；之後以同一個檔案再執行時，
+會改用存下來的 token 重新 sync，並斷言 restart 前的那則訊息仍然回傳 —— 因此
+restart 若真的遺失資料就會失敗，而不是靠新建立的狀態矇混通過。
+
 CI 的 `ci-backend.yml` 會對 development image（`docker-compose.yml`）與
 production image（`docker-compose.release.yml`）各執行一次同一份腳本，且各自
-在 graceful restart backend 容器前後都跑一次，因此映像本身的問題或
-restart 造成的狀態遺失都會讓建置失敗。
+在 graceful restart backend 容器前後都跑一次、共用同一個 `SMOKE_STATE_FILE`，
+因此映像本身的問題或 restart 造成的已提交狀態遺失都會讓建置失敗。
 
 `MAX_SESSIONS_PER_USER`、`PRESENCE_GRACE_MS`、`TYPING_TTL_MS` 分別控制單機
 session、presence 重連寬限與 typing indication TTL。多節點 presence、全域

--- a/docs/ZH-TW/DEVELOPMENT.md
+++ b/docs/ZH-TW/DEVELOPMENT.md
@@ -91,20 +91,27 @@ supertest 相容測試使用。Socket.IO ping interval 為 25 秒、ping timeout
 20 秒，因此 Bun `idleTimeout` 必須大於此視窗。
 
 持久化訊息命令走 REST 並必須帶 `Idempotency-Key`；編輯與收回另需
-`If-Match`。連線後客戶端以最後 cursor 呼叫 `/api/v1/sync`。最小本機
-smoke check：
+`If-Match`。連線後客戶端以最後 cursor 呼叫 `/api/v1/sync`。
+
+`backend/scripts/smoke.ts`（`pnpm --filter near-chat-backend run smoke`，或在
+`backend/` 下執行 `bun run smoke`）是對執行中 stack 的自動化即時通訊 smoke
+測試。它會註冊一個用完即丟的使用者，依序驗證健康檢查、socket 連線並收到
+`realtime_ready`、可靠發送（重送同一個 `Idempotency-Key` 只會產生一則訊息）、
+斷線後靠 sync cursor 補齊變更，以及超限的驗證請求會回傳
+`429`／`TOO_MANY_REQUESTS`。目標位址讀取自 `SMOKE_API_URL`（預設
+`http://localhost:4005`），任何一項失敗都會印出可行動的診斷訊息並以非零結束；
+最後一項檢查需要 stack 的 `RATE_LIMIT_DISABLED` 未設定或為 `false` 才能驗證。
+對 development stack 執行：
 
 ```bash
-curl -sS http://localhost:4005/api/v1/health
-# 完成註冊／登入並建立聊天室後，使用相同 key 重送訊息：
-curl -sS -X POST http://localhost:4005/api/v1/rooms/<roomId>/messages \
-  -H "Authorization: Bearer <token>" \
-  -H "Idempotency-Key: smoke-create-1" \
-  -H 'Content-Type: application/json' \
-  -d '{"content":"smoke"}'
-curl -sS "http://localhost:4005/api/v1/sync?cursor=0&limit=100" \
-  -H "Authorization: Bearer <token>"
+docker compose up -d --wait
+SMOKE_API_URL=http://localhost:4005 pnpm --filter near-chat-backend run smoke
 ```
+
+CI 的 `ci-backend.yml` 會對 development image（`docker-compose.yml`）與
+production image（`docker-compose.release.yml`）各執行一次同一份腳本，且各自
+在 graceful restart backend 容器前後都跑一次，因此映像本身的問題或
+restart 造成的狀態遺失都會讓建置失敗。
 
 `MAX_SESSIONS_PER_USER`、`PRESENCE_GRACE_MS`、`TYPING_TTL_MS` 分別控制單機
 session、presence 重連寬限與 typing indication TTL。多節點 presence、全域


### PR DESCRIPTION
## 變更描述 (Description)

新增自動化即時通訊 smoke 測試套件，驗證 issue #536 的所有驗收標準。

### 主要變更

1. **新增 `backend/scripts/smoke.ts`**
   - 完整的 WebSocket/REST smoke 測試腳本，使用 Bun 執行
   - 驗證以下功能：
     - 健康檢查端點 (`/api/v1/health`)
     - Socket.IO 連線與 `realtime_ready` 事件
     - 冪等訊息發送（重試相同 `Idempotency-Key` 只產生一則訊息）
     - 斷線後透過 sync cursor 補齊遺漏的變更
     - 超限驗證請求回傳 429 `TOO_MANY_REQUESTS`
   - 每項檢查獨立輸出診斷訊息，任何失敗都以非零狀態碼結束

2. **更新 CI 工作流程 (`.github/workflows/ci-backend.yml`)**
   - `release-compose` 工作：在啟動後端後執行 smoke 測試，再執行 graceful restart，最後重新執行測試以驗證恢復能力
   - 新增 `dev-compose-smoke` 工作：對開發映像執行相同的 smoke 測試流程，確保開發與生產映像都能通過

3. **更新文件**
   - `docs/DEVELOPMENT.md` 與 `docs/ZH-TW/DEVELOPMENT.md`：說明如何執行 smoke 測試、其涵蓋的驗收標準，以及 CI 如何使用它

4. **更新 `backend/package.json`**
   - 新增 `smoke` script：`bun run ./scripts/smoke.ts`

## 相關的 Issue (Related Issue)
Closes #536

## 變更類型 (Type of Change)
- [x] `test`: 新增或修正測試案例
- [x] `ci`: CI 設定變更
- [x] `docs`: 修改文件

## 驗證與測試計畫 (Verification & Test Plan)

此變更新增的 smoke 測試本身就是驗證機制。CI 會在以下情況執行：

1. **生產映像測試** (`release-compose`)
   - 啟動生產映像後執行 smoke 測試
   - Graceful restart 後端容器
   - 重新執行 smoke 測試以驗證恢復

2. **開發映像測試** (`dev-compose-smoke`)
   - 啟動開發映像後執行相同的 smoke 測試
   - Graceful restart 後端容器
   - 重新執行 smoke 測試

任何映像或重啟流程的問題都會導致 smoke 測試失敗，進而使建置失敗。

### 本地驗證
可在本地執行以驗證：
```bash
docker compose up -d --wait
SMOKE_API_URL=http://localhost:4005 pnpm --filter near-chat-backend run smoke
```

## 資料庫變更 (Database Changes)
* 此變更是否包含資料庫 Schema 修改？ **否**

## API 與 WebSocket 協定一致性 (API & WebSocket Contract Check)
* 此變更是否涉及 API 路由或 WebSocket 事件的資料結構變更？ **否**
* Smoke 測試驗

https://claude.ai/code/session_01MRYY9oCi1LTB7PkvARmRmB