### PR TITLE
chore(dependabot): guard docker base image major updates (#581)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,6 +39,35 @@ updates:
       - "ci/cd"
       - "dependencies"
 
+  # docker base image 的 major 版本守門（適用於下方 3. 與 4. 兩個項目）
+  #
+  # #555 只為 npm 生態加上 major 守門，兩個 docker 項目當時沒有。但 base image 的
+  # major 升級在本 repo 正是「PR 綠燈、image 卻壞掉」的那一類變更：
+  #
+  # 1. Node 25 起不再隨發行版散布 Corepack。上游 nodejs/corepack README 原文：
+  #    "Corepack is distributed with Node.js from version 14.19.0 up to (but not
+  #    including) 25.0.0."；nodejs.org/api/corepack.html 現已 308 轉址至該 repo。
+  #    而四個 Dockerfile 都靠 corepack 安裝 pnpm：frontend/Dockerfile:10、
+  #    frontend/Dockerfile.prod:15、backend/Dockerfile:24、backend/Dockerfile.prod:19。
+  # 2. Dependabot 的 docker parser 只解析 `FROM`，不解析 `COPY --from=`。已由 PR #591
+  #    實證：該 PR 只改到 backend 的三行 `FROM oven/bun:...`，完全沒動
+  #    backend/Dockerfile:16 與 backend/Dockerfile.prod:18 的 `COPY --from=node:24-slim`。
+  #    因此 node 的 major 升級不可能同時涵蓋 frontend image 與 backend 的 node graft，
+  #    只會讓兩者的 toolchain 版本悄悄分歧。
+  # 3. 沒有任何 CI lane 會 build frontend 的兩個 Dockerfile（`grep -rn "frontend/Dockerfile"
+  #    .github/` 只命中 release-stack.yml 的 tag-time push），破壞會等到發版當下才浮現。
+  #
+  # 用 `"*"` 而不是只擋 `node`：/backend 的唯一 `FROM` 是 oven/bun，只擋 node 形同沒擋
+  # （見 PR #591）。這條規則只擋 major 版本更新：
+  #   - minor / patch 不受影響，`node:24-slim` 這類浮動 tag 仍持續取得 24.x 的修補；
+  #   - GitHub Advisory Database 不涵蓋 container image，docker 生態本來就沒有
+  #     security update PR，因此不會擋掉任何安全性修補。
+  #
+  # 解除條件：待 #582 的 Dockerfile build lane 就緒、且 #583 完成 base image 對齊後，
+  # major 升級才有 CI 訊號可依據，屆時再重新評估這條規則。根因修法（更徹底，但不在
+  # 本項範圍）是把 `corepack enable pnpm` 換成 `npm install -g pnpm@11.15.0`，
+  # 讓 Node major 不再是 breaking change。
+
   # 3. 後端 Docker Base Image (/backend)
   #    Dockerfile 仍位於各套件目錄，因此 docker 項目維持分開宣告。
   - package-ecosystem: "docker"
@@ -50,6 +79,9 @@ updates:
     labels:
       - "docker"
       - "backend"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   # 4. 前端 Docker Base Image (/frontend)
   - package-ecosystem: "docker"
@@ -61,3 +93,6 @@ updates:
     labels:
       - "docker"
       - "frontend"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## 變更描述 (Description)

為 `.github/dependabot.yml` 的兩個 `package-ecosystem: "docker"` 項目（`/backend`、`/frontend`）補上 major 版本守門，與 #555 已為 npm 生態加上的守門對齊。

### 根本原因

#555 只為 npm 項目加了 `ignore`，兩個 docker 項目沒有。base image 的 major 升級因此可以自動開 PR 並合併，而這在本 repo 正是「PR 綠燈、image 卻壞掉」的一類變更，原因有三（皆為本次對 `main` 965e08a 實地驗證）：

1. **Node 25 起不再隨發行版散布 Corepack**，而四個 Dockerfile 都靠 `corepack enable pnpm && corepack prepare pnpm@11.15.0 --activate` 安裝 pnpm（`frontend/Dockerfile:10`、`frontend/Dockerfile.prod:15`、`backend/Dockerfile:24`、`backend/Dockerfile.prod:19`）。
2. **Dependabot 的 docker parser 只解析 `FROM`，不解析 `COPY --from=`。** 因此 node 的 major 升級**不可能**同時涵蓋 frontend image 與 backend 的 node graft，只會讓兩者的 toolchain 版本悄悄分歧——這比 corepack 本身更難察覺。
3. **沒有任何 CI lane 會 build frontend 的兩個 Dockerfile**，破壞會等到打 tag 發版當下才浮現。

### 變更內容

兩個 docker 項目各加上：

```yaml
ignore:
  - dependency-name: "*"
    update-types: ["version-update:semver-major"]
```

並在上方加入 繁體中文 rationale 註解（沿用檔案既有的編號註解風格），記錄上述三點、`"*"` 的選擇理由，以及這條規則的解除條件。

### 與 Issue 原文的兩點差異（請 reviewer 留意）

1. **用 `dependency-name: "*"`，而非 Issue 寫的字面 `"node"`。** `/backend` 的唯一 `FROM` 是 `oven/bun`，node 只透過 `COPY --from=` 進入——而那行 Dependabot 看不到。因此只擋 `node` 等於 `/backend` 完全沒有守門，而 bun 的升級是**現在進行式**（open PR #591）。`"*"` 同時涵蓋兩者，也與 npm 項目既有風格一致。Issue 的驗收條件 (a) 以 `grep -c "version-update:semver-major"` 由 1 變 3 檢查，本 PR 滿足；但若逐字檢查 `dependency-name: "node"` 則不會命中，故在此明確記錄。
2. **Issue 原文引用的 `nodejs/node#57617` 本次無法在 `CHANGELOG_V25.md` 中確認**（且該檔 25.6.0 仍有 `deps: update corepack to 0.34.6`）。改以本次實際查證的上游來源為準——`nodejs/corepack` README 原文：`Corepack is distributed with Node.js from version 14.19.0 up to (but not including) 25.0.0.`，且 `nodejs.org/api/corepack.html` 現已 308 轉址至該 repo。**結論不變，來源已更正。**

### 這條規則不會擋掉什麼

- **minor / patch 不受影響**：`node:24-slim` 這類浮動 tag 仍持續取得 24.x 的修補；`oven/bun` 的 patch 升級（如 #591）照常開 PR。
- **不會擋掉安全性修補**：GitHub Advisory Database 不涵蓋 container image，docker 生態本來就沒有 security update PR。規則亦只列 `version-update:semver-major` 一種 update-type，未觸及 dependabot-core#4027 所述「三種全擋會連帶壓掉 security update」的 footgun。

## 相關的 Issue (Related Issue)

Closes #581

## 變更類型 (Type of Change)

- [ ] `feat`: 新增功能 (Feature)
- [ ] `fix`: 修復 Bug
- [ ] `refactor`: 重構代碼
- [ ] `docs`: 修改文件
- [ ] `test`: 新增或修正測試案例
- [x] `chore`: 建置流程或輔助工具變更
- [ ] `perf`: 效能優化
- [ ] `ci`: CI 設定變更

## 驗證與測試計畫 (Verification & Test Plan)

> **重要：本 PR 不會觸發任何 CI lane。** `.github/dependabot.yml` 不在 `ci.yml` 任何一條 paths-filter 內（`ci.yml:106,118,125` 只列 `.github/workflows/**` 與 `.github/actions/**`），因此只有 `detect` 與 `required-checks` 會跑，其餘五條 lane 全部 resolve 成 false。**這個 PR 的綠燈不代表變更被驗證過**，實際驗證如下在本地完成。repo 中亦無任何 yamllint / actionlint / schema 檢查（`grep -rln "yamllint\|actionlint" .github/ package.json` 無命中）。

### 本地測試 (Local Tests)

本環境**無 Docker daemon**（`docker info` 連不上 `/var/run/docker.sock`），因此以下改為直接執行，非透過 `docker compose exec`：

- [x] 後端型別檢查 (`pnpm -C backend exec tsc --noEmit`) — 通過
- [x] 前端型別檢查 (`pnpm -C frontend exec tsc --noEmit`) — 通過
- [x] 前端 Linter 檢查 (`pnpm -C frontend run lint`) — 0 error（1 個既有的 `no-unused-vars` warning，位於未被本 PR 觸及的 `frontend/tests/chat-memoization.test.tsx:90`）
- [x] 單元測試 (`pnpm -C backend run test:unit`) — 546 pass / 0 fail，41 檔
- [ ] 整合測試 — **未執行**，需要 Postgres 測試資料庫，本環境無 Docker daemon。此變更不含任何執行期程式碼，但仍請 reviewer 依 CONTRIBUTING §5 自行確認。

### 針對本變更的實際驗證

1. **YAML 可解析**（Issue 驗收條件 (b)）：`python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"` 與 `js-yaml@4.3.1` 兩者皆通過。
2. **結構性斷言**（比單純 grep 計數更強：grep 計數在「兩條 ignore 誤植於同一個項目」時也會通過）。以 pyyaml 解析後逐項斷言，14 項全過：
   - 4 個 update 項目、恰好 2 個 docker 項目、directory 為 `/backend` 與 `/frontend`
   - 兩個 docker 項目**各自**都有 `dependency-name: "*"` + `version-update:semver-major`
   - 兩者的 `update-types` **只含** major（確保 minor/patch 仍會流入）
   - 兩者原有 `labels` 未被動到
   - npm 項目的既有守門與 `groups.minor-and-patch` 未被動到
   - github-actions 項目**仍然沒有** `ignore`（未被誤改）
3. **Issue 驗收條件 (a)**：`grep -c "version-update:semver-major" .github/dependabot.yml` 由 `1` 變為 `3`。
4. **`COPY --from=` 不被解析**（本 PR 註解中的關鍵事實）：以 open PR #591 實證——它只改到 `backend/Dockerfile:6`、`backend/Dockerfile.prod:6,54` 三行 `FROM oven/bun:...`（2 檔、+3/-3），**完全沒動** `backend/Dockerfile:16` 與 `backend/Dockerfile.prod:18` 的 `COPY --from=node:24-slim`。另檢索本 repo 全部 Dependabot PR，node 的 docker 升級只出現過 `/frontend`（#430），從未針對 backend 的 node graft。
5. **`dependency-name` 命名**：PR #430 body 內含 `compatibility_score?dependency-name=node&package-manager=docker&previous-version=24-slim&new-version=26-slim`，確認 docker 生態下該 dependency 即名為 `node`。

### 手動測試 (Manual Verification) — 合併後請 reviewer 執行

Dependabot 讀取的是 **default branch** 的設定，因此以下只能在合併後驗證：

1. Insights → Dependency graph → Dependabot：確認 `/backend`、`/frontend` 兩個 docker 項目最近一次 run 沒有解析錯誤（Issue 驗收條件 (c)）。
2. **Issue 驗收條件 (d)「下次週期不再出現 node major PR」是 vacuous，請勿用它驗收**：#430 已被 closed unmerged，Dependabot 因此本來就不會再為該版本重開 PR，所以無論本 PR 是否生效，該條件都會成立。改用直接探測：在 open PR #591 留言 Dependabot 的 `show oven/bun ignore conditions` 指令（即 at-mention `dependabot` 後接該指令），它會回列 Dependabot 實際載入的 ignore conditions，可同時證明「解析成功」與「規則已套用」。

## 資料庫變更 (Database Changes)

* 此變更是否包含資料庫 Schema 修改？ **否**
* 若為是，請寫明 Migration 檔案名稱：不適用
* 是否已確認遷移與 docs/database-design.md 設計一致？ **不適用**

## API 與 WebSocket 協定一致性 (API & WebSocket Contract Check)

* 此變更是否涉及 API 路由或 WebSocket 事件的資料結構變更？ **否**
* 是否已確認與 docs/api-documentation.md 規範完全一致？ **不適用**（本 PR 只變更 Dependabot 設定，不含任何執行期程式碼）

## Advisor 的重點意見

1. **本 PR 是 stopgap，不是根治。** 三種修法由強到弱依序為：(a) 直接消滅根因——把四個 Dockerfile 的 `corepack enable pnpm && corepack prepare pnpm@11.15.0 --activate` 換成 `npm install -g pnpm@11.15.0`，如此 Node major 不再是 breaking change；(b) #582 的 Dockerfile build lane，能攔下 Dependabot 以外的所有來源（人工編輯、上游在浮動 tag 內的變動）；(c) 本 PR，只擋 Dependabot，且是靜默地擋。已將 (a) 記錄於 `dependabot.yml` 註解與 #583，未在本 PR 動 Dockerfile——因為 #583 本來就要改那些檔案，且更動 `backend/**` 會讓兩個昂貴的 docker build job 為了一個純設定變更而啟動。
2. **「rot 風險」比直覺小。** `node:24-slim` 是浮動 tag，凍結 major 不等於凍結 binary，24.x 的修補仍會在 build 時持續進來，到 Node 24 EOL（約 2028-04）之前都有安全性更新；`oven/bun:1.3.14-slim` 則是完整 pin 到 patch，其更新本來就只能靠 Dependabot，而 major 守門不影響 patch。真正無訊號的只有 `COPY --from=node:24-slim` 那道 graft，這在本 PR 前後都一樣，已記錄於註解。
3. **不要加 docker `groups`。** 把 node 與 bun 併成一個 PR 會讓 build 失敗更難二分定位，且橫跨兩個 image。`open-pull-requests-limit: 5` 不受影響；`ignore` 在 grouping 之前套用，與 npm 項目的 `groups.minor-and-patch` 互不影響（各 entry 是獨立 job）。
4. **不要改用 Dependabot 的 `ignore this major version` 留言指令。** 它只針對單一 major，且狀態存在 server side，在 repo 中不可見、不可 review。

## 未驗證事項 (Unverified)

- Dependabot 在合併後實際載入這兩條 ignore 條件的行為，本次無法驗證（Dependabot 只讀 default branch）。驗證方式已寫在上方「手動測試」。
- 四個 Dockerfile 的實際 build：本環境無 Docker daemon，未執行。本 PR 不變更任何 Dockerfile。

---

Generated with Claude Code (https://claude.com/claude-code)