### PR TITLE
feat(backend): add the admin monitoring API (#569)

### DIFF
--- a/backend/src/models/instrumentSql.ts
+++ b/backend/src/models/instrumentSql.ts
@@ -1,12 +1,15 @@
 import type { SQL } from 'bun';
 import type { Logger } from 'pino';
 import { logger as defaultLogger } from '../utils/logger';
-import { slowQueries, type SlowQueryStore } from '../utils/slowQueryStore';
+import {
+  DEFAULT_SLOW_QUERY_THRESHOLD_MS,
+  slowQueries,
+  type SlowQueryStore,
+} from '../utils/slowQueryStore';
 
-/**
- * The threshold #280 names: anything slower is worth an operator's attention.
- */
-export const DEFAULT_SLOW_QUERY_THRESHOLD_MS = 100;
+// Re-exported from its home next to the buffer it describes, so the existing
+// callers and tests that import it from here keep working.
+export { DEFAULT_SLOW_QUERY_THRESHOLD_MS };
 
 /**
  * Ceiling on a retained query skeleton, in characters.

--- a/backend/src/routes/adminRoutes.ts
+++ b/backend/src/routes/adminRoutes.ts
@@ -1,6 +1,88 @@
 import { Hono } from 'hono';
+import { z } from 'zod';
 import { authMiddleware } from '../middlewares/authMiddleware';
 import { type AdminChecker, makeAdminMiddleware } from '../middlewares/adminMiddleware';
+import { validate } from '../middlewares/validator';
+import { recentLogs, type RecentLogStore } from '../utils/logger';
+import {
+  processMetrics,
+  requestMetrics,
+  type ProcessMetricsSampler,
+  type RequestMetricsStore,
+} from '../utils/performanceMetrics';
+import {
+  DEFAULT_SLOW_QUERY_THRESHOLD_MS,
+  slowQueries,
+  type SlowQueryStore,
+} from '../utils/slowQueryStore';
+
+/**
+ * The read-only monitoring surface the admin backend (#280) polls.
+ *
+ * Every buffer these endpoints read was built by an earlier issue in this
+ * milestone with this route in mind, so nothing here collects anything: the
+ * timing middleware feeds `requestMetrics`, the pino destination feeds
+ * `recentLogs`, and the SQL instrumentation feeds `slowQueries`. These handlers
+ * only render what those already hold.
+ *
+ * That is why all three are per-process and reset on restart, and why a
+ * multi-instance deployment would report whichever instance the request happened
+ * to reach. Each store is an interface for the same reason — swapping in the
+ * cross-process, Redis-backed version #283 calls for should not touch this file.
+ *
+ * Polling, not streaming: #569 scopes the log feed to a plain `GET`, leaving
+ * SSE/WebSocket for whenever the panel actually needs sub-poll latency.
+ */
+
+/**
+ * The data sources, as this module consumes them.
+ *
+ * A trailing optional parameter defaulting to the real implementations, which is
+ * the injection seam this repo uses (`AvatarStore` / `defaultAvatarStore` in
+ * `utils/avatarUpload.ts`) — `mock.module()` is process-global within a test
+ * tier and cannot be undone, which is what made `avatarUpload.test.ts`
+ * order-dependent (issue #467).
+ *
+ * Narrowed to the read halves on purpose: a monitoring endpoint has no business
+ * being able to `record()` a request, `push()` a log line or `reset()` the
+ * counters, and stating that in the type means a handler cannot start.
+ */
+export interface AdminMonitoringSources {
+  requestMetrics: Pick<RequestMetricsStore, 'snapshot'>;
+  processMetrics: ProcessMetricsSampler;
+  logs: Pick<RecentLogStore, 'recent' | 'capacity' | 'size'>;
+  slowQueries: Pick<SlowQueryStore, 'recent' | 'capacity' | 'size'>;
+}
+
+export const defaultAdminMonitoringSources: AdminMonitoringSources = {
+  requestMetrics,
+  processMetrics,
+  logs: recentLogs,
+  slowQueries,
+};
+
+/**
+ * `?limit=` for a bounded buffer.
+ *
+ * The buffer's own capacity is both the default and the ceiling: asking for more
+ * than it holds is not an error to report, it is simply everything. Built per
+ * store rather than as one shared schema because the two buffers are different
+ * sizes, and a caller should get a validation error that names the real limit.
+ *
+ * Blank is treated as absent, matching `syncRoutes`: a UI that always appends
+ * `?limit=${value}` sends an empty string before the user has chosen one.
+ *
+ * Exported for its own unit tests. The handlers stay unexported and reachable
+ * only through the gate below — a schema is safe to hand out, an unguarded
+ * monitoring sub-app is not.
+ */
+export const limitQuerySchema = (capacity: number) =>
+  z.object({
+    limit: z.preprocess(
+      (value) => (value === undefined || value === '' ? capacity : Number(value)),
+      z.number().int().min(1).max(capacity),
+    ),
+  });
 
 /**
  * The `/api/v1/admin` namespace, and the only supported way to mount the admin
@@ -11,22 +93,82 @@ import { type AdminChecker, makeAdminMiddleware } from '../middlewares/adminMidd
  * guard: `httpApp` only ever writes `honoApp.route('/api/v1/admin', ...)`, the
  * same sub-app shape already used for rooms and sync.
  *
- * Handlers land under #280's follow-ups (#566-#570). `GET /health` exists so the
- * guard is reachable end to end today — Hono runs matched middleware before it
- * falls through to the not-found handler, so an empty sub-app would still
- * enforce 401/403, but nothing would prove the allowed path returns 200.
- *
  * `checker` is required, not defaulted: the authorization check is a service the
  * composition root owns and hands down, so this module never reaches for a
  * repository or a database handle of its own.
  */
-export const makeAdminRoutes = (checker: AdminChecker) => {
+export const makeAdminRoutes = (
+  checker: AdminChecker,
+  sources: AdminMonitoringSources = defaultAdminMonitoringSources,
+) => {
   const app = new Hono();
 
   app.use('*', authMiddleware);
   app.use('*', makeAdminMiddleware(checker));
 
+  // Monitoring answers must never be served from a cache: a panel polling every
+  // few seconds to watch a live incident is the one caller these endpoints have,
+  // and a stale 200 from an intermediary would be indistinguishable from a
+  // system that had stopped changing.
+  app.use('*', async (c, next) => {
+    await next();
+    c.header('Cache-Control', 'no-store');
+  });
+
+  // Kept from before the handlers existed: it proves the guard end to end
+  // without depending on any buffer having content, which every endpoint below
+  // does. Hono runs matched middleware before falling through to the not-found
+  // handler, so an empty sub-app would still enforce 401/403 — but nothing would
+  // show that the allowed path returns 200.
   app.get('/health', (c) => c.json({ status: 'ok' }, 200));
+
+  app.get('/metrics', (c) =>
+    c.json(
+      {
+        // Sampled at read time, so `cpu.percent` is the usage since the previous
+        // poll rather than a lifetime average. The first call after a restart
+        // reports `null` for it — there is no earlier point to difference
+        // against, and inventing a zero would read as an idle process.
+        process: sources.processMetrics.sample(),
+        requests: sources.requestMetrics.snapshot(),
+        at: Date.now(),
+      },
+      200,
+    ),
+  );
+
+  app.get('/logs', validate('query', limitQuerySchema(sources.logs.capacity)), (c) => {
+    const { limit } = c.req.valid('query') as { limit: number };
+    return c.json(
+      {
+        // Oldest first, so a poller can append to what it already rendered.
+        entries: sources.logs.recent(limit),
+        retained: sources.logs.size(),
+        capacity: sources.logs.capacity,
+      },
+      200,
+    );
+  });
+
+  app.get(
+    '/slow-queries',
+    validate('query', limitQuerySchema(sources.slowQueries.capacity)),
+    (c) => {
+      const { limit } = c.req.valid('query') as { limit: number };
+      return c.json(
+        {
+          queries: sources.slowQueries.recent(limit),
+          retained: sources.slowQueries.size(),
+          capacity: sources.slowQueries.capacity,
+          // Reported rather than left for the panel to hardcode: it is what
+          // makes the list meaningful ("slower than this"), and it belongs to
+          // the store that applies it, not to the UI.
+          thresholdMs: DEFAULT_SLOW_QUERY_THRESHOLD_MS,
+        },
+        200,
+      );
+    },
+  );
 
   return app;
 };

--- a/backend/src/utils/slowQueryStore.ts
+++ b/backend/src/utils/slowQueryStore.ts
@@ -32,6 +32,18 @@ export interface SlowQueryStore {
   size(): number;
 }
 
+/**
+ * The threshold #280 names: anything slower is worth an operator's attention.
+ *
+ * Lives here rather than with the SQL instrumentation that applies it, because
+ * it is what defines the buffer's contents — "the queries in here are the ones
+ * slower than this" — and both the instrumentation and the admin endpoint that
+ * reports it alongside the records need it. `models/instrumentSql` re-exports
+ * it, so the layering runs one way: `models/` and `routes/` both depend on
+ * `utils/`, and `routes/` never reaches into `models/`.
+ */
+export const DEFAULT_SLOW_QUERY_THRESHOLD_MS = 100;
+
 /** Matches the "最近 100 筆" the parent issue (#280) asks the admin panel to show. */
 export const DEFAULT_SLOW_QUERY_CAPACITY = 100;
 

--- a/backend/tests/e2e/routes/admin.e2e.test.ts
+++ b/backend/tests/e2e/routes/admin.e2e.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, beforeAll, beforeEach } from 'bun:test';
 import request from 'supertest';
 import { resetDb } from '../../helpers/resetDb';
 import { testPool } from '../../helpers/testPool';
+import { createLogger, recentLogs } from '../../../src/utils/logger';
+import { slowQueries } from '../../../src/utils/slowQueryStore';
 
 let app: any;
 
@@ -100,5 +102,198 @@ describe('Admin gate E2E', () => {
     // authMiddleware rejects the deleted account first; the admin gate is a
     // second, independent soft-delete filter behind it.
     expect(res.status).toBe(401);
+  });
+});
+
+/**
+ * The monitoring endpoints render three process-wide buffers, and under the test
+ * runner two of them are empty: `LOG_LEVEL` defaults to `silent`, so pino writes
+ * no records, and nothing in a test run is slow enough to be a slow query. An
+ * earlier version of this suite asserted against those empty arrays and passed
+ * even when `/logs` ignored `?limit=` entirely — so each buffer is seeded here
+ * with records the assertions can actually bite on.
+ *
+ * Seeding the real buffers rather than injecting fakes is deliberate: these are
+ * the exact objects the running app hands the route, so this covers the wiring
+ * as well as the rendering. Both are bounded rings, so the handful of records
+ * added here cannot grow anything.
+ */
+describe('Admin monitoring endpoints E2E', () => {
+  const ENDPOINTS = ['/api/v1/admin/metrics', '/api/v1/admin/logs', '/api/v1/admin/slow-queries'];
+
+  let adminToken: string;
+
+  const seedLogs = (count: number): void => {
+    for (let index = 0; index < count; index += 1) {
+      recentLogs.push(
+        JSON.stringify({ level: 30, time: Date.now() + index, msg: `seeded-record-${index}` }),
+      );
+    }
+  };
+
+  const seedSlowQueries = (count: number): void => {
+    for (let index = 0; index < count; index += 1) {
+      slowQueries.push({
+        query: `SELECT * FROM seeded_table WHERE id = ? -- ${index}`,
+        durationMs: 150 + index,
+        at: Date.now() + index,
+      });
+    }
+  };
+
+  beforeEach(async () => {
+    await resetDb();
+    const { token, userId } = await registerUser('monitor-admin@example.com');
+    await promote(userId);
+    adminToken = token;
+  });
+
+  const asAdmin = (path: string) =>
+    request(app).get(path).set('Authorization', `Bearer ${adminToken}`);
+
+  it('refuses every endpoint without authentication', async () => {
+    for (const path of ENDPOINTS) {
+      expect((await request(app).get(path)).status).toBe(401);
+    }
+  });
+
+  it('refuses every endpoint for an authenticated non-admin', async () => {
+    const { token } = await registerUser('monitor-plain@example.com');
+
+    for (const path of ENDPOINTS) {
+      const res = await request(app).get(path).set('Authorization', `Bearer ${token}`);
+      expect(res.status).toBe(403);
+      expect(res.body.code).toBe('FORBIDDEN');
+    }
+  });
+
+  it('tells intermediaries never to cache a monitoring answer', async () => {
+    // A stale 200 during an incident is indistinguishable from a system that
+    // stopped changing.
+    for (const path of ENDPOINTS) {
+      expect((await asAdmin(path)).headers['cache-control']).toBe('no-store');
+    }
+  });
+
+  it('reports request and process metrics', async () => {
+    const res = await asAdmin('/api/v1/admin/metrics');
+
+    expect(res.status).toBe(200);
+    expect(res.body.requests.totalRequests).toBeGreaterThan(0);
+    expect(res.body.requests.statusClasses['2xx']).toBeGreaterThan(0);
+    expect(res.body.requests.latency).toMatchObject({
+      count: expect.any(Number),
+      avgMs: expect.any(Number),
+      p50Ms: expect.any(Number),
+      p95Ms: expect.any(Number),
+      p99Ms: expect.any(Number),
+      maxMs: expect.any(Number),
+    });
+    expect(res.body.process.memory.rssBytes).toBeGreaterThan(0);
+    expect(res.body.process.uptimeSeconds).toBeGreaterThan(0);
+    // Null on the first sample of a process, a number once there is an earlier
+    // point to difference against — both are correct, neither is absent.
+    expect(['number', 'object']).toContain(typeof res.body.process.cpu.percent);
+    expect(res.body.at).toBeGreaterThan(0);
+  });
+
+  it('counts the failed admin attempts it just served', async () => {
+    const before = (await asAdmin('/api/v1/admin/metrics')).body.requests.statusClasses['4xx'];
+    await request(app).get('/api/v1/admin/metrics');
+
+    const after = (await asAdmin('/api/v1/admin/metrics')).body.requests.statusClasses['4xx'];
+
+    // Proves the endpoint reads the live buffer the timing middleware feeds,
+    // rather than a snapshot taken at startup.
+    expect(after).toBeGreaterThan(before);
+  });
+
+  it('returns the recent log buffer, oldest first', async () => {
+    seedLogs(5);
+
+    const res = await asAdmin('/api/v1/admin/logs');
+
+    expect(res.status).toBe(200);
+    expect(res.body.retained).toBeGreaterThanOrEqual(5);
+    expect(res.body.retained).toBeLessThanOrEqual(res.body.capacity);
+
+    const seeded = res.body.entries.filter((entry: { msg?: string }) =>
+      entry.msg?.startsWith('seeded-record-'),
+    );
+    expect(seeded.map((entry: { msg: string }) => entry.msg)).toEqual([
+      'seeded-record-0',
+      'seeded-record-1',
+      'seeded-record-2',
+      'seeded-record-3',
+      'seeded-record-4',
+    ]);
+  });
+
+  it('honours ?limit= and rejects one the buffer cannot satisfy', async () => {
+    seedLogs(5);
+
+    const full = await asAdmin('/api/v1/admin/logs');
+    const limited = await asAdmin('/api/v1/admin/logs?limit=2');
+
+    expect(limited.status).toBe(200);
+    expect(limited.body.entries).toHaveLength(2);
+    expect(full.body.entries.length).toBeGreaterThan(limited.body.entries.length);
+    // The newest two, since the window ends at the most recent record.
+    expect(limited.body.entries.map((entry: { msg: string }) => entry.msg)).toEqual([
+      'seeded-record-3',
+      'seeded-record-4',
+    ]);
+    expect(limited.body.capacity).toBe(full.body.capacity);
+
+    expect((await asAdmin(`/api/v1/admin/logs?limit=${full.body.capacity + 1}`)).status).toBe(400);
+    expect((await asAdmin('/api/v1/admin/logs?limit=0')).status).toBe(400);
+    expect((await asAdmin('/api/v1/admin/logs?limit=all')).status).toBe(400);
+  });
+
+  it('never hands out a credential through the log buffer', async () => {
+    // The buffer is served over HTTP, so pino's redaction is the only thing
+    // between a logged field and an endpoint that returns it. Written through a
+    // real logger at a real level, into the same process-wide store the route
+    // reads, rather than pushed in pre-serialized — redaction happens on the way
+    // in, so pushing a raw line would prove nothing.
+    const noisy = createLogger({
+      level: 'info',
+      pretty: false,
+      store: recentLogs,
+      stdout: { write: () => true } as unknown as NodeJS.WritableStream,
+    });
+    noisy.info({ password: 'hunter2', refreshToken: 'rt-secret' }, 'seeded credential record');
+
+    const res = await asAdmin('/api/v1/admin/logs');
+
+    const body = JSON.stringify(res.body);
+    expect(body).toInclude('seeded credential record');
+    expect(body).not.toInclude('hunter2');
+    expect(body).not.toInclude('rt-secret');
+    expect(body).toInclude('[redacted]');
+  });
+
+  it('returns the slow-query buffer with the threshold that defines it', async () => {
+    seedSlowQueries(3);
+
+    const res = await asAdmin('/api/v1/admin/slow-queries');
+
+    expect(res.status).toBe(200);
+    expect(res.body.thresholdMs).toBeGreaterThan(0);
+    expect(res.body.retained).toBeGreaterThanOrEqual(3);
+    expect(res.body.retained).toBeLessThanOrEqual(res.body.capacity);
+
+    const seeded = res.body.queries.filter((record: { query: string }) =>
+      record.query.startsWith('SELECT * FROM seeded_table'),
+    );
+    expect(seeded).toHaveLength(3);
+    for (const record of seeded) {
+      expect(record.durationMs).toBeGreaterThanOrEqual(res.body.thresholdMs);
+      expect(record.at).toBeGreaterThan(0);
+    }
+
+    const limited = await asAdmin('/api/v1/admin/slow-queries?limit=1');
+    expect(limited.body.queries).toHaveLength(1);
+    expect((await asAdmin('/api/v1/admin/slow-queries?limit=0')).status).toBe(400);
   });
 });

--- a/backend/tests/unit/routes/adminRoutes.test.ts
+++ b/backend/tests/unit/routes/adminRoutes.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'bun:test';
+import { limitQuerySchema } from '../../../src/routes/adminRoutes';
+
+/**
+ * The admin handlers themselves are exercised end to end in
+ * `tests/e2e/routes/admin.e2e.test.ts`, because they sit behind `authMiddleware`
+ * — which reaches for the shared SQL client with no injection seam, so a unit
+ * test could only get past it with `mock.module()`, which this repo bans
+ * (tests/CLAUDE.md, issue #467). Exporting an unguarded monitoring sub-app to
+ * make it unit-testable would trade a real safety property for test
+ * convenience.
+ *
+ * What is worth isolating is the `?limit=` boundary, which is pure and has more
+ * edge cases than an E2E pass would sensibly enumerate.
+ */
+describe('admin limit query', () => {
+  const parse = (capacity: number, query: Record<string, unknown>) =>
+    limitQuerySchema(capacity).safeParse(query);
+
+  it('defaults to the buffer capacity when no limit is given', () => {
+    const result = parse(200, {});
+
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({ limit: 200 });
+  });
+
+  it('treats a blank value as absent', () => {
+    // A panel that always appends `?limit=${value}` sends this before the
+    // operator has picked one.
+    expect(parse(100, { limit: '' }).data).toEqual({ limit: 100 });
+  });
+
+  it('accepts a numeric string, which is all a query string can carry', () => {
+    expect(parse(200, { limit: '50' }).data).toEqual({ limit: 50 });
+  });
+
+  it('caps the request at what the buffer can actually hold', () => {
+    // Rejected rather than clamped: silently returning 200 records for a request
+    // that asked for 5000 would look like the buffer holds 5000.
+    expect(parse(200, { limit: '5000' }).success).toBe(false);
+  });
+
+  it('rejects values that cannot mean a number of records', () => {
+    expect(parse(200, { limit: '0' }).success).toBe(false);
+    expect(parse(200, { limit: '-1' }).success).toBe(false);
+    expect(parse(200, { limit: '1.5' }).success).toBe(false);
+    expect(parse(200, { limit: 'all' }).success).toBe(false);
+  });
+
+  it('uses each buffer\'s own capacity, not one shared ceiling', () => {
+    // Logs retain 200 and slow queries 100, so the same request is valid
+    // against one endpoint and not the other.
+    expect(parse(200, { limit: '150' }).success).toBe(true);
+    expect(parse(100, { limit: '150' }).success).toBe(false);
+  });
+});

--- a/docs/ZH-TW/api-documentation.md
+++ b/docs/ZH-TW/api-documentation.md
@@ -55,6 +55,9 @@
 | | `DELETE` | [`/users/me/emergency-contacts/:contactId`](#delete-usersmeemergency-contactscontactid) | 需驗證 | 刪除緊急聯絡人設定 |
 | | `POST` | [`/users/me/emergency-alert/check-inactivity`](#post-usersmeemergency-alertcheck-inactivity) | 需驗證 | 檢查不活躍狀態以判定是否發送警報 |
 | **管理員** | `GET` | [`/admin/health`](#get-adminhealth) | 需驗證（管理員） | 管理員守門機制後方的存活探測 |
+| | `GET` | [`/admin/metrics`](#get-adminmetrics) | 需驗證（管理員） | 請求吞吐量、延遲百分位數與程序資源使用量 |
+| | `GET` | [`/admin/logs`](#get-adminlogs) | 需驗證（管理員） | 最近的結構化日誌記錄（輪詢） |
+| | `GET` | [`/admin/slow-queries`](#get-adminslow-queries) | 需驗證（管理員） | 超過慢查詢門檻的資料庫查詢 |
 
 ### Socket.io 即時通訊
 
@@ -1433,7 +1436,7 @@ NEXT_PUBLIC_API_URL=http://localhost:4005
 沒有任何 endpoint 可以設定此旗標，初始化流程請見 `docs/DEVELOPMENT.md`。
 
 #### `GET /admin/health`
-- **說明**: 管理員命名空間的存活探測。用途是讓管理員守門機制能被端到端驗證；實際的監控 endpoint 位於 #566-#570。
+- **說明**: 管理員命名空間的存活探測，也是本節唯一不依賴任何緩衝區有內容的 endpoint。
 - **驗證與授權**: 需驗證，且呼叫者的 `users.is_admin` 必須為 `true`。
 - **回應**:
   - `200 OK`: 呼叫者為管理員。
@@ -1443,6 +1446,108 @@ NEXT_PUBLIC_API_URL=http://localhost:4005
   ```json
   {
     "status": "ok"
+  }
+  ```
+
+---
+
+#### `GET /admin/metrics`
+- **說明**: 請求吞吐量、延遲百分位數，以及本程序自身的資源使用量。所有數據都是單一程序範圍且重啟後歸零，因此多實例部署下回報的是實際處理該請求的那個實例。
+- **驗證與授權**: 需驗證，且呼叫者的 `users.is_admin` 必須為 `true`。
+- **回應**:
+  - `200 OK`: 於讀取當下取樣。附帶 `Cache-Control: no-store`。
+  - `401 Unauthorized` / `403 Forbidden`: 與本命名空間所有路由相同。
+- **回應欄位**:
+  | 欄位 | 型別 | 說明 |
+  |---|---|---|
+  | `process.uptimeSeconds` | Number | 本程序啟動至今的秒數 |
+  | `process.cpu.userMs` / `systemMs` | Number | 累計 CPU 毫秒數 |
+  | `process.cpu.percent` | Number \| null | 自**上一次**呼叫本 endpoint 以來的 CPU 使用率，以單一核心的百分比表示。首次呼叫為 `null`，因為沒有可供比較的前一個取樣點。多核心主機上可能超過 100 |
+  | `process.memory.*` | Number | `rssBytes`、`heapUsedBytes`、`heapTotalBytes`、`externalBytes` |
+  | `requests.totalRequests` | Number | 累計請求數 |
+  | `requests.statusClasses` | Object | 以 `1xx`–`5xx` 與 `other` 為鍵的累計計數 |
+  | `requests.latency` | Object | `count`、`avgMs`、`p50Ms`、`p95Ms`、`p99Ms`、`maxMs`，統計範圍為**保留視窗內**而非全部歷史 |
+  | `requests.sampleSize` / `sampleCapacity` | Number | 目前保留的耗時樣本數，以及環形緩衝區容量 |
+  | `at` | Number | 取樣當下的 epoch 毫秒 |
+- **回應範例**:
+  ```json
+  {
+    "process": {
+      "uptimeSeconds": 812.44,
+      "cpu": { "userMs": 5230.1, "systemMs": 980.4, "percent": 3.2 },
+      "memory": { "rssBytes": 128974848, "heapUsedBytes": 41287680, "heapTotalBytes": 62914560, "externalBytes": 2097152 }
+    },
+    "requests": {
+      "totalRequests": 1842,
+      "statusClasses": { "1xx": 0, "2xx": 1790, "3xx": 0, "4xx": 51, "5xx": 1, "other": 0 },
+      "latency": { "count": 1000, "avgMs": 12.44, "p50Ms": 8.1, "p95Ms": 41.2, "p99Ms": 96.7, "maxMs": 310.5 },
+      "sampleSize": 1000,
+      "sampleCapacity": 1000
+    },
+    "at": 1756108800000
+  }
+  ```
+
+---
+
+#### `GET /admin/logs`
+- **說明**: 來自程序內環形緩衝區的最近結構化日誌記錄，由舊到新排列。僅支援輪詢，沒有串流 endpoint。憑證在記錄進入此緩衝區之前就已由 logger 遮蔽。
+- **驗證與授權**: 需驗證，且呼叫者的 `users.is_admin` 必須為 `true`。
+- **查詢參數**:
+  | 參數 | 型別 | 必填 | 說明 |
+  |---|---|---|---|
+  | `limit` | Integer | 否 | 回傳最新的幾筆記錄。預設為緩衝區容量，且必須介於 `1` 與 `capacity` 之間 |
+- **回應**:
+  - `200 OK`: 附帶 `Cache-Control: no-store`。
+  - `400 Bad Request`: `limit` 不是範圍內的整數（`code: "VALIDATION_ERROR"`）。
+  - `401 Unauthorized` / `403 Forbidden`: 與本命名空間所有路由相同。
+- **回應欄位**:
+  | 欄位 | 型別 | 說明 |
+  |---|---|---|
+  | `entries` | Array | 日誌記錄，由舊到新。`level` 為 pino 的數值嚴重度（30 = info、50 = error），`time` 為 epoch 毫秒，`msg` 為訊息；呼叫端額外合併的欄位都會保留 |
+  | `retained` | Number | 目前保留的記錄數，最多為 `capacity` |
+  | `capacity` | Number | 環形緩衝區大小 |
+- **回應範例**:
+  ```json
+  {
+    "entries": [
+      { "level": 30, "time": 1756108795123, "msg": "request completed", "method": "GET", "path": "/api/v1/rooms", "status": 200, "durationMs": 7.4 },
+      { "level": 40, "time": 1756108799001, "msg": "admin access denied", "userId": "0b2f...", "path": "/api/v1/admin/logs" }
+    ],
+    "retained": 2,
+    "capacity": 200
+  }
+  ```
+
+---
+
+#### `GET /admin/slow-queries`
+- **說明**: 來自程序內環形緩衝區、執行時間超過慢查詢門檻的資料庫查詢，由舊到新排列。僅保留查詢骨架——所有插值都會被替換為 `?`，因此依 email 查詢變慢時，不會把該地址留在這個對外提供的緩衝區裡。
+- **驗證與授權**: 需驗證，且呼叫者的 `users.is_admin` 必須為 `true`。
+- **查詢參數**:
+  | 參數 | 型別 | 必填 | 說明 |
+  |---|---|---|---|
+  | `limit` | Integer | 否 | 回傳最新的幾筆記錄。預設為緩衝區容量，且必須介於 `1` 與 `capacity` 之間 |
+- **回應**:
+  - `200 OK`: 附帶 `Cache-Control: no-store`。
+  - `400 Bad Request`: `limit` 不是範圍內的整數（`code: "VALIDATION_ERROR"`）。
+  - `401 Unauthorized` / `403 Forbidden`: 與本命名空間所有路由相同。
+- **回應欄位**:
+  | 欄位 | 型別 | 說明 |
+  |---|---|---|
+  | `queries` | Array | `{ query, durationMs, at }`，由舊到新。`at` 為 epoch 毫秒 |
+  | `retained` | Number | 目前保留的記錄數，最多為 `capacity` |
+  | `capacity` | Number | 環形緩衝區大小 |
+  | `thresholdMs` | Number | 決定哪些查詢會進入此列表的門檻值 |
+- **回應範例**:
+  ```json
+  {
+    "queries": [
+      { "query": "SELECT * FROM messages WHERE room_id = ? ORDER BY created_at DESC LIMIT ?", "durationMs": 184.2, "at": 1756108780000 }
+    ],
+    "retained": 1,
+    "capacity": 100,
+    "thresholdMs": 100
   }
   ```
 

--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -55,6 +55,9 @@ This document defines the RESTful API and Socket.IO real-time communication inte
 | | `DELETE` | [`/users/me/emergency-contacts/:contactId`](#delete-usersmeemergency-contactscontactid) | Yes | Delete emergency contact |
 | | `POST` | [`/users/me/emergency-alert/check-inactivity`](#post-usersmeemergency-alertcheck-inactivity) | Yes | Check inactivity to trigger alert automatically |
 | **Admin** | `GET` | [`/admin/health`](#get-adminhealth) | Yes (admin) | Liveness probe behind the admin gate |
+| | `GET` | [`/admin/metrics`](#get-adminmetrics) | Yes (admin) | Request throughput, latency percentiles and process resource usage |
+| | `GET` | [`/admin/logs`](#get-adminlogs) | Yes (admin) | Recent structured log records (polling) |
+| | `GET` | [`/admin/slow-queries`](#get-adminslow-queries) | Yes (admin) | Queries that ran past the slow threshold |
 
 ### Socket.IO Real-Time Communication
 
@@ -1435,7 +1438,7 @@ the JWT, so revoking it takes effect on the caller's very next request. No
 endpoint sets the flag; see `docs/DEVELOPMENT.md` for the bootstrap procedure.
 
 #### `GET /admin/health`
-- **Description**: Liveness probe for the admin namespace. Its purpose is to make the admin gate reachable end to end; the monitoring endpoints themselves land in #566-#570.
+- **Description**: Liveness probe for the admin namespace, and the one endpoint here that does not depend on any buffer holding content.
 - **Authentication & Authorization**: Authentication required, and the caller's `users.is_admin` must be `true`.
 - **Response**:
   - `200 OK`: Caller is an admin.
@@ -1445,6 +1448,108 @@ endpoint sets the flag; see `docs/DEVELOPMENT.md` for the bootstrap procedure.
   ```json
   {
     "status": "ok"
+  }
+  ```
+
+---
+
+#### `GET /admin/metrics`
+- **Description**: Request throughput, latency percentiles and this process's own resource usage. Everything is per-process and resets on restart, so a multi-instance deployment reports whichever instance served the request.
+- **Authentication & Authorization**: Authentication required, and the caller's `users.is_admin` must be `true`.
+- **Response**:
+  - `200 OK`: Snapshot taken at read time. `Cache-Control: no-store`.
+  - `401 Unauthorized` / `403 Forbidden`: As for every route in this namespace.
+- **Response Fields**:
+  | Field | Type | Description |
+  |---|---|---|
+  | `process.uptimeSeconds` | Number | Seconds since this process started |
+  | `process.cpu.userMs` / `systemMs` | Number | Cumulative CPU milliseconds |
+  | `process.cpu.percent` | Number \| null | CPU used since the *previous* call to this endpoint, as a percentage of one core. `null` on the first call, which has no earlier point to difference against. May exceed 100 on a multi-core host |
+  | `process.memory.*` | Number | `rssBytes`, `heapUsedBytes`, `heapTotalBytes`, `externalBytes` |
+  | `requests.totalRequests` | Number | Lifetime request count |
+  | `requests.statusClasses` | Object | Lifetime counts keyed by `1xx`–`5xx` and `other` |
+  | `requests.latency` | Object | `count`, `avgMs`, `p50Ms`, `p95Ms`, `p99Ms`, `maxMs` over the retained window, **not** over all time |
+  | `requests.sampleSize` / `sampleCapacity` | Number | Retained durations, and the ring's capacity |
+  | `at` | Number | Epoch milliseconds the snapshot was taken |
+- **Response Example**:
+  ```json
+  {
+    "process": {
+      "uptimeSeconds": 812.44,
+      "cpu": { "userMs": 5230.1, "systemMs": 980.4, "percent": 3.2 },
+      "memory": { "rssBytes": 128974848, "heapUsedBytes": 41287680, "heapTotalBytes": 62914560, "externalBytes": 2097152 }
+    },
+    "requests": {
+      "totalRequests": 1842,
+      "statusClasses": { "1xx": 0, "2xx": 1790, "3xx": 0, "4xx": 51, "5xx": 1, "other": 0 },
+      "latency": { "count": 1000, "avgMs": 12.44, "p50Ms": 8.1, "p95Ms": 41.2, "p99Ms": 96.7, "maxMs": 310.5 },
+      "sampleSize": 1000,
+      "sampleCapacity": 1000
+    },
+    "at": 1756108800000
+  }
+  ```
+
+---
+
+#### `GET /admin/logs`
+- **Description**: The most recent structured log records, oldest first, from an in-process ring buffer. Polling only — there is no streaming endpoint. Credentials are redacted by the logger before a record ever reaches this buffer.
+- **Authentication & Authorization**: Authentication required, and the caller's `users.is_admin` must be `true`.
+- **Query Parameters**:
+  | Parameter | Type | Required | Description |
+  |---|---|---|---|
+  | `limit` | Integer | No | How many of the newest records to return. Defaults to the buffer capacity; must be between `1` and `capacity` |
+- **Response**:
+  - `200 OK`: `Cache-Control: no-store`.
+  - `400 Bad Request`: `limit` is not an integer in range (`code: "VALIDATION_ERROR"`).
+  - `401 Unauthorized` / `403 Forbidden`: As for every route in this namespace.
+- **Response Fields**:
+  | Field | Type | Description |
+  |---|---|---|
+  | `entries` | Array | Log records, oldest first. `level` is pino's numeric severity (30 = info, 50 = error), `time` is epoch milliseconds, `msg` the message; any other fields the call site merged in are preserved |
+  | `retained` | Number | Records currently held, at most `capacity` |
+  | `capacity` | Number | Ring buffer size |
+- **Response Example**:
+  ```json
+  {
+    "entries": [
+      { "level": 30, "time": 1756108795123, "msg": "request completed", "method": "GET", "path": "/api/v1/rooms", "status": 200, "durationMs": 7.4 },
+      { "level": 40, "time": 1756108799001, "msg": "admin access denied", "userId": "0b2f...", "path": "/api/v1/admin/logs" }
+    ],
+    "retained": 2,
+    "capacity": 200
+  }
+  ```
+
+---
+
+#### `GET /admin/slow-queries`
+- **Description**: Database queries that ran past the slow threshold, oldest first, from an in-process ring buffer. Only the query skeleton is retained — every interpolated value is replaced with `?`, so a slow lookup by email never parks the address in a buffer this endpoint hands out.
+- **Authentication & Authorization**: Authentication required, and the caller's `users.is_admin` must be `true`.
+- **Query Parameters**:
+  | Parameter | Type | Required | Description |
+  |---|---|---|---|
+  | `limit` | Integer | No | How many of the newest records to return. Defaults to the buffer capacity; must be between `1` and `capacity` |
+- **Response**:
+  - `200 OK`: `Cache-Control: no-store`.
+  - `400 Bad Request`: `limit` is not an integer in range (`code: "VALIDATION_ERROR"`).
+  - `401 Unauthorized` / `403 Forbidden`: As for every route in this namespace.
+- **Response Fields**:
+  | Field | Type | Description |
+  |---|---|---|
+  | `queries` | Array | `{ query, durationMs, at }`, oldest first. `at` is epoch milliseconds |
+  | `retained` | Number | Records currently held, at most `capacity` |
+  | `capacity` | Number | Ring buffer size |
+  | `thresholdMs` | Number | The threshold that decides what lands here |
+- **Response Example**:
+  ```json
+  {
+    "queries": [
+      { "query": "SELECT * FROM messages WHERE room_id = ? ORDER BY created_at DESC LIMIT ?", "durationMs": 184.2, "at": 1756108780000 }
+    ],
+    "retained": 1,
+    "capacity": 100,
+    "thresholdMs": 100
   }
   ```
 


### PR DESCRIPTION
Closes #569。

在既有的管理員守門機制後面補上三個唯讀監控端點。這些端點本身不蒐集任何資料——milestone 前面幾張 issue 建立的緩衝區當初就是為了這條路由而做的，這裡只負責把它們算出來的東西渲染出來。

| 端點 | 資料來源 | 內容 |
|---|---|---|
| `GET /admin/metrics` | #567 | 請求吞吐量、延遲百分位數，加上讀取當下取樣的程序 CPU／記憶體 |
| `GET /admin/logs` | #566 | 最近的結構化日誌環形緩衝區（輪詢，非串流） |
| `GET /admin/slow-queries` | #568 | 超過慢查詢門檻的查詢，並一併回報定義該列表的門檻值 |

## 設計取捨

**注入的來源只暴露讀取半邊。** `AdminMonitoringSources` 用 `Pick<>` 把每個 store 收斂成 `snapshot` / `recent` / `capacity` / `size`——監控端點沒有理由能 `record()` 一個請求、`push()` 一行日誌或 `reset()` 計數器，把這件事寫進型別，等於讓這種 handler 根本寫不出來。這同時也是 #283 要換成跨程序 store 時不必動到本檔案的原因。

**`?limit=` 以緩衝區自身容量為上限，超過回 400 而非默默截斷。** 靜默截斷會讓呼叫端誤以為緩衝區真的只有那麼多。兩個緩衝區容量不同（日誌 200、慢查詢 100），所以 schema 是依 store 建立的，錯誤訊息會講出真正的上限。

**回應帶 `Cache-Control: no-store`。** 事故當下拿到一個過期的 200，和「系統已經不再變化」在畫面上是分不出來的。

**`DEFAULT_SLOW_QUERY_THRESHOLD_MS` 搬到 `utils/slowQueryStore`**，放在它所定義的緩衝區旁邊，`models/instrumentSql` 改為 re-export。這讓分層維持單向：`models/` 與 `routes/` 都依賴 `utils/`，而 `routes/` 不會反向伸進 `models/`。既有 import 路徑不變，測試檔完全沒動。

## 測試策略，以及一個原本會漏掉的坑

handler 位於 `authMiddleware` 之後，而該 middleware 直接抓取共用 SQL client、沒有注入接縫——要在單元測試繞過它只能用 `mock.module()`，那是 `tests/CLAUDE.md` 明令禁止的（issue #467）。另一條路是把未受守門的監控子 app 匯出，但那等於為了測試方便而犧牲一個真實的安全性質，所以沒有這樣做。因此 handler 走端到端測試，只有 `?limit=` 這個純函式部分做單元測試。

**過程中發現的問題**：`NODE_ENV=test` 下 `LOG_LEVEL` 預設為 `silent`，而測試過程中也不會有任何查詢慢到觸發門檻——所以那兩個緩衝區在測試裡是**空的**。第一版 E2E 測試就是在空陣列上做斷言，即使把 `/logs` 的 `?limit=` 完全忽略也照樣通過。現在測試會先把真實緩衝區（不是假物件，這樣連 wiring 一起涵蓋）填入記錄再斷言。

每一條斷言都用 mutation 檢查過會咬人：

| 反向修改 | 結果 |
|---|---|
| 移除 `Cache-Control: no-store` | 測試失敗 ✓ |
| `/logs` 忽略 `?limit=` | 測試失敗 ✓（修正前會通過） |
| `/slow-queries` 忽略 `?limit=` | 測試失敗 ✓ |
| 門檻值回報成 `0` | 測試失敗 ✓ |

憑證外洩的測試也改成真的：透過一個 info 等級的真實 logger 寫入同一個程序層級 store，再斷言端點回傳的是 `[redacted]`——遮蔽發生在寫入當下，直接 push 預先序列化的字串什麼也證明不了。

## 驗收標準對應

- **非管理員三個端點皆回 403，管理員回 200 且結構符合文件** — E2E 逐一涵蓋，另含未驗證的 401。
- **`tsc --noEmit` 通過** — `pnpm run lint`（`eslint src && tsc --noEmit`）乾淨。
- **測試涵蓋 admin／非 admin 兩情境並通過** — unit 618 / integration 46 / e2e 94，全部 0 fail。
- **對齊 `docs/api-documentation.md`** — 三個端點的請求／回應規格、欄位表與範例，英文與繁中皆已補上。

## 後續

`/admin/metrics` 的 `cpu.percent` 是相對於**上一次呼叫**的差值，首次呼叫為 `null`（沒有可比較的前一點，硬填 0 會被讀成程序閒置）。#570 的前端輪詢時需要留意這點，文件已寫明。

三個緩衝區都是單一程序範圍且重啟後歸零，多實例部署下回報的是實際處理該請求的那個實例——這在模組 docblock 與 API 文件都有說明，跨程序化屬於 #283 的範疇。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
