### PR TITLE
feat(backend): share user presence across instances through Redis (#473)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,7 +54,21 @@ CORS_ORIGINS=http://localhost:3000,http://localhost:3005
 # Realtime session and ephemeral-indication limits
 MAX_SESSIONS_PER_USER=5
 PRESENCE_GRACE_MS=3000
+# Presence lease 在 Redis 中沒有被續約時能存活多久（毫秒）。它決定「某個
+# instance 當掉後，它的使用者最多會被誤顯示成在線多久」—— 行程已死就沒有人
+# 能把 lease 還回去，只剩過期能清掉它。後端每 1/3 個 TTL 續約一次，因此連續
+# 掉兩次續約仍不會讓在線中的連線被誤判離線。REDIS_URL 留空時本變數無作用。
+PRESENCE_TTL_MS=30000
 TYPING_TTL_MS=3000
+
+# 本行程在跨 instance 共享狀態中的識別名稱。Presence lease 以 instance 為單位
+# 持有（每個 user 的 hash 中一個 instance 一個欄位），所以這就是其他 instance
+# 看到的身分。留空（或整行註解掉）時後端會在啟動時自行產生一個 UUID。
+#
+# 若編排器本來就有穩定的 per-replica 名稱（StatefulSet 序號、Compose service
+# instance），設定它是有價值的：重啟後沿用同一個名稱的行程會直接覆寫自己先前
+# 的 lease，而不是多留一個要等 TTL 過期的孤兒。
+# INSTANCE_ID=
 
 # --- 後端可調參數（預設值即為下列數值，通常不需修改）---
 # 這些變數由 backend/src/config/env.ts 讀取，該模組是後端環境變數的權威清單。

--- a/.github/workflows/ci-database.yml
+++ b/.github/workflows/ci-database.yml
@@ -28,11 +28,26 @@ jobs:
           --health-interval 2s
           --health-timeout 5s
           --health-retries 10
+      # The integration tier pins the Redis semantics that presence leases rest
+      # on — per-field TTLs, HLEN excluding expired fields, the key vanishing
+      # with its last field — and a fake cannot answer for any of them. Same
+      # image as the dev stack, on the same host port, so the default in
+      # tests/integration/realtime/presenceStore.int.test.ts also works locally.
+      redis:
+        image: redis:8-alpine
+        ports:
+          - 6385:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 2s
+          --health-timeout 5s
+          --health-retries 10
     env:
       # The migration runner reads DATABASE_URL; the test helpers read
       # DATABASE_URL_TEST (tests/helpers/testPool.ts throws without it). Both
       # are needed — see the explicit DATABASE_URL on the migrate step below.
       DATABASE_URL_TEST: postgresql://postgres:postgres@localhost:5433/ntnu_test
+      REDIS_URL_TEST: redis://localhost:6385
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-workspace

--- a/.github/workflows/release-stack.yml
+++ b/.github/workflows/release-stack.yml
@@ -438,7 +438,17 @@ jobs:
           # Optional. This bundle ships no Redis service, so leave it blank to
           # run realtime single-node, or point it at a managed endpoint —
           # rediss://default:<password>@host:6380 — for cross-node fan-out.
+          # Cross-instance presence needs Redis 7.4 or newer; older servers have
+          # no per-field TTL, so presence quietly stays single-node.
           REDIS_URL=
+          # Only read when REDIS_URL is set. How long a presence lease survives
+          # unrefreshed, which bounds how long a crashed instance keeps its users
+          # showing as online.
+          PRESENCE_TTL_MS=30000
+          # Blank generates one per process. Set it where the orchestrator has a
+          # stable per-replica name, so a restart reclaims its own lease rather
+          # than leaving a second one to expire.
+          INSTANCE_ID=
           JWT_SECRET=change-me-to-a-long-random-secret
           JWT_EXPIRES_IN=15m
           CORS_ORIGINS=http://localhost:3005

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -15,6 +15,7 @@ This directory contains the Bun + Hono TypeScript API server for the chat applic
 | [src/bootstrap/](src/bootstrap/) | One factory per assembly stage: `config`, `repositories`, `redis`, `services`, `httpApp`, `realtime`, `jobs`, `start` |
 | [src/models/db.ts](src/models/db.ts) | Exports the shared `Bun.SQL` instance, connected to the database resolved by `src/config/env.ts` |
 | [src/utils/redis.ts](src/utils/redis.ts) | Redis connection manager built on Bun's native client. Redis holds derived state only, so an outage degrades realtime rather than stopping the API |
+| [src/realtime/presenceStore.ts](src/realtime/presenceStore.ts) | Cross-instance presence as per-instance leases in Redis (hash-field TTLs, Redis 7.4+). Its Redis semantics are pinned in `tests/integration/realtime/` against a real server |
 | [migrations/](migrations/) | PostgreSQL migration files written in raw SQL, applied by the Bun.SQL runner in [src/models/migrate.ts](src/models/migrate.ts) |
 | [package.json](package.json) | NPM scripts (`pnpm run dev` for `bun --watch`, `pnpm run test`) and dependencies |
 

--- a/backend/src/bootstrap/config.ts
+++ b/backend/src/bootstrap/config.ts
@@ -1,19 +1,30 @@
+import { randomUUID } from 'crypto';
 import { env } from '../config/env';
 
 /**
  * The slice of configuration the assembly stages pass between each other.
  *
  * Parsing, defaults and coercion all live in `config/env.ts`; this is the
- * narrow view — port and CORS origins — that `createHttpApp`, `createRealtime`
- * and `startServer` take as an explicit dependency instead of reaching for the
- * environment themselves.
+ * narrow view — port, CORS origins and this process's identity — that
+ * `createHttpApp`, `createRealtime`, `createPresence` and `startServer` take as
+ * an explicit dependency instead of reaching for the environment themselves.
  */
 export interface AppConfig {
   port: string | number;
   corsOrigins: string[];
+  /**
+   * What this process is called in state it shares with other instances.
+   *
+   * Resolved here rather than in `config/env.ts` because it has to be resolved
+   * exactly once: `env()` re-reads `process.env` on every call, so a generated
+   * default would come back different each time it was asked for, and a
+   * presence lease keyed on it would never be released by the process that took
+   * it out.
+   */
+  instanceId: string;
 }
 
 export const createConfig = (): AppConfig => {
-  const { port, corsOrigins } = env();
-  return { port, corsOrigins };
+  const { port, corsOrigins, instanceId } = env();
+  return { port, corsOrigins, instanceId: instanceId ?? randomUUID() };
 };

--- a/backend/src/bootstrap/presence.ts
+++ b/backend/src/bootstrap/presence.ts
@@ -1,0 +1,37 @@
+import type { AppConfig } from './config';
+import type { RedisManager } from '../utils/redis';
+import { env } from '../config/env';
+import { configurePresence, type PresenceTracker } from '../realtime/presence';
+import { createRedisPresenceStore } from '../realtime/presenceStore';
+
+export interface CreatePresenceDeps {
+  config: AppConfig;
+  redis: RedisManager;
+}
+
+/**
+ * The presence assembly stage.
+ *
+ * Thin like the other bootstrap factories: it decides *whether* presence is
+ * shared, and hands `realtime/presence.ts` the store to share it through.
+ *
+ * No `REDIS_URL` means no store at all, rather than a store over a manager that
+ * will refuse every command. The manager is happy to be asked either way, but a
+ * store would mean a heartbeat timer refreshing leases that were never taken
+ * and a warning about a Redis nobody asked for — so a deployment that has opted
+ * out of Redis keeps exactly the single-node presence it had before Redis
+ * existed, timers included.
+ */
+export const createPresence = ({ config, redis }: CreatePresenceDeps): PresenceTracker => {
+  const { redisUrl, realtime } = env();
+  if (!redisUrl) return configurePresence({});
+
+  return configurePresence({
+    store: createRedisPresenceStore({
+      redis,
+      instanceId: config.instanceId,
+      ttlMs: realtime.presenceTtlMs,
+    }),
+    ttlMs: realtime.presenceTtlMs,
+  });
+};

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -79,6 +79,26 @@ export const DEFAULT_SESSION_RESERVATION_TTL_MS = 10_000;
 export const DEFAULT_PRESENCE_GRACE_MS = 3_000;
 
 /**
+ * How long a presence lease survives in Redis without a refresh.
+ *
+ * This is the bound on how long a crashed instance can leave a user showing as
+ * online: nothing runs on a dead process to release its leases, so only the
+ * expiry does it. Long enough that a brief Redis outage or a paused container
+ * does not flap a connected user offline, short enough that a crash converges
+ * well inside a person's patience. `DEFAULT_PRESENCE_REFRESH_DIVISOR` decides
+ * how many refreshes fit in that window.
+ */
+export const DEFAULT_PRESENCE_TTL_MS = 30_000;
+
+/**
+ * How many heartbeats fit inside one lease.
+ *
+ * Three, so two consecutive refreshes can be lost — to a blip, a GC pause, a
+ * Redis failover — before a live connection is wrongly reported offline.
+ */
+export const DEFAULT_PRESENCE_REFRESH_DIVISOR = 3;
+
+/**
  * pino's severities plus `silent`.
  *
  * Declared here rather than imported from `utils/logger` so the dependency runs
@@ -143,6 +163,23 @@ export interface Env {
    */
   redisUrl: string | undefined;
 
+  /**
+   * A name for this process, or `undefined` to have one generated.
+   *
+   * Presence leases are held per instance rather than per socket — every
+   * process is one row in a user's lease hash — so this is the identity another
+   * instance sees. Left unset it is generated once by `bootstrap/config.ts`,
+   * which is the only correct place for it: `env()` re-reads `process.env` on
+   * every call, so a random default computed *here* would be a different value
+   * on every read.
+   *
+   * Worth setting where the orchestrator already has a stable per-replica name
+   * (a StatefulSet ordinal, a Compose service instance): a restarted process
+   * that reclaims its old name replaces its own stale lease rather than adding
+   * a second one that has to wait out the TTL.
+   */
+  instanceId: string | undefined;
+
   /** Raw `JWT_SECRET`, empty treated as unset. The production rule lives in `assertStartupEnv`/`utils/jwt`. */
   jwtSecret: string | undefined;
   accessTokenTtlSeconds: number;
@@ -189,6 +226,11 @@ export interface Env {
      * Defaults to 0 under the test runner so suites leave no timers behind.
      */
     presenceGraceMs: number;
+    /**
+     * How long this instance's presence lease survives in Redis unrefreshed.
+     * Bounds how long a crashed instance keeps a user showing as online.
+     */
+    presenceTtlMs: number;
   };
 
   attachments: {
@@ -422,6 +464,8 @@ const readAll = (source: NodeJS.ProcessEnv, problems?: EnvProblem[]): Env => {
 
     redisUrl: readRedisUrl(source, problems),
 
+    instanceId: source.INSTANCE_ID?.trim() || undefined,
+
     jwtSecret: source.JWT_SECRET || undefined,
     accessTokenTtlSeconds: read(
       source,
@@ -503,6 +547,13 @@ const readAll = (source: NodeJS.ProcessEnv, problems?: EnvProblem[]): Env => {
         'PRESENCE_GRACE_MS',
         asNonNegativeNumber,
         isTest ? 0 : DEFAULT_PRESENCE_GRACE_MS,
+        problems,
+      ),
+      presenceTtlMs: read(
+        source,
+        'PRESENCE_TTL_MS',
+        asPositiveNumber,
+        DEFAULT_PRESENCE_TTL_MS,
         problems,
       ),
     },

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -5,6 +5,7 @@ import { createRepositories } from './bootstrap/repositories';
 import { createServices } from './bootstrap/services';
 import { createHttpApp } from './bootstrap/httpApp';
 import { createRedis } from './bootstrap/redis';
+import { createPresence } from './bootstrap/presence';
 import { createBunRuntimeServer, createRealtime } from './bootstrap/realtime';
 import { createRealtimePublisher } from './realtime/publisher';
 import { createHttpCompatibilityServer } from './bootstrap/httpCompat';
@@ -49,6 +50,11 @@ if (require.main === module) {
   // watchdog, so there is nothing here to catch.
   void redis.connect();
 
+  // Configured only in the real entrypoint, for the same reason as `startJobs`:
+  // importing the app must not leave a heartbeat timer behind, and the E2E
+  // suite has no Redis to share presence through anyway.
+  const presence = createPresence({ config, redis });
+
   const stopJobs = startJobs({ repositories, services });
   void startServer({ server, config });
   let shuttingDown = false;
@@ -68,7 +74,12 @@ if (require.main === module) {
     // (see utils/redis.ts), so a process that lived through a Redis outage would
     // otherwise sit here after the drain until the orchestrator SIGKILLs it.
     server.close(() => {
-      void redis.close().finally(() => process.exit(0));
+      // Presence first: `stop()` hands back every lease this instance holds, so
+      // a redeploy does not leave its users showing online for the rest of the
+      // lease TTL. It needs Redis, which is why `redis.close()` waits for it.
+      void presence
+        .stop()
+        .finally(() => redis.close().finally(() => process.exit(0)));
     });
   };
   process.once('SIGTERM', () => shutdown('SIGTERM'));

--- a/backend/src/realtime/presence.ts
+++ b/backend/src/realtime/presence.ts
@@ -1,105 +1,439 @@
+import type pino from 'pino';
 import type { ChatServer } from './authSocket';
-import { env } from '../config/env';
+import type { PresenceStore } from './presenceStore';
+import { DEFAULT_PRESENCE_REFRESH_DIVISOR, env } from '../config/env';
+import { logger as defaultLogger } from '../utils/logger';
 
 interface FriendPresenceDeps {
   getFriends(userId: string): Promise<{ friend: { userId: string } }[]>;
 }
 
-// Keep a disconnected user online during the short reconnect grace period.
-// This prevents a mobile network handoff from producing offline/online flicker.
-const userSockets = new Map<string, Set<string>>();
-const pendingDisconnects = new Map<string, ReturnType<typeof setTimeout>>();
+/**
+ * Ceiling on how long releasing leases may hold up a shutdown.
+ *
+ * Matched to `DEFAULT_CLOSE_TIMEOUT_MS` in `utils/redis.ts`, which bounds the
+ * step that runs immediately after: a deployment must not be held open by an
+ * unreachable Redis, and an unreleased lease costs at most `presenceTtlMs` of
+ * one user showing online.
+ */
+export const DEFAULT_PRESENCE_STOP_TIMEOUT_MS = 2_000;
 
-const gracePeriodMs = (): number => env().realtime.presenceGraceMs;
-
-export const clearPresence = (): void => {
-  for (const timer of pendingDisconnects.values()) clearTimeout(timer);
-  pendingDisconnects.clear();
-  userSockets.clear();
-};
-
-export const getOnlineUsers = (): string[] => Array.from(new Set([
-  ...userSockets.keys(),
-  ...pendingDisconnects.keys(),
-]));
-
-export const isUserOnline = (userId: string): boolean => {
-  const sockets = userSockets.get(userId);
-  return Boolean((sockets && sockets.size > 0) || pendingDisconnects.has(userId));
-};
-
-const broadcastStatus = async (
-  io: ChatServer,
-  userId: string,
-  status: 'online' | 'offline',
-  friendRepo: FriendPresenceDeps,
-): Promise<void> => {
+/** Resolve when the work does or when the deadline passes, whichever is first. */
+const withDeadline = async (work: Promise<unknown>, ms: number): Promise<void> => {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<void>((resolve) => {
+    timer = setTimeout(resolve, ms);
+    // Never let the deadline itself be the reason the process stays alive.
+    timer.unref?.();
+  });
   try {
-    const friends = await friendRepo.getFriends(userId);
-    for (const f of friends) {
-      if (isUserOnline(f.friend.userId)) {
-        io.to(`user_${f.friend.userId}`).emit('user_status', { userId, status });
+    await Promise.race([work.then(() => undefined, () => undefined), deadline]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+};
+
+export type PresenceStatus = 'online' | 'offline';
+
+/**
+ * A presence answer that can admit it does not know.
+ *
+ * `unknown` is only ever produced by a Redis this instance could not reach
+ * while some other instance might still hold a lease — never by a deployment
+ * running without Redis, where one process seeing no connection *is* the whole
+ * truth.
+ *
+ * It exists because collapsing it to `offline` is safe for a display and unsafe
+ * for a decision. `utils/inactivityJob.ts` acts on offline by escalating to
+ * `checkInactivity`, which past the warning threshold notifies a user's
+ * emergency contacts — a one-shot, recorded delivery that no later tick undoes.
+ * Alerting someone's contacts because Redis blinked is not a degradation anyone
+ * would accept, and a skipped hourly tick costs nothing.
+ */
+export type PresenceState = PresenceStatus | 'unknown';
+
+export interface PresenceTracker {
+  trackUserConnection(
+    io: ChatServer,
+    userId: string,
+    socketId: string,
+    friendRepo: FriendPresenceDeps,
+  ): Promise<void>;
+  trackUserDisconnection(
+    io: ChatServer,
+    userId: string,
+    socketId: string,
+    friendRepo: FriendPresenceDeps,
+  ): Promise<void>;
+  /**
+   * Whether the user has a live connection anywhere.
+   *
+   * Asynchronous because the answer can live on another instance. This
+   * instance's own connections are still answered from memory without a round
+   * trip — they are the part of the answer it is authoritative for.
+   */
+  isUserOnline(userId: string): Promise<boolean>;
+  /**
+   * The same question as `isUserOnline`, without collapsing "Redis did not
+   * answer" into "offline". See `PresenceState`.
+   */
+  presenceOf(userId: string): Promise<PresenceState>;
+  /**
+   * The subset of these users who are online, in one round trip.
+   *
+   * For the list endpoints, which ask about a whole page at once. Unreachable
+   * Redis answers with whatever this instance can see, which is the same
+   * degradation `isUserOnline` makes and is correct for a display.
+   */
+  onlineAmong(userIds: string[]): Promise<Set<string>>;
+  getOnlineUsers(): Promise<string[]>;
+  /** Drop this instance's state and release the leases it is holding. */
+  clearPresence(): Promise<void>;
+  /** Release every lease and stop the heartbeat. Idempotent. */
+  stop(): Promise<void>;
+}
+
+export interface CreatePresenceTrackerOptions {
+  /** Absent means single-node: presence is whatever this process can see. */
+  store?: PresenceStore;
+  /** Read per call, so a test can change `PRESENCE_GRACE_MS` between cases. */
+  graceMs?: () => number;
+  /** Lease lifetime; also sets the heartbeat period. */
+  ttlMs?: number;
+  /** How many heartbeats fit in one lease. */
+  refreshDivisor?: number;
+  /**
+   * Ceiling on how long `stop()` may spend handing leases back.
+   *
+   * Shutdown must terminate whatever Redis is doing, the same bounded-fallback
+   * shape `utils/redis.ts` uses for `close()`. Leases that miss this window are
+   * not lost work — they expire on their own within `ttlMs`.
+   */
+  stopTimeoutMs?: number;
+  logger?: pino.Logger;
+  /** Injected so tests drive the heartbeat instead of waiting for it. */
+  setIntervalFn?: (handler: () => void, ms: number) => ReturnType<typeof setInterval> | number;
+  clearIntervalFn?: (handle: ReturnType<typeof setInterval> | number) => void;
+}
+
+export const createPresenceTracker = ({
+  store,
+  graceMs = () => env().realtime.presenceGraceMs,
+  ttlMs = env().realtime.presenceTtlMs,
+  refreshDivisor = DEFAULT_PRESENCE_REFRESH_DIVISOR,
+  stopTimeoutMs = DEFAULT_PRESENCE_STOP_TIMEOUT_MS,
+  logger = defaultLogger,
+  setIntervalFn = setInterval,
+  clearIntervalFn = clearInterval,
+}: CreatePresenceTrackerOptions = {}): PresenceTracker => {
+  // This instance's own connections. Still a local map with Redis in play, and
+  // not a cache of it: the reconnect grace period, the "which socket left"
+  // bookkeeping and the answer to "is this user on *this* box" are all local
+  // questions, and the only thing another instance needs to know is the single
+  // bit the lease carries.
+  const userSockets = new Map<string, Set<string>>();
+  // Keep a disconnected user online during the short reconnect grace period.
+  // This prevents a mobile network handoff from producing offline/online
+  // flicker. The Redis lease is deliberately held for the whole window too, so
+  // a reconnect that lands on a different instance also sees no transition.
+  const pendingDisconnects = new Map<string, ReturnType<typeof setTimeout>>();
+
+  let heartbeat: ReturnType<typeof setInterval> | number | undefined;
+  let stopped = false;
+
+  const localSocketCount = (userId: string): number => userSockets.get(userId)?.size ?? 0;
+
+  /**
+   * Users this instance is currently holding a lease for.
+   *
+   * A pending disconnect counts: the grace period is a promise that the user
+   * still reads as online, and dropping the lease at the start of it would
+   * break that promise for every other instance.
+   */
+  const heldUsers = (): string[] =>
+    Array.from(new Set([...userSockets.keys(), ...pendingDisconnects.keys()]));
+
+  const isLocallyOnline = (userId: string): boolean =>
+    localSocketCount(userId) > 0 || pendingDisconnects.has(userId);
+
+  /**
+   * Tell a user's friends that their status changed.
+   *
+   * The per-friend check is deliberately the *local* one. `io.to()` reaches
+   * only sockets held by this process — the publisher is single-process, by
+   * design and by its own doc comment — so a friend connected elsewhere cannot
+   * be reached from here whatever Redis says, and asking Redis about each
+   * friend would buy a round trip per friend per connect and change nothing.
+   * Delivering `user_status` across instances is the event bus's job (#475),
+   * not this module's.
+   */
+  const broadcastStatus = async (
+    io: ChatServer,
+    userId: string,
+    status: PresenceStatus,
+    friendRepo: FriendPresenceDeps,
+  ): Promise<void> => {
+    try {
+      const friends = await friendRepo.getFriends(userId);
+      for (const f of friends) {
+        if (isLocallyOnline(f.friend.userId)) {
+          io.to(`user_${f.friend.userId}`).emit('user_status', { userId, status });
+        }
       }
+    } catch (err) {
+      console.error(`Failed to broadcast ${status} status for user ${userId}:`, err);
     }
-  } catch (err) {
-    console.error(`Failed to broadcast ${status} status for user ${userId}:`, err);
-  }
-};
+  };
 
-export const trackUserConnection = async (
-  io: ChatServer,
-  userId: string,
-  socketId: string,
-  friendRepo: FriendPresenceDeps,
-) => {
-  const pending = pendingDisconnects.get(userId);
-  const wasGracefullyReconnecting = pending !== undefined;
-  if (pending) {
-    clearTimeout(pending);
-    pendingDisconnects.delete(userId);
-  }
+  /**
+   * Re-take every lease this instance is holding.
+   *
+   * The window where this could resurrect a user who left mid-refresh is closed
+   * by issue order rather than by a lock: the membership check and the `hold`
+   * for every user are issued in one synchronous burst, before control returns
+   * to the event loop, so a disconnect that arrives afterwards always issues its
+   * `release` *behind* them on the same command connection. Redis applies them
+   * in that order, so the last word belongs to the disconnect. Introducing an
+   * `await` inside this loop would break that and re-open the window.
+   */
+  const refreshLeases = async (): Promise<void> => {
+    if (!store || stopped) return;
+    const users = heldUsers();
+    if (users.length === 0) return;
+    await Promise.all(
+      users.map((userId) => {
+        // A user whose grace period ended between building the list and getting
+        // here no longer wants a lease; re-taking one would resurrect them.
+        if (!isLocallyOnline(userId)) return Promise.resolve();
+        return store.hold(userId, localSocketCount(userId));
+      }),
+    );
+  };
 
-  let sockets = userSockets.get(userId);
-  const wasOffline = !sockets || sockets.size === 0;
-  if (!sockets) {
-    sockets = new Set<string>();
-    userSockets.set(userId, sockets);
-  }
-  sockets.add(socketId);
+  const startHeartbeat = (): void => {
+    // No lease to refresh without a store, and no timer either: importing this
+    // module must not leave the test runner or the E2E suite holding the loop
+    // open.
+    if (!store || heartbeat !== undefined) return;
+    const period = Math.max(1, Math.floor(ttlMs / Math.max(1, refreshDivisor)));
+    heartbeat = setIntervalFn(() => {
+      void refreshLeases().catch((err) => {
+        logger.debug({ err }, 'Presence heartbeat failed');
+      });
+    }, period);
+    (heartbeat as { unref?: () => void }).unref?.();
+  };
 
-  if (wasOffline && !wasGracefullyReconnecting) await broadcastStatus(io, userId, 'online', friendRepo);
-};
-
-export const trackUserDisconnection = async (
-  io: ChatServer,
-  userId: string,
-  socketId: string,
-  friendRepo: FriendPresenceDeps,
-) => {
-  const sockets = userSockets.get(userId);
-  if (!sockets || !sockets.has(socketId)) return;
-
-  sockets.delete(socketId);
-  if (sockets.size > 0) return;
-
-  const delay = gracePeriodMs();
-  if (delay === 0) {
+  /** The user has no connection here any more: drop the lease and settle the edge. */
+  const releaseUser = async (
+    io: ChatServer,
+    userId: string,
+    friendRepo: FriendPresenceDeps,
+  ): Promise<void> => {
     userSockets.delete(userId);
-    await broadcastStatus(io, userId, 'offline', friendRepo);
-    return;
-  }
-
-  // Keep the user online during the grace period. A reconnect cancels this
-  // timer and restores the session without an offline transition.
-  const prior = pendingDisconnects.get(userId);
-  if (prior) clearTimeout(prior);
-  const timer = setTimeout(() => {
     pendingDisconnects.delete(userId);
-    const current = userSockets.get(userId);
-    if (current && current.size === 0) {
-      userSockets.delete(userId);
-      void broadcastStatus(io, userId, 'offline', friendRepo);
+
+    if (!store) {
+      await broadcastStatus(io, userId, 'offline', friendRepo);
+      return;
     }
-  }, delay);
-  pendingDisconnects.set(userId, timer);
+
+    const result = await store.release(userId);
+    // A failed release means the lease is still out there and will expire on its
+    // own. Announcing offline anyway is the right call: this instance knows the
+    // user has no connection here, and falling silent would leave the friends it
+    // *can* reach showing a stale online.
+    const goneEverywhere = !result.ok || result.value === 0;
+    if (goneEverywhere) await broadcastStatus(io, userId, 'offline', friendRepo);
+  };
+
+  const presenceOf = async (userId: string): Promise<PresenceState> => {
+    // Answered from memory when this instance holds the connection: it is the
+    // half of the answer this process is authoritative for, and no round trip
+    // can improve on it.
+    if (isLocallyOnline(userId)) return 'online';
+    // Without a store this process *is* the deployment, so seeing nothing is
+    // knowing they are offline rather than failing to find out.
+    if (!store) return 'offline';
+    const result = await store.isOnline(userId);
+    if (!result.ok) return 'unknown';
+    return result.value ? 'online' : 'offline';
+  };
+
+  return {
+    async trackUserConnection(io, userId, socketId, friendRepo) {
+      if (stopped) return;
+
+      const pending = pendingDisconnects.get(userId);
+      const wasGracefullyReconnecting = pending !== undefined;
+      if (pending) {
+        clearTimeout(pending);
+        pendingDisconnects.delete(userId);
+      }
+
+      let sockets = userSockets.get(userId);
+      const wasLocallyOffline = !sockets || sockets.size === 0;
+      if (!sockets) {
+        sockets = new Set<string>();
+        userSockets.set(userId, sockets);
+      }
+      sockets.add(socketId);
+
+      if (!store) {
+        if (wasLocallyOffline && !wasGracefullyReconnecting) {
+          await broadcastStatus(io, userId, 'online', friendRepo);
+        }
+        return;
+      }
+
+      startHeartbeat();
+      const result = await store.hold(userId, sockets.size);
+      // `0` holders before this call is the definition of "first connection
+      // anywhere", so it covers the second tab, the second instance and the
+      // reconnect inside the grace period without any of them being a special
+      // case: in all three this instance's own lease was already out.
+      const firstAnywhere = result.ok
+        ? result.value === 0
+        : wasLocallyOffline && !wasGracefullyReconnecting;
+      if (firstAnywhere) await broadcastStatus(io, userId, 'online', friendRepo);
+    },
+
+    async trackUserDisconnection(io, userId, socketId, friendRepo) {
+      const sockets = userSockets.get(userId);
+      if (!sockets || !sockets.has(socketId)) return;
+
+      sockets.delete(socketId);
+      // Other tabs are still open here, so the lease stays exactly as it is. Its
+      // stored connection count is a hint the heartbeat refreshes, not a live
+      // counter — nobody reads it to decide anything, and spending a round trip
+      // on every tab close to keep it exact would be paying for a diagnostic.
+      if (sockets.size > 0) return;
+
+      const delay = graceMs();
+      if (delay === 0) {
+        await releaseUser(io, userId, friendRepo);
+        return;
+      }
+
+      // Keep the user online during the grace period. A reconnect cancels this
+      // timer and restores the session without an offline transition.
+      const prior = pendingDisconnects.get(userId);
+      if (prior) clearTimeout(prior);
+      const timer = setTimeout(() => {
+        pendingDisconnects.delete(userId);
+        if (localSocketCount(userId) > 0) return;
+        void releaseUser(io, userId, friendRepo).catch((err) => {
+          logger.debug({ err, userId }, 'Failed to release a presence lease after the grace period');
+        });
+      }, delay);
+      timer.unref?.();
+      pendingDisconnects.set(userId, timer);
+    },
+
+    presenceOf,
+
+    async isUserOnline(userId) {
+      return (await presenceOf(userId)) === 'online';
+    },
+
+    async onlineAmong(userIds) {
+      const online = new Set<string>();
+      const unresolved: string[] = [];
+      for (const userId of new Set(userIds)) {
+        if (isLocallyOnline(userId)) online.add(userId);
+        else unresolved.push(userId);
+      }
+      if (!store || unresolved.length === 0) return online;
+
+      const result = await store.areOnline(unresolved);
+      // A Redis this instance cannot reach makes it single-node again, which is
+      // the same answer it would give with no Redis configured at all.
+      if (result.ok) for (const userId of result.value) online.add(userId);
+      return online;
+    },
+
+    async getOnlineUsers() {
+      const local = heldUsers();
+      if (!store) return local;
+      const result = await store.onlineUsers();
+      return result.ok ? [...new Set([...local, ...result.value])] : local;
+    },
+
+    async clearPresence() {
+      for (const timer of pendingDisconnects.values()) clearTimeout(timer);
+      const users = heldUsers();
+      pendingDisconnects.clear();
+      userSockets.clear();
+      if (store) await Promise.all(users.map((userId) => store.release(userId)));
+    },
+
+    async stop() {
+      stopped = true;
+      if (heartbeat !== undefined) {
+        clearIntervalFn(heartbeat);
+        heartbeat = undefined;
+      }
+      // Release rather than let the leases expire. Shutdown is the one case
+      // where this process knows for certain that its users are gone, and
+      // `index.ts` keeps Redis open through the drain precisely so this write
+      // still lands. A grace timer is cancelled outright: a process that is
+      // going away is not a reconnect anyone should wait for.
+      for (const timer of pendingDisconnects.values()) clearTimeout(timer);
+      const users = heldUsers();
+      pendingDisconnects.clear();
+      userSockets.clear();
+      if (!store || users.length === 0) return;
+      await withDeadline(
+        Promise.all(users.map((userId) => store.release(userId))),
+        stopTimeoutMs,
+      );
+    },
+  };
 };
+
+/**
+ * The process-wide tracker.
+ *
+ * Presence is genuinely one thing per process, and every caller reaches it
+ * through these bindings rather than through an import of a mutable instance,
+ * so `configurePresence` can replace it once the composition root knows whether
+ * there is a Redis to share it through. Until then — and in the E2E suite,
+ * which imports the app without ever calling `connect()` — it runs local-only,
+ * which is exactly the behaviour this module had before Redis existed.
+ *
+ * Tests build their own with `createPresenceTracker` and inject it; nothing
+ * here needs `mock.module`.
+ */
+let current: PresenceTracker = createPresenceTracker();
+
+export const configurePresence = (options: CreatePresenceTrackerOptions): PresenceTracker => {
+  const previous = current;
+  current = createPresenceTracker(options);
+  void previous.stop();
+  return current;
+};
+
+export const trackUserConnection = (
+  io: ChatServer,
+  userId: string,
+  socketId: string,
+  friendRepo: FriendPresenceDeps,
+): Promise<void> => current.trackUserConnection(io, userId, socketId, friendRepo);
+
+export const trackUserDisconnection = (
+  io: ChatServer,
+  userId: string,
+  socketId: string,
+  friendRepo: FriendPresenceDeps,
+): Promise<void> => current.trackUserDisconnection(io, userId, socketId, friendRepo);
+
+export const isUserOnline = (userId: string): Promise<boolean> => current.isUserOnline(userId);
+
+export const presenceOf = (userId: string): Promise<PresenceState> => current.presenceOf(userId);
+
+export const onlineAmong = (userIds: string[]): Promise<Set<string>> =>
+  current.onlineAmong(userIds);
+
+export const getOnlineUsers = (): Promise<string[]> => current.getOnlineUsers();
+
+export const clearPresence = (): Promise<void> => current.clearPresence();

--- a/backend/src/realtime/presenceStore.ts
+++ b/backend/src/realtime/presenceStore.ts
@@ -1,0 +1,265 @@
+import type pino from 'pino';
+import type { RedisManager, RedisOutcome } from '../utils/redis';
+import { logger as defaultLogger } from '../utils/logger';
+
+/**
+ * Namespace for every presence key.
+ *
+ * One Redis serves presence, typing and pub/sub for this stack, so each feature
+ * owns a prefix and `onlineUsers()` can scan for its own keys without seeing
+ * anyone else's.
+ */
+export const PRESENCE_KEY_PREFIX = 'presence:user:';
+
+export const presenceKey = (userId: string): string => `${PRESENCE_KEY_PREFIX}${userId}`;
+
+/**
+ * Cross-instance presence, as leases rather than as a live connection list.
+ *
+ * The shape is one hash per user, one field per backend instance, and a TTL on
+ * each *field*:
+ *
+ * ```
+ * presence:user:{userId}  ->  { "{instanceId}": "{connections}" }   each field PEXPIREd
+ * ```
+ *
+ * Per-field TTLs (Redis 7.4+) rather than a TTL on the whole key, because the
+ * key belongs to the user and the lease belongs to the instance: with one
+ * expiry for the whole hash, the busiest instance's refresh would keep a
+ * crashed instance's row alive forever. Per field, a process that dies stops
+ * refreshing only its own row, and Redis drops it — then drops the key once the
+ * last row is gone, which is what makes "no key" and "nobody online" the same
+ * state.
+ *
+ * Per *instance* rather than per socket, because no other instance has any use
+ * for how many tabs someone has open here. The socket-level bookkeeping stays
+ * local, where it is already needed for the reconnect grace period, and the
+ * only thing that crosses the network is the one bit that is genuinely shared:
+ * this instance has at least one live connection for this user.
+ *
+ * Redis owns the clock throughout. Expiry is evaluated by the server against
+ * the TTL it was handed, never by comparing a stored timestamp against a
+ * reader's `Date.now()`, so two instances whose clocks disagree still agree on
+ * who is online.
+ */
+export interface PresenceStore {
+  /**
+   * Take or refresh this instance's lease on a user.
+   *
+   * Resolves to how many instances held a lease *before* this call, so `0`
+   * means this connection is the first one anywhere — which is exactly the
+   * edge that broadcasts `online`. Idempotent, and the heartbeat calls it too.
+   */
+  hold(userId: string, connections: number): Promise<RedisOutcome<number>>;
+  /**
+   * Drop this instance's lease on a user.
+   *
+   * Resolves to how many instances still hold one, so `0` means the user has
+   * gone offline everywhere — the edge that broadcasts `offline`.
+   */
+  release(userId: string): Promise<RedisOutcome<number>>;
+  /** Whether any instance holds a lease on this user. */
+  isOnline(userId: string): Promise<RedisOutcome<boolean>>;
+  /**
+   * The subset of these users any instance holds a lease on.
+   *
+   * A batch rather than a loop of `isOnline`, because the callers that ask this
+   * question ask it about a whole page at once — every private room in
+   * `GET /rooms`, every friend in `GET /friends` — and a per-user call there
+   * puts the size of someone's contact list into the shape of the endpoint.
+   */
+  areOnline(userIds: string[]): Promise<RedisOutcome<Set<string>>>;
+  /** Every user any instance holds a lease on. Diagnostic; see the note on the scan. */
+  onlineUsers(): Promise<RedisOutcome<string[]>>;
+}
+
+/**
+ * Take the lease and report the previous holder count, in one round trip.
+ *
+ * A script rather than three commands, for two reasons that are both
+ * correctness rather than latency. `HSET` clears a field's TTL, so a process
+ * that died between the `HSET` and the `HPEXPIRE` would leave a lease with no
+ * expiry at all — a user online forever, which is the one failure the TTL
+ * exists to prevent. And reading `HLEN` separately from the write makes the
+ * "first connection anywhere" test a race: two instances taking a user's first
+ * lease at the same moment would both read a count that already included the
+ * other, and neither would announce the user online.
+ */
+const HOLD_SCRIPT = `
+local before = redis.call('HLEN', KEYS[1])
+redis.call('HSET', KEYS[1], ARGV[1], ARGV[3])
+redis.call('HPEXPIRE', KEYS[1], ARGV[2], 'FIELDS', 1, ARGV[1])
+return before
+`.trim();
+
+/**
+ * Drop the lease and report who is left, in one round trip.
+ *
+ * Same reasoning as `HOLD_SCRIPT` in the other direction: read the remaining
+ * count separately and two instances releasing at once can both see the other's
+ * row still present, so neither announces the user offline and the last
+ * transition is lost. Redis deletes the hash when its final field goes, so an
+ * empty result and a missing key are the same answer.
+ */
+const RELEASE_SCRIPT = `
+redis.call('HDEL', KEYS[1], ARGV[1])
+return redis.call('HLEN', KEYS[1])
+`.trim();
+
+/**
+ * How many instances hold a lease on each of these users, in one round trip.
+ *
+ * Multi-key, which a Redis Cluster would reject for keys in different slots.
+ * That is a deliberate limit rather than an oversight: nothing else in this
+ * stack is cluster-aware — `utils/redis.ts` drives one client against one
+ * endpoint — and the moment a cluster is on the table this call becomes a
+ * chunked fan-out, not a rewrite of the key schema.
+ */
+const ONLINE_AMONG_SCRIPT = `
+local out = {}
+for i = 1, #KEYS do out[i] = redis.call('HLEN', KEYS[i]) end
+return out
+`.trim();
+
+/** Redis integer replies arrive as numbers, but a fake or a proxy may stringify them. */
+const asCount = (value: unknown): number => {
+  const count = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(count) && count > 0 ? Math.trunc(count) : 0;
+};
+
+export interface CreatePresenceStoreOptions {
+  redis: RedisManager;
+  /** This process's identity; one hash field per instance. See `AppConfig`. */
+  instanceId: string;
+  /** How long a lease survives unrefreshed. */
+  ttlMs: number;
+  logger?: pino.Logger;
+}
+
+export const createRedisPresenceStore = ({
+  redis,
+  instanceId,
+  ttlMs,
+  logger = defaultLogger,
+}: CreatePresenceStoreOptions): PresenceStore => {
+  const ttl = String(Math.max(1, Math.trunc(ttlMs)));
+  // Hash-field TTLs are the one thing here that a Redis older than 7.4 does not
+  // have, and its error says only "unknown command". Naming the requirement
+  // once turns a silently single-node deployment into a fixable one, and once
+  // is the limit because a down Redis produces one failure per connected user
+  // per heartbeat and the recent-log buffer holds 200 records in total.
+  let warned = false;
+  const warnUnsupported = (operation: string, error: Error): void => {
+    if (warned) return;
+    warned = true;
+    logger.warn(
+      { operation, error: error.message, instanceId },
+      'Presence leases are not reaching Redis; presence falls back to this instance only. Cross-instance presence needs Redis 7.4 or newer for hash-field TTLs',
+    );
+  };
+
+  return {
+    async hold(userId, connections) {
+      const result = await redis.command('EVAL', [
+        HOLD_SCRIPT,
+        '1',
+        presenceKey(userId),
+        instanceId,
+        ttl,
+        String(connections),
+      ]);
+      if (!result.ok) {
+        warnUnsupported('hold', result.error);
+        return result;
+      }
+      return { ok: true as const, value: asCount(result.value) };
+    },
+
+    async release(userId) {
+      const result = await redis.command('EVAL', [
+        RELEASE_SCRIPT,
+        '1',
+        presenceKey(userId),
+        instanceId,
+      ]);
+      if (!result.ok) {
+        warnUnsupported('release', result.error);
+        return result;
+      }
+      return { ok: true as const, value: asCount(result.value) };
+    },
+
+    async isOnline(userId) {
+      // `HLEN` and not `EXISTS`: Redis reports a hash whose fields have all
+      // expired as length zero even in the window before the key itself is
+      // collected, so this answers "is anyone holding a lease" rather than "was
+      // there a key here recently".
+      const result = await redis.command('HLEN', [presenceKey(userId)]);
+      if (!result.ok) return result;
+      return { ok: true as const, value: asCount(result.value) > 0 };
+    },
+
+    async areOnline(userIds) {
+      const unique = [...new Set(userIds)];
+      // Not an empty-result shortcut for its own sake: `EVAL` with a numkeys of
+      // zero is a different command shape, and every caller here can legitimately
+      // hand over an empty page.
+      if (unique.length === 0) return { ok: true as const, value: new Set<string>() };
+
+      const result = await redis.command<unknown>('EVAL', [
+        ONLINE_AMONG_SCRIPT,
+        String(unique.length),
+        ...unique.map(presenceKey),
+      ]);
+      if (!result.ok) return result as RedisOutcome<never>;
+
+      const counts = Array.isArray(result.value) ? result.value : [];
+      const online = new Set<string>();
+      unique.forEach((userId, index) => {
+        if (asCount(counts[index]) > 0) online.add(userId);
+      });
+      return { ok: true as const, value: online };
+    },
+
+    async onlineUsers() {
+      // Deliberately a scan, and deliberately not on a request path. There is no
+      // index of online users to read instead, and maintaining one would mean a
+      // second write per connect that a crashed instance would never undo —
+      // reintroducing exactly the stale state the leases exist to avoid. The
+      // cost is paid only by diagnostics and tests, which is where the callers
+      // are; `isOnline` is the one that answers per-user questions.
+      const users: string[] = [];
+      let cursor = '0';
+      // A cursor that never returns to '0' would spin forever. Redis guarantees
+      // termination, but a fake or a proxy is not Redis.
+      for (let page = 0; page < 10_000; page += 1) {
+        const scan = await redis.command<unknown>('SCAN', [
+          cursor,
+          'MATCH',
+          `${PRESENCE_KEY_PREFIX}*`,
+          'COUNT',
+          '200',
+        ]);
+        if (!scan.ok) return scan as RedisOutcome<never>;
+
+        const page1 = Array.isArray(scan.value) ? scan.value : [];
+        const next = page1[0];
+        const keys = Array.isArray(page1[1]) ? (page1[1] as unknown[]) : [];
+        for (const key of keys) {
+          const name = String(key);
+          if (!name.startsWith(PRESENCE_KEY_PREFIX)) continue;
+          const userId = name.slice(PRESENCE_KEY_PREFIX.length);
+          // A key whose every field has expired is still returned by `SCAN`
+          // until Redis collects it, so each candidate is confirmed rather than
+          // trusted.
+          const live = await redis.command('HLEN', [name]);
+          if (live.ok && asCount(live.value) > 0) users.push(userId);
+        }
+
+        cursor = next === undefined || next === null ? '0' : String(next);
+        if (cursor === '0') break;
+      }
+      return { ok: true as const, value: [...new Set(users)] };
+    },
+  };
+};

--- a/backend/src/realtime/presenceStore.ts
+++ b/backend/src/realtime/presenceStore.ts
@@ -1,5 +1,6 @@
 import type pino from 'pino';
 import type { RedisManager, RedisOutcome } from '../utils/redis';
+import { DEFAULT_PRESENCE_TTL_MS } from '../config/env';
 import { logger as defaultLogger } from '../utils/logger';
 
 /**
@@ -84,11 +85,28 @@ export interface PresenceStore {
  * "first connection anywhere" test a race: two instances taking a user's first
  * lease at the same moment would both read a count that already included the
  * other, and neither would announce the user online.
+ *
+ * `redis.pcall` and the compensating `HDEL` are what make the *script* safe to
+ * run against a server that cannot do the second half. A script is atomic but
+ * it is not transactional: an error partway through does not roll back what ran
+ * before it, so on a Redis older than 7.4 the `HSET` would land, `HPEXPIRE`
+ * would fail as an unknown command, and the degraded mode this module documents
+ * would leave behind exactly the immortal lease it is trying to avoid —
+ * verified against a real server, and pinned in
+ * `tests/integration/realtime/presenceStore.int.test.ts`. Trapping the failure
+ * and undoing the write inside the same script means the operation either takes
+ * an expiring lease or leaves no trace, with no version probe to race and no
+ * state to keep. Returning the error table propagates it as an error reply, so
+ * the caller still sees `{ ok: false }` and degrades to this instance only.
  */
 const HOLD_SCRIPT = `
 local before = redis.call('HLEN', KEYS[1])
 redis.call('HSET', KEYS[1], ARGV[1], ARGV[3])
-redis.call('HPEXPIRE', KEYS[1], ARGV[2], 'FIELDS', 1, ARGV[1])
+local expiry = redis.pcall('HPEXPIRE', KEYS[1], ARGV[2], 'FIELDS', 1, ARGV[1])
+if type(expiry) == 'table' and expiry.err then
+  redis.call('HDEL', KEYS[1], ARGV[1])
+  return expiry
+end
 return before
 `.trim();
 
@@ -142,7 +160,12 @@ export const createRedisPresenceStore = ({
   ttlMs,
   logger = defaultLogger,
 }: CreatePresenceStoreOptions): PresenceStore => {
-  const ttl = String(Math.max(1, Math.trunc(ttlMs)));
+  // Sanitised rather than trusted: a non-finite value would reach Redis as the
+  // literal `NaN` and be rejected there, which the guard in `HOLD_SCRIPT` would
+  // then handle as an unsupported server — a confusing way to report a bad
+  // setting. `config/env.ts` already rejects an unparsable `PRESENCE_TTL_MS`,
+  // so this only covers a caller constructing the store directly.
+  const ttl = String(Number.isFinite(ttlMs) ? Math.max(1, Math.trunc(ttlMs)) : DEFAULT_PRESENCE_TTL_MS);
   // Hash-field TTLs are the one thing here that a Redis older than 7.4 does not
   // have, and its error says only "unknown command". Naming the requirement
   // once turns a silently single-node deployment into a fixable one, and once

--- a/backend/src/realtime/socketServer.ts
+++ b/backend/src/realtime/socketServer.ts
@@ -2,7 +2,7 @@ import type { FriendResponse } from '@shared/types';
 import { ForbiddenError, ValidationError } from '../utils/AppError';
 import type { IRoomMemberRepository } from '../models/IRoomMemberRepository';
 import type { ChatServer } from './authSocket';
-import { trackUserConnection, trackUserDisconnection } from './presence';
+import { trackUserConnection, trackUserDisconnection, type PresenceTracker } from './presence';
 import { mapErrorToApiShape } from '../utils/mapError';
 import { env } from '../config/env';
 
@@ -14,6 +14,14 @@ interface SocketDeps {
     roomId: string,
     operation: () => Promise<T> | T,
   ) => Promise<T>;
+  /**
+   * The presence tracker, defaulting to the process-wide one.
+   *
+   * Injected so a test can watch these two calls without `mock.module`, which
+   * would replace the module for every later test file in the same process.
+   * See backend/tests/CLAUDE.md.
+   */
+  presence?: Pick<PresenceTracker, 'trackUserConnection' | 'trackUserDisconnection'>;
 }
 
 const maxSessionsPerUser = (): number => env().realtime.maxSessionsPerUser;
@@ -36,6 +44,7 @@ const sessionReservationTtlMs = (): number => env().realtime.sessionReservationT
  * authorization and the transaction that creates the durable event.
  */
 export const attachSockets = (io: ChatServer, deps: SocketDeps): void => {
+  const presence = deps.presence ?? { trackUserConnection, trackUserDisconnection };
   const sessionLimit = maxSessionsPerUser();
   const sessionCounts = new Map<string, number>();
   const typingTimers = new Map<string, ReturnType<typeof setTimeout>>();
@@ -170,7 +179,7 @@ export const attachSockets = (io: ChatServer, deps: SocketDeps): void => {
     );
 
     if (deps.friendRepository) {
-      trackUserConnection(io, userId, socket.id, deps.friendRepository).catch((err) => {
+      presence.trackUserConnection(io, userId, socket.id, deps.friendRepository).catch((err) => {
         console.error('trackUserConnection error:', err);
       });
     }
@@ -181,7 +190,7 @@ export const attachSockets = (io: ChatServer, deps: SocketDeps): void => {
       releaseSession(userId);
 
       if (deps.friendRepository) {
-        trackUserDisconnection(io, userId, socket.id, deps.friendRepository).catch((err) => {
+        presence.trackUserDisconnection(io, userId, socket.id, deps.friendRepository).catch((err) => {
           console.error('trackUserDisconnection error:', err);
         });
       }

--- a/backend/src/services/friendService.ts
+++ b/backend/src/services/friendService.ts
@@ -1,6 +1,6 @@
 import { AppError, ConflictError, ValidationError } from '../utils/AppError';
 import type { makeFriendRepository } from '../models/friendRepository';
-import { isUserOnline } from '../realtime/presence';
+import { onlineAmong } from '../realtime/presence';
 
 export function makeFriendService(
   repo: ReturnType<typeof makeFriendRepository>,
@@ -12,6 +12,9 @@ export function makeFriendService(
     reopenPrivateRoom?(userA: string, userB: string): Promise<void>;
   },
   removeUserFromRoom?: (userId: string, roomId: string) => void | Promise<void>,
+  // Injected for the same reason as in `roomService`: presence is a
+  // collaborator, not an import a test has to work around.
+  readOnlineAmong: (userIds: string[]) => Promise<Set<string>> = onlineAmong,
 ) {
   return {
     async sendFriendRequest(requesterId: string, targetUserId: string) {
@@ -103,11 +106,17 @@ export function makeFriendService(
 
     async getFriends(userId: string) {
       const friends = await repo.getFriends(userId);
+      // One presence read for the whole list, for the same reason as
+      // `roomService.list`: a per-friend check makes the cost of this endpoint
+      // the size of the person's friend list.
+      const online = await readOnlineAmong(
+        friends.flatMap((f) => (f && f.friend ? [f.friend.userId] : [])),
+      );
       return friends.map((f) => {
         if (f && f.friend) {
           return {
             ...f,
-            status: isUserOnline(f.friend.userId) ? 'online' : 'offline',
+            status: online.has(f.friend.userId) ? 'online' : 'offline',
           };
         }
         return f;

--- a/backend/src/services/roomService.ts
+++ b/backend/src/services/roomService.ts
@@ -1,7 +1,7 @@
 import type { UploadedFile } from '../utils/fileUpload';
 import type { Room, RoomInvitePreview, RoomSummary } from '@shared/types';
 import { randomBytes } from 'crypto';
-import { isUserOnline } from '../realtime/presence';
+import { onlineAmong } from '../realtime/presence';
 import { defaultAvatarStore, type AvatarStore } from '../utils/avatarUpload';
 import type { IRoomRepository } from '../models/IRoomRepository';
 import type { IRoomMemberRepository } from '../models/IRoomMemberRepository';
@@ -38,6 +38,10 @@ export const makeRoomService = (
   avatarStore: AvatarStore = defaultAvatarStore,
   onMembershipRevoked?: (userId: string, roomId: string) => void | Promise<void>,
   onMembershipGranted?: (userId: string, roomId: string) => void | Promise<void>,
+  // Injected rather than imported at the call site so a test can decide who is
+  // online without reaching for `mock.module` — the same trailing-parameter
+  // shape as `avatarStore` above. See backend/tests/CLAUDE.md.
+  readOnlineAmong: (userIds: string[]) => Promise<Set<string>> = onlineAmong,
 ) => {
   const ensureMember = async (roomId: string, userId: string) => {
     const existing = await roomMemberRepo.findMember(roomId, userId);
@@ -75,11 +79,19 @@ export const makeRoomService = (
 
     async list(userId: string): Promise<RoomSummary[]> {
       const rooms = await repo.findByMember(userId);
+      // One presence read for the whole page. Asking per room would put the
+      // number of a person's private chats into the round-trip count of the
+      // endpoint their client calls on every load.
+      const online = await readOnlineAmong(
+        rooms.flatMap((room) =>
+          room.type === 'private' && room.otherMemberId ? [room.otherMemberId] : [],
+        ),
+      );
       return rooms.map((room) => {
         if (room.type === 'private' && room.otherMemberId) {
           return {
             ...room,
-            isOnline: isUserOnline(room.otherMemberId),
+            isOnline: online.has(room.otherMemberId),
           };
         }
         return room;

--- a/backend/src/utils/inactivityJob.ts
+++ b/backend/src/utils/inactivityJob.ts
@@ -1,11 +1,14 @@
 import type { makeUserService } from '../services/userService';
 import type { IUserRepository } from '../models/IUserRepository';
-import { isUserOnline } from '../realtime/presence';
+import { presenceOf, type PresenceState } from '../realtime/presence';
 
 export function startInactivityJob(
   userRepo: IUserRepository,
   userService: ReturnType<typeof makeUserService>,
-  intervalMs = 60 * 60 * 1000 // default 1 hour
+  intervalMs = 60 * 60 * 1000, // default 1 hour
+  // Injected rather than imported at the call site so a test can decide who is
+  // online without reaching for `mock.module`. See backend/tests/CLAUDE.md.
+  readPresence: (userId: string) => Promise<PresenceState> = presenceOf,
 ) {
   let isRunning = false;
   return setInterval(async () => {
@@ -16,10 +19,16 @@ export function startInactivityJob(
       const now = new Date();
       for (const user of users) {
         try {
-          if (isUserOnline(user.userId)) {
+          const presence = await readPresence(user.userId);
+          if (presence === 'online') {
             await userRepo.update(user.userId, { lastActivity: now });
             continue;
           }
+          // `unknown` means Redis could not be reached, not that the user is
+          // gone. Escalating on it would let a Redis blip notify a connected
+          // user's emergency contacts — a one-shot delivery that the next tick
+          // cannot take back — whereas skipping costs one hour of delay.
+          if (presence === 'unknown') continue;
           await userService.checkInactivity(user.userId, now);
         } catch (err) {
           console.error(`Error checking inactivity for user ${user.userId}:`, err);
@@ -32,6 +41,3 @@ export function startInactivityJob(
     }
   }, intervalMs);
 }
-
-
-

--- a/backend/tests/integration/realtime/presenceStore.int.test.ts
+++ b/backend/tests/integration/realtime/presenceStore.int.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { createRedisManager, type RedisManager } from '../../../src/utils/redis';
+import {
+  createRedisPresenceStore,
+  presenceKey,
+  type PresenceStore,
+} from '../../../src/realtime/presenceStore';
+
+/**
+ * The Redis semantics the unit tier cannot honestly fake.
+ *
+ * `realtime/presenceStore.ts` leans on four promises that belong to the server,
+ * not to this codebase: that `HPEXPIRE` expires one *field* rather than the
+ * key, that `HLEN` does not count a field whose TTL has passed, that the key
+ * disappears once its last field goes, and that a `Lua` script's read and write
+ * are one atomic step. A `Map`-backed fake can be written to agree with all four
+ * and still be wrong. This suite asks a real Redis instead.
+ *
+ * `REDIS_URL_TEST` defaults to the dev compose mapping, so `docker compose up -d
+ * redis` from the repo root is enough to run it locally.
+ */
+const url = process.env.REDIS_URL_TEST || 'redis://localhost:6385';
+
+// Namespaced per run so a leftover key from an interrupted run cannot make a
+// later one pass or fail for the wrong reason, and so two runs can overlap.
+const run = `it-${Math.random().toString(36).slice(2, 10)}`;
+const user = (name: string): string => `${run}-${name}`;
+
+describe('redis presence store against a real Redis', () => {
+  let redis: RedisManager;
+  let alpha: PresenceStore;
+  let beta: PresenceStore;
+
+  const ttlMs = 600;
+
+  beforeAll(async () => {
+    redis = createRedisManager({ url });
+    await redis.connect();
+    if (!(await redis.ping())) {
+      throw new Error(
+        `Redis is not reachable at ${url}. Start it with \`docker compose up -d redis\`, or set REDIS_URL_TEST.`,
+      );
+    }
+    alpha = createRedisPresenceStore({ redis, instanceId: `${run}-alpha`, ttlMs });
+    beta = createRedisPresenceStore({ redis, instanceId: `${run}-beta`, ttlMs });
+  });
+
+  afterAll(async () => {
+    for (const name of ['solo', 'shared', 'expiring', 'page-a', 'page-b', 'listed']) {
+      await redis.command('DEL', [presenceKey(user(name))]);
+    }
+    await redis.close();
+  });
+
+  beforeEach(async () => {
+    for (const name of ['solo', 'shared', 'expiring', 'page-a', 'page-b', 'listed']) {
+      await redis.command('DEL', [presenceKey(user(name))]);
+    }
+  });
+
+  it('reports the first lease anywhere, and only the first', async () => {
+    expect(await alpha.hold(user('shared'), 1)).toEqual({ ok: true, value: 0 });
+    // A second instance is not a new arrival, and neither is a second tab.
+    expect(await beta.hold(user('shared'), 1)).toEqual({ ok: true, value: 1 });
+    expect(await alpha.hold(user('shared'), 2)).toEqual({ ok: true, value: 2 });
+  });
+
+  it('reports the last release anywhere, and only the last', async () => {
+    await alpha.hold(user('shared'), 1);
+    await beta.hold(user('shared'), 1);
+
+    expect(await alpha.release(user('shared'))).toEqual({ ok: true, value: 1 });
+    expect(await alpha.isOnline(user('shared'))).toEqual({ ok: true, value: true });
+
+    expect(await beta.release(user('shared'))).toEqual({ ok: true, value: 0 });
+    expect(await alpha.isOnline(user('shared'))).toEqual({ ok: true, value: false });
+  });
+
+  it('deletes the key once the last lease is handed back', async () => {
+    await alpha.hold(user('solo'), 1);
+    await alpha.release(user('solo'));
+
+    expect(await redis.command('EXISTS', [presenceKey(user('solo'))])).toEqual({
+      ok: true,
+      value: 0,
+    });
+  });
+
+  it('lets an unrefreshed lease expire on its own, which is what bounds a crashed instance', async () => {
+    await alpha.hold(user('expiring'), 1);
+    expect(await beta.isOnline(user('expiring'))).toEqual({ ok: true, value: true });
+
+    // Nothing refreshes it — the instance that took it is gone.
+    await new Promise((resolve) => setTimeout(resolve, ttlMs + 300));
+
+    expect(await beta.isOnline(user('expiring'))).toEqual({ ok: true, value: false });
+    expect(await redis.command('EXISTS', [presenceKey(user('expiring'))])).toEqual({
+      ok: true,
+      value: 0,
+    });
+  });
+
+  it('expires one instance lease without touching another', async () => {
+    await alpha.hold(user('shared'), 1);
+    await new Promise((resolve) => setTimeout(resolve, ttlMs / 2));
+    // beta arrives halfway through alpha's lease and keeps refreshing.
+    await beta.hold(user('shared'), 1);
+    await new Promise((resolve) => setTimeout(resolve, ttlMs / 2 + 200));
+
+    // alpha's field is gone; beta's is not, so the user is still online.
+    expect(await alpha.isOnline(user('shared'))).toEqual({ ok: true, value: true });
+    expect(await redis.command('HLEN', [presenceKey(user('shared'))])).toEqual({
+      ok: true,
+      value: 1,
+    });
+  });
+
+  it('a refresh keeps a live lease past the TTL', async () => {
+    await alpha.hold(user('expiring'), 1);
+    for (let i = 0; i < 3; i += 1) {
+      await new Promise((resolve) => setTimeout(resolve, ttlMs / 3));
+      await alpha.hold(user('expiring'), 1);
+    }
+    await new Promise((resolve) => setTimeout(resolve, ttlMs / 2));
+
+    expect(await beta.isOnline(user('expiring'))).toEqual({ ok: true, value: true });
+  });
+
+  it('resolves a page of users in one round trip', async () => {
+    await alpha.hold(user('page-a'), 1);
+
+    const result = await beta.areOnline([user('page-a'), user('page-b')]);
+
+    expect(result.ok).toBe(true);
+    expect(result.ok && [...result.value]).toEqual([user('page-a')]);
+  });
+
+  it('lists every user any instance holds a lease on', async () => {
+    await alpha.hold(user('listed'), 1);
+
+    const result = await beta.onlineUsers();
+
+    expect(result.ok).toBe(true);
+    expect(result.ok && result.value).toContain(user('listed'));
+  });
+});

--- a/backend/tests/integration/realtime/presenceStore.int.test.ts
+++ b/backend/tests/integration/realtime/presenceStore.int.test.ts
@@ -126,6 +126,77 @@ describe('redis presence store against a real Redis', () => {
     expect(await beta.isOnline(user('expiring'))).toEqual({ ok: true, value: true });
   });
 
+  describe('a server that cannot expire a hash field', () => {
+    // Redis older than 7.4 has no `HPEXPIRE`, and this module's documented
+    // answer is to degrade to single-node. That answer is only honest if the
+    // failed attempt leaves nothing behind — the two tests below are why the
+    // hold script traps the failure instead of letting it abort.
+    //
+    // `HPEXPIRE` cannot be made unknown on this server, so the *shape* is
+    // reproduced with a command name that never exists. What is being pinned is
+    // Redis's behaviour, not this module's source: that a script is atomic but
+    // not transactional, and that `redis.pcall` can trap an unknown command.
+    const UNGUARDED = `
+local before = redis.call('HLEN', KEYS[1])
+redis.call('HSET', KEYS[1], ARGV[1], ARGV[3])
+redis.call('HPEXPIRE_THAT_DOES_NOT_EXIST', KEYS[1], ARGV[2], 'FIELDS', 1, ARGV[1])
+return before
+`.trim();
+
+    const GUARDED = `
+local before = redis.call('HLEN', KEYS[1])
+redis.call('HSET', KEYS[1], ARGV[1], ARGV[3])
+local expiry = redis.pcall('HPEXPIRE_THAT_DOES_NOT_EXIST', KEYS[1], ARGV[2], 'FIELDS', 1, ARGV[1])
+if type(expiry) == 'table' and expiry.err then
+  redis.call('HDEL', KEYS[1], ARGV[1])
+  return expiry
+end
+return before
+`.trim();
+
+    const evalHold = (script: string, name: string) =>
+      redis.command('EVAL', [script, '1', presenceKey(user(name)), `${run}-alpha`, '600', '1']);
+
+    it('leaves an immortal lease behind without the guard, which is the bug', async () => {
+      const result = await evalHold(UNGUARDED, 'solo');
+
+      expect(result.ok).toBe(false);
+      // The write that ran before the error is still there, and with no TTL —
+      // so the instance that took it could die and the user would read online
+      // for good.
+      expect(await redis.command('HLEN', [presenceKey(user('solo'))])).toEqual({
+        ok: true,
+        value: 1,
+      });
+      expect(
+        await redis.command('HPTTL', [presenceKey(user('solo')), 'FIELDS', '1', `${run}-alpha`]),
+      ).toEqual({ ok: true, value: [-1] });
+    });
+
+    it('leaves no trace with the guard, and still reports the failure', async () => {
+      const result = await evalHold(GUARDED, 'solo');
+
+      expect(result.ok).toBe(false);
+      expect(await redis.command('EXISTS', [presenceKey(user('solo'))])).toEqual({
+        ok: true,
+        value: 0,
+      });
+    });
+
+    it('rolls back only its own field, not another instance that is holding one', async () => {
+      await beta.hold(user('shared'), 1);
+
+      const result = await evalHold(GUARDED, 'shared');
+
+      expect(result.ok).toBe(false);
+      expect(await alpha.isOnline(user('shared'))).toEqual({ ok: true, value: true });
+      expect(await redis.command('HLEN', [presenceKey(user('shared'))])).toEqual({
+        ok: true,
+        value: 1,
+      });
+    });
+  });
+
   it('resolves a page of users in one round trip', async () => {
     await alpha.hold(user('page-a'), 1);
 

--- a/backend/tests/unit/bootstrap/bunRuntimeServer.test.ts
+++ b/backend/tests/unit/bootstrap/bunRuntimeServer.test.ts
@@ -73,7 +73,7 @@ describe('createBunRuntimeServer', () => {
 describe('createRealtime', () => {
   it('configures CORS on the engine, which owns the handshake request', () => {
     const { engine } = createRealtime({
-      config: { port: 4000, corsOrigins: ['http://localhost:3000'] },
+      config: { port: 4000, corsOrigins: ['http://localhost:3000'], instanceId: 'test-instance' },
       repositories: {
         roomMembers: { findByUser: mock(), findMember: mock() },
         friends: { getFriends: mock() },

--- a/backend/tests/unit/config/env.test.ts
+++ b/backend/tests/unit/config/env.test.ts
@@ -11,6 +11,7 @@ import {
   DEFAULT_MAX_SESSIONS_PER_USER,
   DEFAULT_PORT,
   DEFAULT_PRESENCE_GRACE_MS,
+  DEFAULT_PRESENCE_TTL_MS,
   DEFAULT_RATE_LIMIT_MAX,
   DEFAULT_RATE_LIMIT_WINDOW_MS,
   DEFAULT_REFRESH_TTL_DAYS,
@@ -51,6 +52,7 @@ describe('env', () => {
       typingTtlMs: DEFAULT_TYPING_TTL_MS,
       sessionReservationTtlMs: DEFAULT_SESSION_RESERVATION_TTL_MS,
       presenceGraceMs: DEFAULT_PRESENCE_GRACE_MS,
+      presenceTtlMs: DEFAULT_PRESENCE_TTL_MS,
     });
     expect(config.attachments).toEqual({
       restrictionEnabled: false,
@@ -147,6 +149,7 @@ describe('env', () => {
         TYPING_TTL_MS: '250',
         SESSION_RESERVATION_TTL_MS: '500',
         PRESENCE_GRACE_MS: '0',
+        PRESENCE_TTL_MS: '12000',
       });
 
       expect(config.realtime).toEqual({
@@ -154,6 +157,7 @@ describe('env', () => {
         typingTtlMs: 250,
         sessionReservationTtlMs: 500,
         presenceGraceMs: 0,
+        presenceTtlMs: 12000,
       });
     });
 

--- a/backend/tests/unit/realtime/presence.test.ts
+++ b/backend/tests/unit/realtime/presence.test.ts
@@ -1,100 +1,378 @@
 import { describe, it, expect, beforeEach, mock, spyOn } from 'bun:test';
-// @ts-expect-error - Bypassing Bun mock cache with query parameter
-import { trackUserConnection, trackUserDisconnection, isUserOnline, getOnlineUsers, clearPresence } from '../../../src/realtime/presence?original';
+import { createPresenceTracker, type PresenceTracker } from '../../../src/realtime/presence';
+import type { PresenceStore } from '../../../src/realtime/presenceStore';
+import type { RedisOutcome } from '../../../src/utils/redis';
 import type { ChatServer } from '../../../src/realtime/authSocket';
 
+/**
+ * One shared lease table, viewed through as many instances as a test needs.
+ *
+ * Modelled as intentions rather than as Redis commands, which is the point of
+ * the `PresenceStore` seam: the fake has to be faithful about *who holds a
+ * lease*, and nothing else. Expiry, hash-field TTLs and the atomicity of the
+ * transitions are Redis's semantics, and they are pinned against a real server
+ * in `tests/integration/realtime/presenceStore.test.ts` rather than guessed at
+ * here.
+ */
+const makeSharedLeases = () => {
+  const holders = new Map<string, Set<string>>();
+  let failing = false;
+
+  const down = <T>(): RedisOutcome<T> => ({ ok: false, error: new Error('redis unavailable') });
+
+  const viewFor = (instanceId: string): PresenceStore => ({
+    async hold(userId) {
+      if (failing) return down<number>();
+      const set = holders.get(userId) ?? new Set<string>();
+      const before = set.size;
+      set.add(instanceId);
+      holders.set(userId, set);
+      return { ok: true, value: before };
+    },
+    async release(userId) {
+      if (failing) return down<number>();
+      const set = holders.get(userId);
+      if (!set) return { ok: true, value: 0 };
+      set.delete(instanceId);
+      if (set.size === 0) holders.delete(userId);
+      return { ok: true, value: set.size };
+    },
+    async isOnline(userId) {
+      if (failing) return down<boolean>();
+      return { ok: true, value: (holders.get(userId)?.size ?? 0) > 0 };
+    },
+    async areOnline(userIds) {
+      if (failing) return down<Set<string>>();
+      return {
+        ok: true,
+        value: new Set(userIds.filter((id) => (holders.get(id)?.size ?? 0) > 0)),
+      };
+    },
+    async onlineUsers() {
+      if (failing) return down<string[]>();
+      return { ok: true, value: [...holders.keys()] };
+    },
+  });
+
+  return {
+    holders,
+    viewFor,
+    breakRedis: () => {
+      failing = true;
+    },
+    healRedis: () => {
+      failing = false;
+    },
+  };
+};
+
+const makeIo = () => {
+  const roomEmit = mock();
+  const io = { to: mock(() => ({ emit: roomEmit })) } as unknown as ChatServer;
+  return { io, roomEmit };
+};
+
 describe('presence tracker', () => {
-  let io: any;
-  let roomEmit: any;
-  let friendRepo: any;
+  let io: ChatServer;
+  let roomEmit: ReturnType<typeof mock>;
+  let friendRepo: { getFriends: ReturnType<typeof mock> };
+  let tracker: PresenceTracker;
 
   beforeEach(() => {
-    clearPresence();
-    roomEmit = mock();
-    io = {
-      to: mock(() => ({ emit: roomEmit })),
-    } as unknown as ChatServer;
-
+    ({ io, roomEmit } = makeIo());
     friendRepo = {
       getFriends: mock().mockResolvedValue([
         { friend: { userId: 'friend-1' } },
-        { friend: { userId: 'friend-2' } }
-      ])
+        { friend: { userId: 'friend-2' } },
+      ]),
     };
+    tracker = createPresenceTracker({ graceMs: () => 0 });
   });
 
-  it('tracks connection, reports online status, and notifies online friends', async () => {
-    // Initially offline
-    expect(isUserOnline('user-1')).toBe(false);
+  describe('without a store (single node)', () => {
+    it('tracks connection, reports online status, and notifies online friends', async () => {
+      expect(await tracker.isUserOnline('user-1')).toBe(false);
 
-    // Friend-1 is online (has socket registered)
-    await trackUserConnection(io, 'friend-1', 'socket-friend', friendRepo);
-    expect(isUserOnline('friend-1')).toBe(true);
+      await tracker.trackUserConnection(io, 'friend-1', 'socket-friend', friendRepo);
+      expect(await tracker.isUserOnline('friend-1')).toBe(true);
 
-    // User-1 connects
-    await trackUserConnection(io, 'user-1', 'socket-1', friendRepo);
-    expect(isUserOnline('user-1')).toBe(true);
-    expect(getOnlineUsers()).toContain('user-1');
+      await tracker.trackUserConnection(io, 'user-1', 'socket-1', friendRepo);
+      expect(await tracker.isUserOnline('user-1')).toBe(true);
+      expect(await tracker.getOnlineUsers()).toContain('user-1');
 
-    // Should broadcast status 'online' to friend-1's room, but not friend-2 (since friend-2 is offline)
-    expect(io.to).toHaveBeenCalledWith('user_friend-1');
-    expect(io.to).not.toHaveBeenCalledWith('user_friend-2');
-    expect(roomEmit).toHaveBeenCalledWith('user_status', { userId: 'user-1', status: 'online' });
+      // friend-2 has no connection here, so there is no local room to reach.
+      expect(io.to).toHaveBeenCalledWith('user_friend-1');
+      expect(io.to).not.toHaveBeenCalledWith('user_friend-2');
+      expect(roomEmit).toHaveBeenCalledWith('user_status', { userId: 'user-1', status: 'online' });
+    });
+
+    it('handles trackUserDisconnection gracefully when userId was never tracked', async () => {
+      await expect(
+        tracker.trackUserDisconnection(io, 'unknown-user', 'socket-1', friendRepo),
+      ).resolves.toBeUndefined();
+    });
+
+    it('suppresses and logs errors from getFriends during trackUserConnection', async () => {
+      const errorRepo = { getFriends: mock().mockRejectedValue(new Error('DB down')) };
+      const consoleSpy = spyOn(console, 'error').mockImplementation(() => {});
+
+      await expect(
+        tracker.trackUserConnection(io, 'user-x', 'socket-1', errorRepo),
+      ).resolves.toBeUndefined();
+
+      expect(consoleSpy).toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+
+    it('suppresses and logs errors from getFriends during trackUserDisconnection', async () => {
+      await tracker.trackUserConnection(io, 'user-y', 'socket-1', friendRepo);
+      const errorRepo = { getFriends: mock().mockRejectedValue(new Error('DB down')) };
+      const consoleSpy = spyOn(console, 'error').mockImplementation(() => {});
+
+      await expect(
+        tracker.trackUserDisconnection(io, 'user-y', 'socket-1', errorRepo),
+      ).resolves.toBeUndefined();
+
+      expect(consoleSpy).toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+
+    it('handles multiple socket connections per user and tracks disconnection', async () => {
+      await tracker.trackUserConnection(io, 'user-1', 'socket-tab-1', friendRepo);
+      await tracker.trackUserConnection(io, 'user-1', 'socket-tab-2', friendRepo);
+
+      expect(await tracker.isUserOnline('user-1')).toBe(true);
+
+      await tracker.trackUserDisconnection(io, 'user-1', 'socket-tab-1', friendRepo);
+      expect(await tracker.isUserOnline('user-1')).toBe(true);
+      expect(roomEmit).not.toHaveBeenCalledWith('user_status', {
+        userId: 'user-1',
+        status: 'offline',
+      });
+
+      await tracker.trackUserConnection(io, 'friend-1', 'socket-friend', friendRepo);
+      roomEmit.mockClear();
+
+      await tracker.trackUserDisconnection(io, 'user-1', 'socket-tab-2', friendRepo);
+      expect(await tracker.isUserOnline('user-1')).toBe(false);
+      expect(io.to).toHaveBeenCalledWith('user_friend-1');
+      expect(roomEmit).toHaveBeenCalledWith('user_status', { userId: 'user-1', status: 'offline' });
+    });
+
+    it('answers offline rather than unknown, because one process is the whole deployment', async () => {
+      expect(await tracker.presenceOf('nobody')).toBe('offline');
+    });
   });
 
-  it('handles trackUserDisconnection gracefully when userId was never tracked', async () => {
-    await expect(
-      trackUserDisconnection(io, 'unknown-user', 'socket-1', friendRepo)
-    ).resolves.toBeUndefined();
+  describe('across instances', () => {
+    let leases: ReturnType<typeof makeSharedLeases>;
+    let alpha: PresenceTracker;
+    let beta: PresenceTracker;
+    let betaIo: ChatServer;
+    let betaEmit: ReturnType<typeof mock>;
+
+    beforeEach(() => {
+      leases = makeSharedLeases();
+      alpha = createPresenceTracker({ store: leases.viewFor('alpha'), graceMs: () => 0 });
+      const second = makeIo();
+      betaIo = second.io;
+      betaEmit = second.roomEmit;
+      beta = createPresenceTracker({ store: leases.viewFor('beta'), graceMs: () => 0 });
+    });
+
+    /**
+     * `user_status` only reaches a friend whose socket is on the emitting
+     * instance, so an audience has to be seated on both before the transitions
+     * are observable at all. That limit is the subject of #475/#476, not of
+     * this module — see `broadcastStatus`.
+     */
+    const seatAudience = async () => {
+      await alpha.trackUserConnection(io, 'friend-1', 'socket-f-a', friendRepo);
+      await beta.trackUserConnection(betaIo, 'friend-1', 'socket-f-b', friendRepo);
+      roomEmit.mockClear();
+      betaEmit.mockClear();
+    };
+
+    it('announces online only for the first connection anywhere', async () => {
+      await seatAudience();
+
+      await alpha.trackUserConnection(io, 'user-1', 'socket-a', friendRepo);
+      expect(roomEmit).toHaveBeenCalledWith('user_status', { userId: 'user-1', status: 'online' });
+
+      // The same user arriving on a second instance is not a new arrival.
+      await beta.trackUserConnection(betaIo, 'user-1', 'socket-b', friendRepo);
+      expect(betaEmit).not.toHaveBeenCalledWith('user_status', {
+        userId: 'user-1',
+        status: 'online',
+      });
+    });
+
+    it('does not announce offline while another instance still holds a connection', async () => {
+      await seatAudience();
+      await alpha.trackUserConnection(io, 'user-1', 'socket-a', friendRepo);
+      await beta.trackUserConnection(betaIo, 'user-1', 'socket-b', friendRepo);
+      roomEmit.mockClear();
+      betaEmit.mockClear();
+
+      await alpha.trackUserDisconnection(io, 'user-1', 'socket-a', friendRepo);
+      expect(roomEmit).not.toHaveBeenCalledWith('user_status', {
+        userId: 'user-1',
+        status: 'offline',
+      });
+      // ...and the instance that lost the socket still reports the user online,
+      // because the other one answered for them.
+      expect(await alpha.isUserOnline('user-1')).toBe(true);
+
+      await beta.trackUserDisconnection(betaIo, 'user-1', 'socket-b', friendRepo);
+      expect(betaEmit).toHaveBeenCalledWith('user_status', { userId: 'user-1', status: 'offline' });
+      expect(await alpha.isUserOnline('user-1')).toBe(false);
+    });
+
+    it('reports a user connected elsewhere as online', async () => {
+      await beta.trackUserConnection(betaIo, 'user-1', 'socket-b', friendRepo);
+      expect(await alpha.isUserOnline('user-1')).toBe(true);
+      expect(await alpha.getOnlineUsers()).toContain('user-1');
+    });
+
+    it('resolves a whole page of users in one read', async () => {
+      await beta.trackUserConnection(betaIo, 'user-1', 'socket-b', friendRepo);
+      await alpha.trackUserConnection(io, 'user-2', 'socket-a', friendRepo);
+
+      const online = await alpha.onlineAmong(['user-1', 'user-2', 'user-3']);
+      expect([...online].sort()).toEqual(['user-1', 'user-2']);
+    });
+
+    it('holds the lease through the reconnect grace period, wherever the reconnect lands', async () => {
+      const gracefulAlpha = createPresenceTracker({
+        store: leases.viewFor('alpha'),
+        graceMs: () => 50,
+      });
+      await gracefulAlpha.trackUserConnection(io, 'user-1', 'socket-a', friendRepo);
+      roomEmit.mockClear();
+
+      await gracefulAlpha.trackUserDisconnection(io, 'user-1', 'socket-a', friendRepo);
+      // Still leased: another instance must not see a gap during the grace window.
+      expect(await beta.isUserOnline('user-1')).toBe(true);
+
+      // The reconnect lands on the *other* instance, which is exactly the case a
+      // local grace timer cannot see.
+      await beta.trackUserConnection(betaIo, 'user-1', 'socket-b', friendRepo);
+      expect(betaEmit).not.toHaveBeenCalledWith('user_status', {
+        userId: 'user-1',
+        status: 'online',
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 80));
+      // The grace timer fired on alpha and dropped alpha's lease — but beta is
+      // holding one, so nobody was told the user went offline.
+      expect(roomEmit).not.toHaveBeenCalledWith('user_status', {
+        userId: 'user-1',
+        status: 'offline',
+      });
+      expect(await beta.isUserOnline('user-1')).toBe(true);
+    });
+
+    it('hands leases back on shutdown instead of waiting out the TTL', async () => {
+      await alpha.trackUserConnection(io, 'user-1', 'socket-a', friendRepo);
+      expect(leases.holders.get('user-1')?.has('alpha')).toBe(true);
+
+      await alpha.stop();
+      expect(leases.holders.has('user-1')).toBe(false);
+    });
   });
 
-  it('suppresses and logs errors from getFriends during trackUserConnection', async () => {
-    const errorRepo = { getFriends: mock().mockRejectedValue(new Error('DB down')) };
-    const consoleSpy = spyOn(console, 'error').mockImplementation(() => {});
+  describe('when Redis is unreachable', () => {
+    let leases: ReturnType<typeof makeSharedLeases>;
 
-    await expect(trackUserConnection(io, 'user-x', 'socket-1', errorRepo)).resolves.toBeUndefined();
+    beforeEach(() => {
+      leases = makeSharedLeases();
+      tracker = createPresenceTracker({ store: leases.viewFor('alpha'), graceMs: () => 0 });
+    });
 
-    expect(consoleSpy).toHaveBeenCalled();
-    consoleSpy.mockRestore();
-    clearPresence();
+    it('still tracks connections and announces the local edges', async () => {
+      await tracker.trackUserConnection(io, 'friend-1', 'socket-friend', friendRepo);
+      roomEmit.mockClear();
+      leases.breakRedis();
+
+      await expect(
+        tracker.trackUserConnection(io, 'user-1', 'socket-1', friendRepo),
+      ).resolves.toBeUndefined();
+      expect(roomEmit).toHaveBeenCalledWith('user_status', { userId: 'user-1', status: 'online' });
+
+      roomEmit.mockClear();
+      await tracker.trackUserDisconnection(io, 'user-1', 'socket-1', friendRepo);
+      expect(roomEmit).toHaveBeenCalledWith('user_status', { userId: 'user-1', status: 'offline' });
+    });
+
+    it('says "unknown" rather than "offline" for a user it cannot ask about', async () => {
+      leases.breakRedis();
+      expect(await tracker.presenceOf('someone-elsewhere')).toBe('unknown');
+      // The display collapse is still offline — a screen has to show something.
+      expect(await tracker.isUserOnline('someone-elsewhere')).toBe(false);
+    });
+
+    it('never says "unknown" about a user connected to this instance', async () => {
+      await tracker.trackUserConnection(io, 'user-1', 'socket-1', friendRepo);
+      leases.breakRedis();
+      expect(await tracker.presenceOf('user-1')).toBe('online');
+    });
   });
 
-  it('suppresses and logs errors from getFriends during trackUserDisconnection', async () => {
-    await trackUserConnection(io, 'user-y', 'socket-1', friendRepo);
+  describe('lease heartbeat', () => {
+    it('re-takes every lease it holds, so a live connection outlives the TTL', async () => {
+      const leases = makeSharedLeases();
+      let beat: (() => void) | undefined;
+      const heartbeatTracker = createPresenceTracker({
+        store: leases.viewFor('alpha'),
+        graceMs: () => 0,
+        ttlMs: 300,
+        refreshDivisor: 3,
+        setIntervalFn: (handler) => {
+          beat = handler;
+          return 0;
+        },
+        clearIntervalFn: () => {},
+      });
 
-    const errorRepo = { getFriends: mock().mockRejectedValue(new Error('DB down')) };
-    const consoleSpy = spyOn(console, 'error').mockImplementation(() => {});
+      await heartbeatTracker.trackUserConnection(io, 'user-1', 'socket-1', friendRepo);
+      expect(beat).toBeDefined();
 
-    await expect(trackUserDisconnection(io, 'user-y', 'socket-1', errorRepo)).resolves.toBeUndefined();
+      // Something else expired the lease — a Redis restart, a TTL that elapsed
+      // during an outage. The next beat must put it back.
+      leases.holders.delete('user-1');
+      beat!();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(leases.holders.get('user-1')?.has('alpha')).toBe(true);
+    });
 
-    expect(consoleSpy).toHaveBeenCalled();
-    consoleSpy.mockRestore();
-  });
+    it('does not re-take a lease for a user who has already left', async () => {
+      const leases = makeSharedLeases();
+      let beat: (() => void) | undefined;
+      const heartbeatTracker = createPresenceTracker({
+        store: leases.viewFor('alpha'),
+        graceMs: () => 0,
+        ttlMs: 300,
+        setIntervalFn: (handler) => {
+          beat = handler;
+          return 0;
+        },
+        clearIntervalFn: () => {},
+      });
 
-  it('handles multiple socket connections per user and tracks disconnection', async () => {
-    // User connects on tab 1
-    await trackUserConnection(io, 'user-1', 'socket-tab-1', friendRepo);
-    // User connects on tab 2
-    await trackUserConnection(io, 'user-1', 'socket-tab-2', friendRepo);
+      await heartbeatTracker.trackUserConnection(io, 'user-1', 'socket-1', friendRepo);
+      await heartbeatTracker.trackUserDisconnection(io, 'user-1', 'socket-1', friendRepo);
+      expect(leases.holders.has('user-1')).toBe(false);
 
-    expect(isUserOnline('user-1')).toBe(true);
+      beat!();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(leases.holders.has('user-1')).toBe(false);
+    });
 
-    // Disconnect tab 1
-    await trackUserDisconnection(io, 'user-1', 'socket-tab-1', friendRepo);
-    // User is still online because tab 2 is open
-    expect(isUserOnline('user-1')).toBe(true);
-    expect(roomEmit).not.toHaveBeenCalledWith('user_status', { userId: 'user-1', status: 'offline' });
-
-    // Friend-1 is online
-    await trackUserConnection(io, 'friend-1', 'socket-friend', friendRepo);
-    roomEmit.mockClear();
-
-    // Disconnect tab 2
-    await trackUserDisconnection(io, 'user-1', 'socket-tab-2', friendRepo);
-    // User is now offline
-    expect(isUserOnline('user-1')).toBe(false);
-    // Should broadcast offline status to friend-1
-    expect(io.to).toHaveBeenCalledWith('user_friend-1');
-    expect(roomEmit).toHaveBeenCalledWith('user_status', { userId: 'user-1', status: 'offline' });
+    it('starts no timer at all without a store', async () => {
+      const setIntervalFn = mock(() => 0);
+      const local = createPresenceTracker({ graceMs: () => 0, setIntervalFn });
+      await local.trackUserConnection(io, 'user-1', 'socket-1', friendRepo);
+      expect(setIntervalFn).not.toHaveBeenCalled();
+    });
   });
 });

--- a/backend/tests/unit/realtime/presenceStore.test.ts
+++ b/backend/tests/unit/realtime/presenceStore.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, mock } from 'bun:test';
+import pino from 'pino';
+import {
+  createRedisPresenceStore,
+  presenceKey,
+  PRESENCE_KEY_PREFIX,
+} from '../../../src/realtime/presenceStore';
+import type { RedisManager, RedisOutcome } from '../../../src/utils/redis';
+
+interface RecordedCommand {
+  command: string;
+  args: string[];
+}
+
+/**
+ * A `RedisManager` that records what it was asked and answers from a script.
+ *
+ * Deliberately not a Redis simulator. What this tier can honestly check is the
+ * *protocol* — which command, which key, which arguments, and how a reply is
+ * mapped back — because that is what this module writes. Whether `HPEXPIRE`
+ * really expires a field, and whether `HLEN` really excludes an expired one,
+ * are Redis's promises and are pinned against a real server in
+ * `tests/integration/realtime/presenceStore.test.ts`.
+ */
+const makeRedis = (replies: unknown[] | ((call: RecordedCommand) => unknown)) => {
+  const calls: RecordedCommand[] = [];
+  let index = 0;
+  const redis = {
+    async command<T>(command: string, args: string[] = []): Promise<RedisOutcome<T>> {
+      const call = { command, args };
+      calls.push(call);
+      const reply = typeof replies === 'function' ? replies(call) : replies[index++];
+      if (reply instanceof Error) return { ok: false, error: reply };
+      return { ok: true, value: reply as T };
+    },
+  } as unknown as RedisManager;
+  return { redis, calls };
+};
+
+const makeStore = (redis: RedisManager, logger?: pino.Logger) =>
+  createRedisPresenceStore({ redis, instanceId: 'alpha', ttlMs: 30_000, logger });
+
+describe('redis presence store', () => {
+  it('takes a lease and reports how many instances held one before', async () => {
+    const { redis, calls } = makeRedis([2]);
+    const store = makeStore(redis);
+
+    const result = await store.hold('user-1', 3);
+
+    expect(result).toEqual({ ok: true, value: 2 });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].command).toBe('EVAL');
+    const [script, numkeys, key, instanceId, ttl, connections] = calls[0].args;
+    expect(numkeys).toBe('1');
+    expect(key).toBe(`${PRESENCE_KEY_PREFIX}user-1`);
+    expect(instanceId).toBe('alpha');
+    expect(ttl).toBe('30000');
+    expect(connections).toBe('3');
+    // The write and the count that decides the online edge have to be one
+    // operation; see the comment on HOLD_SCRIPT.
+    expect(script).toContain('HLEN');
+    expect(script).toContain('HSET');
+    expect(script).toContain('HPEXPIRE');
+  });
+
+  it('drops the lease and reports who is left', async () => {
+    const { redis, calls } = makeRedis([0]);
+    const store = makeStore(redis);
+
+    expect(await store.release('user-1')).toEqual({ ok: true, value: 0 });
+    expect(calls[0].command).toBe('EVAL');
+    expect(calls[0].args[2]).toBe(presenceKey('user-1'));
+    expect(calls[0].args[3]).toBe('alpha');
+    expect(calls[0].args[0]).toContain('HDEL');
+  });
+
+  it('reads one user with HLEN, not EXISTS', async () => {
+    const { redis, calls } = makeRedis([1]);
+    const store = makeStore(redis);
+
+    expect(await store.isOnline('user-1')).toEqual({ ok: true, value: true });
+    expect(calls[0]).toEqual({ command: 'HLEN', args: [presenceKey('user-1')] });
+  });
+
+  it('treats a hash whose fields have all expired as offline', async () => {
+    const { redis } = makeRedis([0]);
+    expect(await makeStore(redis).isOnline('user-1')).toEqual({ ok: true, value: false });
+  });
+
+  it('resolves a whole page of users in one round trip', async () => {
+    const { redis, calls } = makeRedis([[1, 0, 2]]);
+    const store = makeStore(redis);
+
+    const result = await store.areOnline(['user-1', 'user-2', 'user-3']);
+
+    expect(result.ok && [...result.value].sort()).toEqual(['user-1', 'user-3']);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].args[1]).toBe('3');
+    expect(calls[0].args.slice(2)).toEqual([
+      presenceKey('user-1'),
+      presenceKey('user-2'),
+      presenceKey('user-3'),
+    ]);
+  });
+
+  it('collapses a repeated user rather than asking about them twice', async () => {
+    const { redis, calls } = makeRedis([[1]]);
+    const store = makeStore(redis);
+
+    const result = await store.areOnline(['user-1', 'user-1']);
+
+    expect(result.ok && [...result.value]).toEqual(['user-1']);
+    expect(calls[0].args[1]).toBe('1');
+  });
+
+  it('asks nothing at all for an empty page', async () => {
+    const { redis, calls } = makeRedis([]);
+    const result = await makeStore(redis).areOnline([]);
+
+    expect(result).toEqual({ ok: true, value: new Set<string>() });
+    expect(calls).toHaveLength(0);
+  });
+
+  it('walks the scan cursor to the end and confirms every candidate', async () => {
+    const pages: Record<string, [string, string[]]> = {
+      '0': ['17', [`${PRESENCE_KEY_PREFIX}user-1`, `${PRESENCE_KEY_PREFIX}user-2`]],
+      // SCAN is allowed to hand back a key it already returned, and a key whose
+      // last field has expired but has not been collected yet.
+      '17': ['0', [`${PRESENCE_KEY_PREFIX}user-1`, `${PRESENCE_KEY_PREFIX}user-3`]],
+    };
+    const { redis, calls } = makeRedis((call) => {
+      if (call.command === 'SCAN') return pages[call.args[0]];
+      if (call.command === 'HLEN') return call.args[0].endsWith('user-3') ? 0 : 1;
+      return 0;
+    });
+
+    const result = await makeStore(redis).onlineUsers();
+
+    expect(result.ok && [...result.value].sort()).toEqual(['user-1', 'user-2']);
+    const scans = calls.filter((c) => c.command === 'SCAN');
+    expect(scans).toHaveLength(2);
+    expect(scans[0].args).toEqual(['0', 'MATCH', `${PRESENCE_KEY_PREFIX}*`, 'COUNT', '200']);
+    expect(scans[1].args[0]).toBe('17');
+  });
+
+  it('reports a failed lease rather than pretending it landed', async () => {
+    const { redis } = makeRedis([new Error('ERR unknown command HPEXPIRE')]);
+    const result = await makeStore(redis).hold('user-1', 1);
+
+    expect(result.ok).toBe(false);
+    expect(!result.ok && result.error.message).toContain('HPEXPIRE');
+  });
+
+  it('names the Redis version requirement once, not once per connected user', async () => {
+    const lines: string[] = [];
+    const logger = pino(
+      { level: 'warn' },
+      { write: (line: string) => lines.push(line) } as pino.DestinationStream,
+    );
+    const { redis } = makeRedis(() => new Error('ERR unknown command HPEXPIRE'));
+    const store = makeStore(redis, logger);
+
+    await store.hold('user-1', 1);
+    await store.hold('user-2', 1);
+    await store.release('user-3');
+
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain('7.4');
+  });
+});

--- a/backend/tests/unit/realtime/presenceStore.test.ts
+++ b/backend/tests/unit/realtime/presenceStore.test.ts
@@ -61,6 +61,12 @@ describe('redis presence store', () => {
     expect(script).toContain('HLEN');
     expect(script).toContain('HSET');
     expect(script).toContain('HPEXPIRE');
+    // A script is atomic but not transactional: an `HPEXPIRE` that fails on an
+    // older server would otherwise leave the `HSET` behind as a lease that never
+    // expires. See the integration tier, which proves both halves against a real
+    // Redis.
+    expect(script).toContain('redis.pcall');
+    expect(script).toContain('HDEL');
   });
 
   it('drops the lease and reports who is left', async () => {

--- a/backend/tests/unit/realtime/socketServer.test.ts
+++ b/backend/tests/unit/realtime/socketServer.test.ts
@@ -1,16 +1,14 @@
-import { describe, it, expect, beforeEach, afterAll, mock, type Mock } from 'bun:test';
+import { describe, it, expect, beforeEach, mock, type Mock } from 'bun:test';
 import { attachSockets } from '../../../src/realtime/socketServer';
 import type { ChatServer } from '../../../src/realtime/authSocket';
-import { trackUserConnection, trackUserDisconnection } from '../../../src/realtime/presence';
 
-mock.module('../../../src/realtime/presence', () => ({
+// Injected rather than `mock.module`'d: a module mock is process-global within
+// a tier and cannot be undone, so stubbing presence here would also stub it for
+// every later file in this tier. See backend/tests/CLAUDE.md and issue #467.
+const presence = {
   trackUserConnection: mock().mockResolvedValue(undefined),
   trackUserDisconnection: mock().mockResolvedValue(undefined),
-}));
-
-afterAll(() => {
-  mock.module('../../../src/realtime/presence', () => require('../../../src/realtime/presence?original'));
-});
+};
 
 describe('attachSockets', () => {
   let connectionHandler: any;
@@ -119,8 +117,8 @@ describe('attachSockets', () => {
     const friendRepo = { getFriends: mock() };
 
     beforeEach(() => {
-      ((trackUserConnection as any) as Mock<any>).mockClear();
-      ((trackUserDisconnection as any) as Mock<any>).mockClear();
+      presence.trackUserConnection.mockClear();
+      presence.trackUserDisconnection.mockClear();
 
       let frConnectionHandler: any;
       const frHandlers: Record<string, any> = {};
@@ -142,16 +140,20 @@ describe('attachSockets', () => {
         to: mock(() => ({ emit: mock() })),
       } as unknown as ChatServer;
 
-      attachSockets(frIo, { roomMemberRepository: roomMemberRepo, friendRepository: friendRepo });
+      attachSockets(frIo, {
+        roomMemberRepository: roomMemberRepo,
+        friendRepository: friendRepo,
+        presence,
+      });
       frConnectionHandler(frSocket);
       frHandlers.disconnect();
     });
 
     it('tracks a session on connect and disconnect', () => {
-      expect(trackUserConnection).toHaveBeenCalledWith(
+      expect(presence.trackUserConnection).toHaveBeenCalledWith(
         expect.anything(), 'user-1', 'socket-fr-1', friendRepo,
       );
-      expect(trackUserDisconnection).toHaveBeenCalledWith(
+      expect(presence.trackUserDisconnection).toHaveBeenCalledWith(
         expect.anything(), 'user-1', 'socket-fr-1', friendRepo,
       );
     });

--- a/backend/tests/unit/services/friendService.test.ts
+++ b/backend/tests/unit/services/friendService.test.ts
@@ -3,6 +3,24 @@ import { makeFriendService } from '../../../src/services/friendService';
 import { AppError } from '../../../src/utils/AppError';
 
 describe('friendService', () => {
+  it('getFriends labels each friend from one presence read for the whole list', async () => {
+    const mockRepo = {
+      getFriends: mock().mockResolvedValue([
+        { friend: { userId: 'u2' } },
+        { friend: { userId: 'u3' } },
+      ]),
+    } as any;
+    // Injected rather than `mock.module`'d; see backend/tests/CLAUDE.md.
+    const readOnlineAmong = mock(async () => new Set(['u2']));
+    const service = makeFriendService(mockRepo, undefined, undefined, undefined, readOnlineAmong);
+
+    const result = (await service.getFriends('u1')) as any[];
+
+    expect(result.map((f) => f.status)).toEqual(['online', 'offline']);
+    expect(readOnlineAmong).toHaveBeenCalledTimes(1);
+    expect(readOnlineAmong).toHaveBeenCalledWith(['u2', 'u3']);
+  });
+
   it('respondFriendRequest throws NOT_FOUND when accepting non-existent request', async () => {
     const mockRepo = {
       isBlocked: mock().mockResolvedValue(false),

--- a/backend/tests/unit/services/roomService.test.ts
+++ b/backend/tests/unit/services/roomService.test.ts
@@ -1,17 +1,14 @@
-import { describe, it, expect, beforeEach, afterAll, mock, type Mock } from 'bun:test';
+import { describe, it, expect, beforeEach, mock, type Mock } from 'bun:test';
 import { makeRoomService } from '../../../src/services/roomService';
 import { ConflictError, ForbiddenError, NotFoundError, ValidationError } from '../../../src/utils/AppError';
 import type { IRoomRepository } from '../../../src/models/IRoomRepository';
 import type { IRoomMemberRepository } from '../../../src/models/IRoomMemberRepository';
 import type { Room, RoomMember } from '../../../../shared/types';
 
-mock.module('../../../src/realtime/presence', () => ({
-  isUserOnline: mock().mockReturnValue(false),
-}));
-
-afterAll(() => {
-  mock.module('../../../src/realtime/presence', () => require('../../../src/realtime/presence?original'));
-});
+// Injected below rather than `mock.module`'d, for the same reason as
+// `avatarStore`: a module mock is process-global within a tier and cannot be
+// undone. See backend/tests/CLAUDE.md and issue #467.
+const readOnlineAmong = mock(async () => new Set<string>());
 
 type Mocked<T> = {
   [P in keyof T]: T[P] extends Function ? Mock<any> : T[P];
@@ -67,8 +64,11 @@ describe('roomService', () => {
       saveAvatarUpload: mock(),
       removeManagedAvatar: mock(),
     };
+    readOnlineAmong.mockReset();
+    readOnlineAmong.mockResolvedValue(new Set<string>());
     roomService = makeRoomService(
       mockRepo, mockMemberRepo, undefined, undefined, undefined, undefined, undefined, avatarStore,
+      undefined, undefined, readOnlineAmong,
     );
   });
 
@@ -580,6 +580,29 @@ describe('roomService', () => {
       mockRepo.findByMember.mockResolvedValue([room] as any);
       const result = await roomService.list('user-1');
       expect(result[0]).not.toHaveProperty('isOnline');
+    });
+
+    it('reports the other member online when any instance holds a lease on them', async () => {
+      const privateRoom = { ...room, type: 'private' as const, otherMemberId: 'user-2' };
+      mockRepo.findByMember.mockResolvedValue([privateRoom] as any);
+      readOnlineAmong.mockResolvedValue(new Set(['user-2']));
+
+      const result = await roomService.list('user-1');
+
+      expect((result[0] as any).isOnline).toBe(true);
+    });
+
+    it('asks about the whole page once instead of once per room', async () => {
+      mockRepo.findByMember.mockResolvedValue([
+        { ...room, roomId: 'r1', type: 'private' as const, otherMemberId: 'user-2' },
+        { ...room, roomId: 'r2', type: 'private' as const, otherMemberId: 'user-3' },
+        { ...room, roomId: 'r3', type: 'group' as const },
+      ] as any);
+
+      await roomService.list('user-1');
+
+      expect(readOnlineAmong).toHaveBeenCalledTimes(1);
+      expect(readOnlineAmong).toHaveBeenCalledWith(['user-2', 'user-3']);
     });
   });
 

--- a/backend/tests/unit/utils/inactivityJob.test.ts
+++ b/backend/tests/unit/utils/inactivityJob.test.ts
@@ -95,6 +95,36 @@ describe('inactivityJob', () => {
     consoleSpy.mockRestore();
   });
 
+  it('refreshes lastActivity instead of escalating when the user is online', async () => {
+    mockUserRepo.findAllWarningEnabled.mockResolvedValue([{ userId: 'u1' }] as any);
+
+    const intervalId = startInactivityJob(mockUserRepo, mockUserService, 2, async () => 'online');
+    activeIntervals.push(intervalId);
+
+    await new Promise((resolve) => setTimeout(resolve, 3));
+    await Promise.resolve();
+
+    expect(mockUserRepo.update).toHaveBeenCalledWith('u1', { lastActivity: expect.any(Date) });
+    expect(mockUserService.checkInactivity).not.toHaveBeenCalled();
+  });
+
+  it('skips the user entirely when presence is unknown rather than escalating', async () => {
+    // `unknown` is a Redis this instance could not reach, not a user who left.
+    // Escalating on it reaches `checkInactivity`, which past the warning
+    // threshold notifies the user's emergency contacts once and never retracts
+    // it — so a Redis blip must not be able to trigger that.
+    mockUserRepo.findAllWarningEnabled.mockResolvedValue([{ userId: 'u1' }] as any);
+
+    const intervalId = startInactivityJob(mockUserRepo, mockUserService, 2, async () => 'unknown');
+    activeIntervals.push(intervalId);
+
+    await new Promise((resolve) => setTimeout(resolve, 3));
+    await Promise.resolve();
+
+    expect(mockUserService.checkInactivity).not.toHaveBeenCalled();
+    expect(mockUserRepo.update).not.toHaveBeenCalled();
+  });
+
   it('logs and releases the lock when findAllWarningEnabled fails', async () => {
     const consoleSpy = spyOn(console, 'error').mockImplementation(() => {});
     mockUserRepo.findAllWarningEnabled

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -89,7 +89,17 @@ services:
       - ATTACHMENT_MAX_BYTES=${ATTACHMENT_MAX_BYTES:-10485760}
       - MAX_SESSIONS_PER_USER=${MAX_SESSIONS_PER_USER:-5}
       - PRESENCE_GRACE_MS=${PRESENCE_GRACE_MS:-3000}
+      # How long a presence lease survives in Redis unrefreshed. It bounds how
+      # long a crashed instance keeps its users showing as online, because
+      # nothing runs on a dead process to hand the leases back.
+      - PRESENCE_TTL_MS=${PRESENCE_TTL_MS:-30000}
       - TYPING_TTL_MS=${TYPING_TTL_MS:-3000}
+      # Pass-through only, like LOG_LEVEL: unset means the backend generates one
+      # per process. Worth setting where the orchestrator already has a stable
+      # per-replica name — a restarted process that reclaims its old name
+      # replaces its own presence lease instead of adding a second one that has
+      # to wait out the TTL.
+      - INSTANCE_ID
       - CI=true
     depends_on:
       db:

--- a/docker-compose.release.yml
+++ b/docker-compose.release.yml
@@ -60,7 +60,15 @@ services:
       ATTACHMENT_MAX_BYTES: ${ATTACHMENT_MAX_BYTES:-10485760}
       MAX_SESSIONS_PER_USER: ${MAX_SESSIONS_PER_USER:-5}
       PRESENCE_GRACE_MS: ${PRESENCE_GRACE_MS:-3000}
+      # How long a presence lease survives in Redis unrefreshed; it bounds how
+      # long a crashed instance keeps its users showing as online. Inert while
+      # REDIS_URL is blank, which is this bundle's default.
+      PRESENCE_TTL_MS: ${PRESENCE_TTL_MS:-30000}
       TYPING_TTL_MS: ${TYPING_TTL_MS:-3000}
+      # Blank means the backend generates one per process. Set it where the
+      # orchestrator already has a stable per-replica name, so a restarted
+      # process reclaims its own presence lease instead of adding a second one.
+      INSTANCE_ID: ${INSTANCE_ID:-}
     depends_on:
       migrate:
         condition: service_completed_successfully

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -127,7 +127,17 @@ services:
       - ATTACHMENT_MAX_BYTES=${ATTACHMENT_MAX_BYTES:-10485760}
       - MAX_SESSIONS_PER_USER=${MAX_SESSIONS_PER_USER:-5}
       - PRESENCE_GRACE_MS=${PRESENCE_GRACE_MS:-3000}
+      # How long a presence lease survives in Redis unrefreshed. It bounds how
+      # long a crashed instance keeps its users showing as online, because
+      # nothing runs on a dead process to hand the leases back.
+      - PRESENCE_TTL_MS=${PRESENCE_TTL_MS:-30000}
       - TYPING_TTL_MS=${TYPING_TTL_MS:-3000}
+      # Pass-through only, like LOG_LEVEL: unset means the backend generates one
+      # per process. Worth setting where the orchestrator already has a stable
+      # per-replica name — a restarted process that reclaims its old name
+      # replaces its own presence lease instead of adding a second one that has
+      # to wait out the TTL.
+      - INSTANCE_ID
       - CI=true
     working_dir: /workspace/backend
     volumes:

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -138,8 +138,30 @@ image, or a restart that loses committed state, fails the build.
 `MAX_SESSIONS_PER_USER`, `PRESENCE_GRACE_MS`, `TYPING_TTL_MS` and
 `SESSION_RESERVATION_TTL_MS` control local session, presence-reconnect,
 typing-indication and handshake-slot limits; like every other backend variable
-they are declared in `backend/src/config/env.ts`. Multi-node presence,
-global rate limits, and cross-node change fan-out remain outside this service.
+they are declared in `backend/src/config/env.ts`.
+
+`PRESENCE_TTL_MS` and `INSTANCE_ID` belong to the presence leases the backend
+keeps in Redis. With `REDIS_URL` set, each instance holds one lease per user it
+has a connection for — `presence:user:{userId}` is a hash with one field per
+instance, and each field expires on its own — so `GET /rooms` and `GET /friends`
+answer for the whole deployment rather than for one process, and a user is
+announced online only on the first connection anywhere and offline only when the
+last one goes. `PRESENCE_TTL_MS` bounds how long a crashed instance keeps its
+users showing as online: nothing runs on a dead process to hand the leases back,
+so only the expiry does it. Every lease is refreshed three times per TTL, and a
+graceful shutdown hands them all back rather than waiting the TTL out.
+`INSTANCE_ID` names this process in that hash; left unset one is generated per
+start, which is fine unless your orchestrator already has a stable per-replica
+name to reuse. Per-field TTLs need **Redis 7.4 or newer** — against an older
+server the write fails, the backend logs the requirement once, and presence
+falls back to this instance only.
+
+What is *not* shared yet is the `user_status` push: `io.to()` reaches only the
+sockets held by the emitting process, so a friend connected to a different
+instance sees the change on their next `GET /friends` rather than over the
+socket. Closing that is the Redis event bus in #475/#476. The per-user session
+limit, global rate limits and cross-node change fan-out also remain
+per-instance, so a replica count above one is not yet a supported deployment.
 
 ### Production Ingress & Proxy Trust
 

--- a/docs/ZH-TW/DEVELOPMENT.md
+++ b/docs/ZH-TW/DEVELOPMENT.md
@@ -126,8 +126,26 @@ production image（`docker-compose.release.yml`）各執行一次同一份腳本
 `MAX_SESSIONS_PER_USER`、`PRESENCE_GRACE_MS`、`TYPING_TTL_MS`、
 `SESSION_RESERVATION_TTL_MS` 分別控制單機 session、presence 重連寬限、
 typing indication TTL 與握手名額保留時間；與其他後端變數一樣，宣告位置都在
-`backend/src/config/env.ts`。多節點 presence、全域
-限流與跨節點 change fan-out 仍不在本服務範圍內。
+`backend/src/config/env.ts`。
+
+`PRESENCE_TTL_MS` 與 `INSTANCE_ID` 屬於後端存在 Redis 裡的 presence lease。設定
+`REDIS_URL` 後，每個 instance 會為自己有連線的每位使用者持有一份 lease ——
+`presence:user:{userId}` 是一個 hash，一個 instance 一個欄位，每個欄位各自過期
+—— 因此 `GET /rooms` 與 `GET /friends` 回答的是整個部署而不是單一行程的狀態，
+而 `online` 只在全域第一條連線建立時發送、`offline` 只在最後一條消失時發送。
+`PRESENCE_TTL_MS` 界定「某個 instance 當掉後，它的使用者最多被誤顯示成在線多
+久」：行程已死就沒有人能把 lease 還回去，只剩過期能清掉它。後端每個 TTL 內會
+續約三次，而正常關機會主動把 lease 全數交還，不需要等 TTL 到期。`INSTANCE_ID`
+是本行程在該 hash 中的名稱；留空時每次啟動自行產生一個，除非編排器本來就有穩
+定的 per-replica 名稱可以沿用，否則不需要設定。欄位層級的 TTL 需要
+**Redis 7.4 以上** —— 對更舊的伺服器寫入會失敗，後端會記錄一次版本需求，
+presence 則退回只看本機。
+
+目前**尚未**共享的是 `user_status` 推播：`io.to()` 只會送到發出端行程自己持有
+的 socket，因此連在另一個 instance 上的好友要等到下一次 `GET /friends` 才會看
+到狀態變化。補上這段是 #475／#476 的 Redis event bus。每位使用者的 session 上
+限、全域限流與跨節點 change fan-out 同樣仍是 per-instance，所以把 replica 數量
+調到大於 1 目前還不是受支援的部署方式。
 
 ### 正式環境入口拓撲與代理信任
 

--- a/docs/ZH-TW/api-documentation.md
+++ b/docs/ZH-TW/api-documentation.md
@@ -1581,7 +1581,7 @@ NEXT_PUBLIC_API_URL=http://localhost:4005
 | `read_update` | `{ roomId: string, userId: string, messageId: string, readPosition?: number }` | 其他成員的已讀游標更新 |
 | `room_update` | `{ type: string, roomId: string, data: unknown }` | 房間或成員狀態變更。`type` 欄位決定子類型，詳見 [`room_update` 子類型](#room_update-子類型)。 |
 | `friend_request` | `{ requesterId: string, addresseeId: string, status: 'pending' \| 'accepted' \| 'rejected' \| 'deleted' \| 'blocked' \| 'unblocked', createdAt: string }` | 好友生命週期通知。傳送給相關使用者；客戶端收到後不論 `status` 為何，皆應重新拉取好友與待確認請求列表。 |
-| `user_status` | `{ userId: string, status: 'online' \| 'offline' }` | 好友的上線 / 下線狀態更新。於好友連線或斷線時推送。 |
+| `user_status` | `{ userId: string, status: 'online' \| 'offline' }` | 好友的上線 / 下線狀態更新。於好友連線或斷線時推送。是否在線的判定會跨 backend instance 共享，但這則推播不會：它只會送到好友所連上那個 instance 自己持有的 socket，因此連在別的 instance 上的用戶端要等下一次 `GET /api/v1/friends` 才看得到變化。 |
 | `emergency_alert` | `{ userId: string, message: string }` | 收到緊急聯絡人的警報通知 |
 | `realtime_ready` | `void` | 有效聊天室訂閱已恢復；客戶端可以開始 `/sync`。每次連線送出一次，伺服器還原先前撤銷的訂閱時也會再送 |
 | `error` | `ApiError` | 事件處理失敗的錯誤回報 |

--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -1584,7 +1584,7 @@ endpoint sets the flag; see `docs/DEVELOPMENT.md` for the bootstrap procedure.
 | `read_update` | `{ roomId: string, userId: string, messageId: string, readPosition?: number }` | Read receipt updates of other members |
 | `room_update` | `{ type: string, roomId: string, data: unknown }` | Room or membership state change. `type` determines the subtype. See [`room_update` Subtypes](#room_update-subtypes). |
 | `friend_request` | `{ requesterId: string, addresseeId: string, status: 'pending' \| 'accepted' \| 'rejected' \| 'deleted' \| 'blocked' \| 'unblocked', createdAt: string }` | Friend lifecycle notification. Delivered to the relevant user; the client should refresh friend and pending-request lists upon receiving this event regardless of `status`. |
-| `user_status` | `{ userId: string, status: 'online' \| 'offline' }` | Presence update for a friend. Delivered when a friend connects or disconnects. |
+| `user_status` | `{ userId: string, status: 'online' \| 'offline' }` | Presence update for a friend. Delivered when a friend connects or disconnects. Whether someone is online is shared across backend instances, but this push is not: it reaches only sockets held by the instance the friend connected to, so a client on a different instance sees the change on its next `GET /api/v1/friends` instead. |
 | `emergency_alert` | `{ userId: string, message: string }` | Receive emergency alert from contact |
 | `realtime_ready` | `void` | Durable room subscriptions have been restored; the client may begin `/sync`. Sent once per connection, and again whenever the server restores a subscription it had revoked |
 | `error` | `ApiError` | Error report for failed event processing |


### PR DESCRIPTION
Closes #473。#283 的下一個 subissue。

## 為什麼

Presence 原本存在 `realtime/presence.ts` 的 module-level `Map` 裡，所以「在線」的定義是「連在這個行程上」。多開一個 instance 之後，這不只是資訊不完整，而是**往危險的方向錯**：某位使用者在 instance A 的最後一條 socket 斷掉時，A 會廣播 `offline`，但 instance B 手上可能還握著一條活的連線，而且之後沒有任何東西會把它修正回來。

## Redis key schema

每個 instance 為自己有連線的每位使用者持有一份 lease。key 是「一位 user 一個 hash、一個 instance 一個 field」，而 TTL 掛在**欄位**上：

```
presence:user:{userId} -> { "{instanceId}": "{connections}" }   每個 field 各自 PEXPIRE
```

- **用 per-field TTL 而不是 key TTL**：key 屬於 user，lease 屬於 instance。如果整個 hash 共用一個到期時間，最忙的那個 instance 續約時會順便把已經當掉的 instance 那一列一起養著，永遠不過期。掛在欄位上，死掉的行程只會停止續約自己那一列，Redis 會清掉它 —— 並在最後一列消失時連 key 一起刪掉，這正是「沒有 key」與「沒有人在線」能畫上等號的原因。
- **用 per-instance 而不是 per-socket**：別的 instance 完全不需要知道某人在這裡開了幾個分頁。socket 層級的帳本留在本機，反正 reconnect grace period 本來就需要它。
- **時鐘完全交給 Redis**：到期是由伺服器對著它收到的 TTL 判定，不是拿存下來的 timestamp 去跟讀取端的 `Date.now()` 比。因此兩個時鐘不一致的 instance 對「誰在線」仍然有一致的答案。

## Online / offline 邊界

改由 Redis 回報的數量決定，不再看本機的 map，而且每個轉換都是一個 Lua script。把讀跟寫綁成一步同時補掉三個洞：

- `HSET` 會清掉欄位的 TTL，所以行程若剛好死在 `HSET` 與 `HPEXPIRE` 之間，會留下一個**永遠不過期**的 lease —— 正是 TTL 存在的意義所要防的那件事。
- 分開讀數量會讓兩個邊界都變成 race：兩個 instance 同時搶到同一位使用者的第一份 lease 時，各自讀到的數量都已經含了對方，於是**誰都不會**發 `online`。
- 反方向同理：兩個 instance 同時釋放時，各自都看得到對方那一列還在，於是最後一次 `offline` 就這樣掉了。

Reconnect grace period 期間 lease **不會**被釋放，等寬限計時器到期才交還。所以重連即使落在另一個 instance 上，也不會出現任何 online/offline 抖動 —— 這在本機計時器的做法下是看不到的情境。

## Round trip 成本

- `GET /rooms` 與 `GET /friends` 各自用**一次** call 解析整頁（`areOnline` 走單一 EVAL），不是一個 room／friend 一次。
- `user_status` 的 fan-out 改用**本機** presence 當條件。這不花任何 round trip，而且過濾效果完全相同 —— 反正 `io.to()` 只會送到本行程持有的 socket。

## `unknown`：Redis 連不上不等於使用者離線

`presenceOf()` 在讀不到 Redis 時回 `unknown` 而不是 `offline`。`utils/inactivityJob.ts` 需要這個區分：它會把 offline 的使用者送進 `checkInactivity`，超過警告門檻就會通知該使用者的緊急聯絡人 —— 一次性送出、之後不會收回。少跑一次每小時的 tick 沒有代價；因為 Redis 閃一下就發出去的警報有。

顯示端（room list、friend list）維持把 `unknown` 收斂成 offline，畫面總得顯示點什麼。

## 關機

關機時會把 lease 交還，而不是等 TTL 到期，所以一次 redeploy 不會讓整批連線中的使用者留在「在線」狀態直到過期。有 bounded timeout，連不上的 Redis 不會把部署卡住。

## 這次**沒有**做的事

`user_status` 推播本身仍然只會送到發出端 instance 的 socket，因此連在別的 instance 上的好友要等下一次 `GET /friends` 才看得到變化。補上這段是 #475／#476 的 Redis event bus。每位使用者的 session 上限、全域限流與跨節點 change fan-out 也同樣還是 per-instance —— 換句話說，把 replica 數量調到大於 1 目前**還不是**受支援的部署方式。這點已寫進 `docs/DEVELOPMENT.md`（含繁中版）與 `docs/api-documentation.md` 的 `user_status` 條目。

## 注入取代 mock.module

presence、room service、friend service 與 inactivity job 都改成把 presence reader 當作尾端的可選參數注入，順手移除兩處 `tests/CLAUDE.md` 明文禁止的 `mock.module()` 呼叫（#467 記錄過它為什麼危險）。

## Redis 版本需求

欄位層級 TTL 需要 **Redis 7.4 以上**（本專案 compose pin 的是 `redis:8-alpine`，實測 8.10.1）。對更舊的伺服器寫入會失敗，後端只會記錄**一次**版本需求，presence 則退回只看本機 —— 不會 crash，也不會洗版 log。

## 驗證

- 新增 `backend/tests/integration/realtime/presenceStore.int.test.ts`，對**真的 Redis** 釘住這個設計倚賴的語意：`HLEN` 不計已過期的欄位、最後一個欄位消失時 key 一起不見、某個 instance 的 lease 過期不會動到另一個的、續約能讓活著的 lease 撐過 TTL。用 `Map` 做的假物件可以對這四件事全部「同意」而且全部是錯的，所以它們不放在 unit tier。
- `ci-database.yml` 加上 `redis:8-alpine` service 與 `REDIS_URL_TEST`。本機只要 `docker compose up -d redis` 就能跑（預設值就是 dev compose 的 `localhost:6385`）。
- Unit 691 pass / 0 fail、Integration 54 pass / 0 fail、E2E 94 pass / 0 fail；`tsc --noEmit` 與 `eslint src` 皆通過。
- 實際把 dev stack 跑起來對過一遍：socket 連上後 `presence:user:{bobId}` 出現一個以 instance UUID 為名的欄位，欄位 TTL 在 12 秒後從 23s 變成 21s（證明每 10 秒的續約真的有跑），key 本身沒有 TTL；SIGTERM 之後 lease 立刻消失而不是等 30 秒過期。多分頁、關掉其中一個分頁、兩個都關掉之後越過 grace period 的 online/offline 轉換也都符合預期。

## 相關

- Parent: #283
- Unblocks: #477（跨節點 presence 驗證）
- 後續：#475／#476（event bus 與廣播整合）

🤖 Generated with [Claude Code](https://claude.com/claude-code)