### PR TITLE
chore: lower the Node baseline to 22.22.2 across engines and CI (#579)

### DIFF
--- a/.github/actions/setup-workspace/action.yml
+++ b/.github/actions/setup-workspace/action.yml
@@ -20,7 +20,13 @@ inputs:
   node-version:
     description: Node.js version
     required: false
-    default: '24'
+    # Major form, not a patch pin. An exact pin would only ever prove that one
+    # patch works — the opposite of what CI should show — and would stop
+    # receiving Node's own security fixes the moment the next patch ships. The
+    # floor itself (22.22.2, set by jsdom) is proven instead by the node-version
+    # matrix on ci-frontend.yml's `test` job, which runs that exact version
+    # alongside this default rather than replacing it.
+    default: '22'
   bun-version:
     description: Bun version
     required: false

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -34,11 +34,39 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    # The only job in CI given a Node version matrix, and deliberately so. Both
+    # legs install a byte-identical dependency tree — pnpm resolves from the
+    # lockfile, and optional-dependency filtering keys on os/cpu/libc, never on
+    # the Node version — so the matrix varies exactly one thing: the binary that
+    # executes the task. That only buys signal where the Node version is what
+    # the floor is about, and here it is: jsdom is the sole package in the graph
+    # that sets the 22.22.2 floor, and this job is its only consumer
+    # (frontend/vitest.config.ts runs `environment: "jsdom"`). lint, typecheck
+    # and build would each cost another runner slot on every workflow-touching
+    # PR to re-prove a floor far below both legs (eslint 22.13.0, next 20.9.0).
+    strategy:
+      # Off, not stylistic: with fail-fast on, the failing leg cancels the other
+      # and destroys the one bit this matrix exists to produce — which version
+      # broke it. That would make a two-leg matrix strictly worse than no matrix.
+      fail-fast: false
+      matrix:
+        # '22' is what every other job resolves to via the setup-workspace
+        # default (the latest 22.x, 22.23.2 today), and is listed first because
+        # it is the leg that represents the rest of CI. '22.22.2' is the literal
+        # floor declared in the root package.json `engines.node`, set by
+        # jsdom@30's `^22.22.2 || ^24.15.0 || >=26.0.0`. An exact pin is correct
+        # for a matrix leg and wrong for a default: it proves the floor itself
+        # is runnable, at the cost of a ~10-20s Node download (it is outside the
+        # runner toolcache) and of receiving no later 22.x security fixes. Do
+        # not "fix" it into a floating tag — that would delete the coverage.
+        # Keep this literal in step with `engines.node` until #580 derives it.
+        node-version: ['22', '22.22.2']
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-workspace
         with:
           package: near-chat-frontend
+          node-version: ${{ matrix.node-version }}
       - run: pnpm --filter near-chat-frontend test
 
   build:

--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -37,7 +37,11 @@ jobs:
       # job deliberately does not use the setup-workspace composite action.
       - uses: actions/setup-node@v7
         with:
-          node-version: 24
+          # Hardcoded because this job deliberately skips the composite action
+          # (see above), so it cannot inherit that action's default. Keep this
+          # in step with `node-version` in .github/actions/setup-workspace: two
+          # majors drifting apart is the exact defect issue #579 set out to fix.
+          node-version: '22'
       # `--ratchet` with no baseline present exits 0 and writes one, even with
       # findings at or above --fail-on. A runner always starts from a clean
       # checkout, so if .cve-lite/baseline.json ever stops being tracked, every

--- a/package.json
+++ b/package.json
@@ -8,6 +8,6 @@
   },
   "packageManager": "pnpm@11.15.0",
   "engines": {
-    "node": ">=24"
+    "node": ">=22.22.2"
   }
 }


### PR DESCRIPTION
## 變更描述 (Description)

依 #575 留言（2026-08-25）所定的方向 **選項 B**：把 Node baseline 下修至 `22.22.2`，並以 GitHub Actions matrix 驗證兩種版本。

### 根本原因

root `package.json` 宣告 `engines.node: ">=24"`，但 dependency graph 中最嚴格的條件來自 `jsdom@30.0.1` 的 `^22.22.2 || ^24.15.0 || >=26.0.0`。因此 `">=24"` 的錯誤方向是**太寬鬆**：它允許 24.0.0–24.14.x，而這個區間會被 jsdom 拒絕。加上 repo 無 `.npmrc`、未設 `engine-strict`，`engines` 目前沒有任何強制力，這個落差只會以一行 `[WARN] Unsupported engine` 的形式出現，不會讓任何檢查變紅。

本次已對現行 `main`（`c94a7d5`）重新驗證：

```
$ grep -oP "engines: \{node: \K[^}]*" pnpm-lock.yaml | sort | uniq -c
      1 ^22.22.2 || ^24.15.0 || >=26.0.0     <- jsdom，全 lockfile 僅此一筆
      1 '>=22.19.0'                          <- undici，並非最嚴格
      1 ^20.9.0                              <- next，production runtime floor
```

```
$ node --version
v22.22.2
$ pnpm install --frozen-lockfile
[WARN] Unsupported engine: wanted: {"node":">=24"} (current: {"node":"v22.22.2","pnpm":"11.15.0"})
```

### 變更內容與理由

| 宣告點 | 變更前 | 變更後 |
|---|---|---|
| `package.json` | `">=24"` | `">=22.22.2"` |
| `.github/actions/setup-workspace/action.yml` | `default: '24'` | `default: '22'` |
| `.github/workflows/ci-security.yml` | `node-version: 24` | `node-version: '22'` |

- **CI 版本一律使用 major 形式**。精確 patch pin 只證明單一 patch 可用（與 CI 應證明的相反），且在下一個 patch 發布後不再取得安全性修補。
- **floor 本身改由 matrix 證明**，而不是靠改預設值：在 `ci-frontend.yml` 的 `test` job 加上 `node-version: ['22', '22.22.2']`。
- **只有 `test` 一個 job 上 matrix**。兩條 leg 安裝的 dependency tree 完全相同（pnpm 依 lockfile 解析，optional dependency 的篩選條件是 os/cpu/libc，與 Node 版本無關），因此 matrix 唯一改變的是執行任務的 Node binary。這只在「Node 版本正是 floor 成因」的地方有訊號——而這裡正是：jsdom 是 graph 中唯一設下 22.22.2 的套件，`test` 是 CI 中唯一的 jsdom 消費者（`frontend/vitest.config.ts` 的 `environment: "jsdom"`）。`lint` / `typecheck` / `build` 的實際 floor（eslint 22.13.0、next 20.9.0）都遠低於兩條 leg，多開三個 runner slot 換不到訊號。
- **`fail-fast: false` 是必要而非風格選擇**：預設值會讓失敗的那條 leg 取消另一條，正好抹掉 matrix 唯一要產出的資訊——是哪一個版本壞掉。
- matrix 位於 reusable lane **之內**，會自動收斂成該 lane 的單一 result，因此 `ci.yml` 的 `detect` output、`required-checks` 的 `check_lane` 條目與 branch protection **都不需要改動**。

### 需要記錄的取捨：`">=22.22.2"` 仍然偏寬鬆

`">=22.22.2"` 的 floor 正確，但它同時允許 23.x、24.0.0–24.14.x、25.x，其中 **24.0.0–24.14.x 正是本 issue §2 點名的缺陷區間**。以 semver 實測：

```
--- engines.node = >=22.22.2 ---
  node 22.22.2   declAllows=true   jsdomOK=true
  node 23.11.0   declAllows=true   jsdomOK=false   <== 允許但 jsdom 拒絕
  node 24.0.0    declAllows=true   jsdomOK=false   <== 允許但 jsdom 拒絕
  node 24.14.0   declAllows=true   jsdomOK=false   <== 允許但 jsdom 拒絕
  node 24.15.0   declAllows=true   jsdomOK=true
```

把 `pnpm-lock.yaml` 全部 `engines.node` 取交集，結果等於 jsdom 自身的字串：`^22.22.2 || ^24.15.0 || >=26.0.0`。

本 PR **依維護者的決定原樣寫入 `">=22.22.2"`**（#579 驗收標準第一項要求的正是「等於留言中決定的字串」），不自行改成聯集形式。但這會影響 #580：該 issue 的驗收標準明確要求「`engines.node` 比實際 floor 寬鬆 → 失敗」，並以 `">=20"` 為例要求腳本點名 `jsdom`，因此 #580 的守門一掛上 CI 就會對 `">=22.22.2"` 判紅。已在 #580 留言記錄此前提，實作 #580 時需先決定是否一併收緊為聯集形式。

### 其他已確認事項

- **不在本 PR 範圍**：四個 Dockerfile 的 `node:24-slim` base image（#583）、`@types/node` 對齊（#584）、lockfile floor 守門（#580）。合併後到 #583 之間會有一段「CI 在 Node 22 驗證、prod image 仍是 node:24-slim」的過渡期；這不危險（production 的真實 floor 是 `next@16.3.1` 的 `>=20.9.0`），但該組合在此期間無人測試，建議 #583 接續處理。
- `@types/node` 在前後端皆為 `^26.2.0`，本次下修後 `tsc` 檢查的 API surface 與實際執行的 runtime 差距從 2 個 major 擴大到 4 個。已確認目前 source code 未使用 Node 24-only API，但這讓 #584 的優先度值得提高。
- `docs/archive/deep-research-report.md` 是唯一仍提到 Node 24 的文件，依 CLAUDE.md 為凍結交付物，**刻意未修改**。
- Node 22 自 2025-10-21 起為 maintenance、EOL 2027-04-30（v24 為 Active LTS、EOL 2028-04-30）。此取捨已在 #575 由維護者明確接受。
- 驗收標準第三項對 major 形式的解讀：`'22'` 作為字面 semver 不落在 `>=22.22.2` 內，此處以 **setup-node 解析後的實際版本**（今日為 22.23.2）為準。

## 相關的 Issue (Related Issue)

Closes #579

## 變更類型 (Type of Change)

- [x] `chore`: 建置流程或輔助工具變更
- [x] `ci`: CI 設定變更

## 驗證與測試計畫 (Verification & Test Plan)

### 本地測試 (Local Tests)

本次驗證環境為 **Node v22.22.2**（正好等於新 floor）、pnpm 11.15.0、Bun 1.3.11。本環境**無 Docker daemon**，因此以直接執行 workspace 指令取代 `docker compose exec`：

- [x] 前端型別檢查 `pnpm --filter near-chat-frontend typecheck` — 通過
- [x] 前端 Linter `pnpm --filter near-chat-frontend lint` — 0 error（1 個既有的 `no-unused-vars` warning，非本次引入）
- [x] 前端單元測試 `pnpm --filter near-chat-frontend test` — 3 檔 39 測試全過
- [x] 前端 production build `pnpm --filter near-chat-frontend build` — 通過，11 條路由
- [x] 後端型別檢查與 Linter `pnpm --filter near-chat-backend lint`（`eslint src && tsc --noEmit`）— 通過
- [x] 後端單元測試 `bun test tests/unit` — 618 pass / 0 fail
- [ ] 整合測試 — 本環境無 Docker daemon，未執行；需由 reviewer 或 CI `database` lane 驗證
- [ ] Playwright browser lane — 本環境預裝的 Chromium 與 pinned `@playwright/test` 版本不符（`Looks like Playwright was just installed or updated`），**未能在本地驗證**；CI 的 `ci-browser` lane 自行執行 `playwright install --with-deps chromium`，由該 lane 驗證

### 驗收標準逐項對照

1. `node -p "require('./package.json').engines.node"` → `>=22.22.2`，等於 #575 留言決定的字串。已執行確認。
2. 在 Node 22.22.2 執行 `pnpm install --frozen-lockfile`，輸出**不再包含** `Unsupported engine`。已執行確認（變更前後對照見上）。
3. `grep -rn "node-version" .github/` 列出的值只剩 `ci-security.yml` 的 `'22'` 與 `ci-frontend.yml` matrix 的 `['22', '22.22.2']`，兩者解析後皆落在新範圍內；`ci-security.yml` 不再硬編與其他兩處不同的值。已以 semver 實測確認。
4. CI 五條 lane 全綠 — 由本 PR 自身的 CI 判定。本 PR 觸及 `.github/workflows/**`、`.github/actions/**` 與 `package.json`，三者同時命中 `frontend`、`backend`、`security` 三個 filter，`browser` 跟隨 `frontend`、`database` 跟隨 `backend`，且 base 為 `main` 使 `run-build=true`，因此**這個 PR 本身就會點亮全部五條 lane 並開啟 build**。

### 手動測試 (Manual Verification)

YAML 已以 `yaml.safe_load` 解析驗證，並斷言解析後的實際值（避免 unquoted `22.0` 被誤判為 float 這類 scalar typing 陷阱）：

```
test.strategy = {'fail-fast': False, 'matrix': {'node-version': ['22', '22.22.2']}}
setup step with: {'package': 'near-chat-frontend', 'node-version': '${{ matrix.node-version }}'}
ci-security node-version = '22'
composite default = '22'
```

## 資料庫變更 (Database Changes)

* 此變更是否包含資料庫 Schema 修改？ **否**

## API 與 WebSocket 協定一致性 (API & WebSocket Contract Check)

* 此變更是否涉及 API 路由或 WebSocket 事件的資料結構變更？ **否**

---

Generated with Claude Code (https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013vRcykEfTTH17UmGUE2XAq)_