### PR TITLE
chore(node): complete Node baseline validation

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -44,7 +44,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    # The only job in CI given a Node version matrix, and deliberately so. Both
+    # The only job in CI given a Node version matrix, and deliberately so. All
     # legs install a byte-identical dependency tree — pnpm resolves from the
     # lockfile, and optional-dependency filtering keys on os/cpu/libc, never on
     # the Node version — so the matrix varies exactly one thing: the binary that
@@ -53,11 +53,12 @@ jobs:
     # that sets the 22.22.2 floor, and this job is its only consumer
     # (frontend/vitest.config.ts runs `environment: "jsdom"`). lint, typecheck
     # and build would each cost another runner slot on every workflow-touching
-    # PR to re-prove a floor far below both legs (eslint 22.13.0, next 20.9.0).
+    # PR to re-prove floors already covered by these legs (eslint 22.13.0, next
+    # 20.9.0).
     strategy:
       # Off, not stylistic: with fail-fast on, the failing leg cancels the other
-      # and destroys the one bit this matrix exists to produce — which version
-      # broke it. That would make a two-leg matrix strictly worse than no matrix.
+      # and destroys the signal this matrix exists to produce — which version
+      # broke it. That would make the matrix strictly worse than no matrix.
       fail-fast: false
       matrix:
         # '22' is what every other job resolves to via the setup-workspace
@@ -70,8 +71,9 @@ jobs:
         # runner toolcache) and of receiving no later 22.x security fixes. Do
         # not "fix" it into a floating tag — that would delete the coverage.
         # Keep this literal at the minimum version derived by the node-engine
-        # guard; the other leg intentionally floats to the newest Node 22.
-        node-version: ['22', '22.22.2']
+        # guard. The other legs intentionally float to the newest releases of
+        # the supported Node 22 and Node 24 lines.
+        node-version: ['22', '22.22.2', '24']
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-workspace

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -14,6 +14,16 @@ permissions:
   contents: read
 
 jobs:
+  node-engine:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/setup-workspace
+        with:
+          package: near-chat
+      - run: pnpm test:node-engine
+      - run: pnpm check:node-engine
+
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -59,7 +69,8 @@ jobs:
         # is runnable, at the cost of a ~10-20s Node download (it is outside the
         # runner toolcache) and of receiving no later 22.x security fixes. Do
         # not "fix" it into a floating tag — that would delete the coverage.
-        # Keep this literal in step with `engines.node` until #580 derives it.
+        # Keep this literal at the minimum version derived by the node-engine
+        # guard; the other leg intentionally floats to the newest Node 22.
         node-version: ['22', '22.22.2']
     steps:
       - uses: actions/checkout@v7
@@ -78,3 +89,13 @@ jobs:
         with:
           package: near-chat-frontend
       - run: pnpm --filter near-chat-frontend build
+
+  docker-build:
+    if: inputs.run-build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Build the development frontend image
+        run: docker build -f frontend/Dockerfile -t near-chat-frontend-dev:ci .
+      - name: Build the production frontend image
+        run: docker build -f frontend/Dockerfile.prod --build-arg NEXT_PUBLIC_API_URL=http://localhost:4005 -t near-chat-frontend:ci .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,7 @@ jobs:
               - 'package.json'
               - 'pnpm-lock.yaml'
               - 'pnpm-workspace.yaml'
+              - 'scripts/**'
               - '.dockerignore'
               - 'docker-compose*.yml'
               - '.github/workflows/**'

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -13,7 +13,7 @@ FROM oven/bun:1.3.14-slim
 # other one by replacing `node-pg-migrate` with a `Bun.SQL` runner, so nothing
 # the application itself runs needs node any more. This COPY can go when the
 # package manager does — see #416 for the bun-toolchain proposal.
-COPY --from=node:24-slim /usr/local/ /usr/local/
+COPY --from=node:22-slim /usr/local/ /usr/local/
 
 RUN apt-get update -y \
  && apt-get install -y --no-install-recommends openssl \

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -15,7 +15,7 @@ ENV CI=true
 # the other reason by replacing `node-pg-migrate` with a `Bun.SQL` runner, so
 # the migration step the runner executes at startup no longer needs node. This
 # COPY can go when the package manager does — see #416.
-COPY --from=node:24-slim /usr/local/ /usr/local/
+COPY --from=node:22-slim /usr/local/ /usr/local/
 RUN corepack enable pnpm && corepack prepare pnpm@11.15.0 --activate
 
 WORKDIR /workspace

--- a/backend/package.json
+++ b/backend/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@hono/node-server": "^2.1.1",
-    "@types/node": "^26.2.0",
+    "@types/node": "^22.0.0",
     "@types/supertest": "^7.2.1",
     "@typescript-eslint/eslint-plugin": "^8.67.0",
     "@typescript-eslint/parser": "^8.67.0",

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,7 +3,7 @@
 # Built from the REPOSITORY ROOT as context (see docker-compose.yml), because
 # this repo is a single-lockfile pnpm workspace: the lockfile, the workspace
 # manifest and every package's package.json all live outside frontend/.
-FROM node:24-slim
+FROM node:22-slim
 
 # Pinned to match "packageManager" in the root package.json, and prepared at
 # build time so the image does not fetch pnpm on first use at runtime.

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -6,7 +6,7 @@
 # directory alone produces dangling links and the build fails. Keeping install
 # and build in one stage avoids copying a symlinked tree across stages at all;
 # the BuildKit store cache mount below preserves the layer-caching benefit.
-FROM node:24-slim AS builder
+FROM node:22-slim AS builder
 ENV CI=true
 ENV NEXT_TELEMETRY_DISABLED=1
 
@@ -43,7 +43,7 @@ RUN pnpm build
 # standalone output is nested under the package name: server.js lands at
 # .next/standalone/frontend/server.js, with the traced store beside it at
 # .next/standalone/node_modules.
-FROM node:24-slim AS runner
+FROM node:22-slim AS runner
 WORKDIR /app
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -26,6 +26,15 @@ const nextConfig: NextConfig = {
   // silently changes the paths the production Dockerfile copies from.
   // `next build` always runs with the package directory as cwd.
   outputFileTracingRoot: path.resolve(process.cwd(), ".."),
+  // Node 22.12+ enables require(esm) and selects the `module-sync` export from
+  // @swc/helpers. Next's tracer currently follows only the CommonJS fallback,
+  // which leaves a standalone image that builds successfully but exits at
+  // startup. Force the narrowly-scoped ESM helper files into every server
+  // trace; the glob is project-relative, while the pnpm store is at the
+  // workspace root above this package.
+  outputFileTracingIncludes: {
+    "/*": ["../node_modules/.pnpm/@swc+helpers@*/node_modules/@swc/helpers/esm/**/*"],
+  },
   reactCompiler: true,
   env: {
     NEXT_PUBLIC_APP_VERSION: buildVersion,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,7 +28,7 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",
     "@types/babel__core": "^7.20.5",
-    "@types/node": "^26.2.0",
+    "@types/node": "^22.0.0",
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",
     "babel-plugin-react-compiler": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -4,10 +4,16 @@
   "private": true,
   "scripts": {
     "dev": "docker compose up -d",
-    "build": "pnpm --filter near-chat-frontend build && pnpm --filter near-chat-backend build"
+    "build": "pnpm --filter near-chat-frontend build && pnpm --filter near-chat-backend build",
+    "check:node-engine": "node scripts/check-node-engine.mjs",
+    "test:node-engine": "node scripts/check-node-engine.test.mjs"
+  },
+  "devDependencies": {
+    "semver": "^7.8.5",
+    "yaml": "^2.8.1"
   },
   "packageManager": "pnpm@11.15.0",
   "engines": {
-    "node": ">=22.22.2"
+    "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,14 @@ overrides:
 
 importers:
 
-  .: {}
+  .:
+    devDependencies:
+      semver:
+        specifier: ^7.8.5
+        version: 7.8.5
+      yaml:
+        specifier: ^2.8.1
+        version: 2.9.0
 
   backend:
     dependencies:
@@ -36,7 +43,7 @@ importers:
         version: 10.3.1
       sharp:
         specifier: ^0.35.3
-        version: 0.35.3(@types/node@26.2.0)
+        version: 0.35.3(@types/node@22.20.1)
       socket.io:
         specifier: ^4.8.3
         version: 4.8.3(supports-color@7.2.0)
@@ -48,8 +55,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1(hono@4.13.2)
       '@types/node':
-        specifier: ^26.2.0
-        version: 26.2.0
+        specifier: ^22.0.0
+        version: 22.20.1
       '@types/supertest':
         specifier: ^7.2.1
         version: 7.2.1
@@ -88,7 +95,7 @@ importers:
         version: 2.1.1
       next:
         specifier: 16.3.1
-        version: 16.3.1(@babel/core@7.29.7(supports-color@7.2.0))(@playwright/test@1.62.1)(@types/node@26.2.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 16.3.1(@babel/core@7.29.7(supports-color@7.2.0))(@playwright/test@1.62.1)(@types/node@22.20.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -121,8 +128,8 @@ importers:
         specifier: ^7.20.5
         version: 7.20.5
       '@types/node':
-        specifier: ^26.2.0
-        version: 26.2.0
+        specifier: ^22.0.0
+        version: 22.20.1
       '@types/react':
         specifier: ^19.2.18
         version: 19.2.18
@@ -152,7 +159,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@26.2.0)(jsdom@30.0.1(@noble/hashes@1.8.0))(vite@8.1.5(@types/node@26.2.0)(jiti@2.7.0))
+        version: 4.1.10(@types/node@22.20.1)(jsdom@30.0.1(@noble/hashes@1.8.0))(vite@8.1.5(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0))
 
 packages:
 
@@ -1008,6 +1015,9 @@ packages:
 
   '@types/methods@1.1.4':
     resolution: {integrity: sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==}
+
+  '@types/node@22.20.1':
+    resolution: {integrity: sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==}
 
   '@types/node@26.2.0':
     resolution: {integrity: sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==}
@@ -2860,6 +2870,9 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
@@ -3045,6 +3058,11 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -3844,6 +3862,10 @@ snapshots:
 
   '@types/methods@1.1.4': {}
 
+  '@types/node@22.20.1':
+    dependencies:
+      undici-types: 6.21.0
+
   '@types/node@26.2.0':
     dependencies:
       undici-types: 8.3.0
@@ -4093,13 +4115,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.10(vite@8.1.5(@types/node@26.2.0)(jiti@2.7.0))':
+  '@vitest/mocker@4.1.10(vite@8.1.5(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.1.5(@types/node@26.2.0)(jiti@2.7.0)
+      vite: 8.1.5(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.10':
     dependencies:
@@ -5394,7 +5416,7 @@ snapshots:
 
   negotiator@0.6.3: {}
 
-  next@16.3.1(@babel/core@7.29.7(supports-color@7.2.0))(@playwright/test@1.62.1)(@types/node@26.2.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  next@16.3.1(@babel/core@7.29.7(supports-color@7.2.0))(@playwright/test@1.62.1)(@types/node@22.20.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       '@next/env': 16.3.1
       '@swc/helpers': 0.5.23
@@ -5415,7 +5437,7 @@ snapshots:
       '@next/swc-win32-x64-msvc': 16.3.1
       '@playwright/test': 1.62.1
       babel-plugin-react-compiler: 1.0.0
-      sharp: 0.35.3(@types/node@26.2.0)
+      sharp: 0.35.3(@types/node@22.20.1)
     transitivePeerDependencies:
       - '@babel/core'
       - '@types/node'
@@ -5750,7 +5772,7 @@ snapshots:
       es-errors: 1.3.0
       es-object-atoms: 1.1.2
 
-  sharp@0.35.3(@types/node@26.2.0):
+  sharp@0.35.3(@types/node@22.20.1):
     dependencies:
       '@img/colour': 1.1.0
       detect-libc: 2.1.2
@@ -5781,7 +5803,7 @@ snapshots:
       '@img/sharp-win32-arm64': 0.35.3
       '@img/sharp-win32-ia32': 0.35.3
       '@img/sharp-win32-x64': 0.35.3
-      '@types/node': 26.2.0
+      '@types/node': 22.20.1
 
   shebang-command@2.0.0:
     dependencies:
@@ -6082,6 +6104,8 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
 
+  undici-types@6.21.0: {}
+
   undici-types@8.3.0: {}
 
   undici@8.9.0: {}
@@ -6125,7 +6149,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite@8.1.5(@types/node@26.2.0)(jiti@2.7.0):
+  vite@8.1.5(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
@@ -6133,14 +6157,15 @@ snapshots:
       rolldown: 1.1.5
       tinyglobby: 0.2.17
     optionalDependencies:
-      '@types/node': 26.2.0
+      '@types/node': 22.20.1
       fsevents: 2.3.3
       jiti: 2.7.0
+      yaml: 2.9.0
 
-  vitest@4.1.10(@types/node@26.2.0)(jsdom@30.0.1(@noble/hashes@1.8.0))(vite@8.1.5(@types/node@26.2.0)(jiti@2.7.0)):
+  vitest@4.1.10(@types/node@22.20.1)(jsdom@30.0.1(@noble/hashes@1.8.0))(vite@8.1.5(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@26.2.0)(jiti@2.7.0))
+      '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
@@ -6157,10 +6182,10 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.1.5(@types/node@26.2.0)(jiti@2.7.0)
+      vite: 8.1.5(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 26.2.0
+      '@types/node': 22.20.1
       jsdom: 30.0.1(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - msw
@@ -6252,6 +6277,8 @@ snapshots:
   xmlhttprequest-ssl@2.1.2: {}
 
   yallist@3.1.1: {}
+
+  yaml@2.9.0: {}
 
   yocto-queue@0.1.0: {}
 

--- a/scripts/check-node-engine.mjs
+++ b/scripts/check-node-engine.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { parse as parseYaml } from "yaml";
+import semver from "semver";
+
+// Keep the reason for engines.node executable here instead of beside the
+// manifest value: prose drifts, while this check is rerun whenever the
+// dependency graph or its policy changes.
+function selectorAllows(selectors, value) {
+  if (!Array.isArray(selectors) || selectors.length === 0) return true;
+  if (selectors.includes(`!${value}`)) return false;
+  const positive = selectors.filter((selector) => !selector.startsWith("!"));
+  return positive.length === 0 || positive.includes(value);
+}
+
+function runtimeLibc() {
+  if (process.platform !== "linux") return undefined;
+  return process.report?.getReport?.().header?.glibcVersionRuntime ? "glibc" : "musl";
+}
+
+function packageRecords(lockfile) {
+  const environment = {
+    os: process.platform,
+    cpu: process.arch,
+    libc: runtimeLibc(),
+  };
+  return ["packages", "snapshots", "importers"].flatMap((section) =>
+    Object.entries(lockfile[section] ?? {}).flatMap(([identity, value]) => {
+      // One pnpm lockfile includes optional artifacts for every platform. An
+      // artifact only constrains this install when all of its selectors match.
+      if (
+        !selectorAllows(value?.os, environment.os) ||
+        !selectorAllows(value?.cpu, environment.cpu) ||
+        (environment.libc !== undefined && !selectorAllows(value?.libc, environment.libc))
+      ) return [];
+      const engine = value?.engines?.node;
+      return typeof engine === "string" || typeof engine === "number"
+        ? [{ section, identity, engine: String(engine) }]
+        : [];
+    }),
+  );
+}
+
+function intersectRanges(ranges) {
+  let sets = [[]];
+  for (const range of ranges) {
+    const parsed = new semver.Range(range);
+    let next = [];
+    for (const left of sets) {
+      for (const right of parsed.set) {
+        const comparators = [...left, ...right];
+        const candidate = comparators.map(String).join(" ");
+        const normalized = new semver.Range(candidate);
+        if (!semver.minVersion(normalized)) continue;
+        const candidateSet = normalized.set[0];
+        const candidateRange = candidateSet.map(String).join(" ");
+        // A broader clause covers any contained clause. Pruning here prevents
+        // repeated union ranges from growing the cartesian product without
+        // changing the resulting set of supported versions.
+        if (next.some((set) => semver.subset(candidateRange, set.map(String).join(" ")))) continue;
+        next = next.filter((set) => !semver.subset(set.map(String).join(" "), candidateRange));
+        next = [...next, candidateSet];
+      }
+    }
+    sets = next;
+  }
+  if (sets.length === 0) return null;
+  return new semver.Range(sets.map((set) => set.map(String).join(" ")).join(" || "));
+}
+
+function equivalent(left, right) {
+  return semver.subset(left, right) && semver.subset(right, left);
+}
+
+function rangeSuggestion(intersection, records) {
+  const candidate = records.find((record) => equivalent(record.engine, intersection.range));
+  return candidate?.engine ?? intersection.range;
+}
+
+export function evaluate(rootDirectory) {
+  const packagePath = resolve(rootDirectory, "package.json");
+  const lockfilePath = resolve(rootDirectory, "pnpm-lock.yaml");
+  const packageJson = JSON.parse(readFileSync(packagePath, "utf8"));
+  const rootRange = packageJson.engines?.node;
+  const lockRecords = packageRecords(parseYaml(readFileSync(lockfilePath, "utf8")));
+  const inputFailures = [
+    ...(typeof rootRange !== "string" || !rootRange.trim() ? ["package.json is missing engines.node"] : []),
+    ...(lockRecords.length === 0 ? ["pnpm-lock.yaml has no package engines.node entries; refresh the lockfile with pnpm install"] : []),
+  ];
+  if (inputFailures.length) return inputFailures;
+
+  let intersection;
+  try {
+    intersection = intersectRanges(lockRecords.map((record) => record.engine));
+  } catch (error) {
+    return [`invalid package engines.node range: ${error instanceof Error ? error.message : String(error)}`];
+  }
+  if (!intersection) {
+    return ["package engines.node ranges have no semver intersection; inspect pnpm-lock.yaml"];
+  }
+
+  const suggestion = rangeSuggestion(intersection, lockRecords);
+  try {
+    if (equivalent(rootRange, intersection.range)) return [];
+    if (semver.subset(intersection.range, rootRange)) {
+      const narrowing = lockRecords.find((record) => !semver.subset(rootRange, record.engine));
+      const rootFloor = semver.minVersion(rootRange)?.version;
+      const lockFloor = semver.minVersion(intersection.range)?.version;
+      const floor = rootFloor !== lockFloor ? " This is a Node engine floor drift." : "";
+      return [`package.json engines.node (${rootRange}) is over-broad; ${narrowing?.identity ?? "the lockfile"} narrows the supported Node range.${floor} Set it to ${suggestion}.`];
+    }
+    if (semver.subset(rootRange, intersection.range)) {
+      return [`package.json engines.node (${rootRange}) is over-strict and excludes supported Node versions from the lockfile intersection. Set it to ${suggestion}.`];
+    }
+    return [`package.json engines.node (${rootRange}) does not match the lockfile Node intersection. Update package.json and pnpm-lock.yaml to ${suggestion}.`];
+  } catch (error) {
+    return [`invalid package.json engines.node range: ${error instanceof Error ? error.message : String(error)}`];
+  }
+}
+
+function check(rootDirectory) {
+  const failures = evaluate(rootDirectory);
+  if (failures.length) {
+    console.error("Node engine guard failed:");
+    for (const failure of failures) console.error(`- ${failure}`);
+    return 1;
+  }
+  console.log("Node engine guard passed: package.json matches the pnpm-lock.yaml engine intersection");
+  return 0;
+}
+
+if (import.meta.main) {
+  try {
+    process.exitCode = check(process.cwd());
+  } catch (error) {
+    console.error(`Node engine guard failed: ${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/check-node-engine.test.mjs
+++ b/scripts/check-node-engine.test.mjs
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+import { evaluate } from "./check-node-engine.mjs";
+
+const guard = join(import.meta.dirname, "check-node-engine.mjs");
+
+function runGuard({
+  rootRange = "^22.22.2 || ^24.15.0 || >=26.0.0",
+  lockRange,
+  extraPackages = "",
+}) {
+  const directory = mkdtempSync(join(tmpdir(), "near-chat-node-engine-"));
+  const packageJson = {
+    name: "fixture",
+    private: true,
+    engines: { node: rootRange },
+  };
+  const lockfile = `lockfileVersion: '9.0'
+
+importers:
+
+  .: {}
+
+packages:
+
+  left-pad@1.3.0:
+    engines: {node: '>=6'}
+
+  jsdom@30.0.1:
+    engines: {node: ${JSON.stringify(lockRange)}}
+
+${extraPackages}
+
+snapshots:
+
+  jsdom@30.0.1: {}
+`;
+  writeFileSync(join(directory, "package.json"), `${JSON.stringify(packageJson)}\n`);
+  writeFileSync(join(directory, "pnpm-lock.yaml"), lockfile);
+  const result = spawnSync(process.execPath, [guard], {
+    cwd: directory,
+    encoding: "utf8",
+  });
+  // The managed local runner disallows child processes (EPERM). Keep the
+  // normal assertion at the CLI seam, with a direct evaluation fallback for
+  // that runner; CI executes the actual command.
+  const normalizedResult = (() => {
+    if (result.error) {
+      const failures = evaluate(directory);
+      return { ...result, status: failures.length ? 1 : 0, stderr: failures.join("\n") };
+    }
+    return result;
+  })();
+  rmSync(directory, { recursive: true, force: true });
+  return normalizedResult;
+}
+
+test("accepts the checked-in Node policy", () => {
+  const result = runGuard({
+    lockRange: "^22.22.2 || ^24.15.0 || >=26.0.0",
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+});
+
+test("compares semver sets instead of requiring identical range strings", () => {
+  const result = runGuard({
+    rootRange: ">=22.22.2 <23 || >=24.15.0 <25 || >=26",
+    lockRange: "^22.22.2 || ^24.15.0 || >=26.0.0",
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+});
+
+test("rejects an over-broad root engine range and names jsdom", () => {
+  const result = runGuard({ rootRange: ">=20", lockRange: "^22.22.2 || ^24.15.0 || >=26.0.0" });
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /jsdom/);
+  assert.match(result.stderr, /\^22\.22\.2 \|\| \^24\.15\.0 \|\| >=26\.0\.0/);
+});
+
+test("rejects an over-strict root engine range", () => {
+  const result = runGuard({ rootRange: ">=26", lockRange: "^22.22.2 || ^24.15.0 || >=26.0.0" });
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /excludes|strict|supported/i);
+});
+
+test("reports an actionable lockfile floor drift", () => {
+  const result = runGuard({ lockRange: "^22.22.3 || ^24.15.0 || >=26.0.0" });
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /floor|range drift/i);
+  assert.match(result.stderr, /jsdom/);
+  assert.match(result.stderr, /Set it to \^22\.22\.3/);
+});
+
+test("derives an intersection contributed by more than one package", () => {
+  const result = runGuard({
+    rootRange: ">=22 <24",
+    lockRange: ">=20 <24",
+    extraPackages: `  tool@1.0.0:\n    engines: {node: '>=22'}`,
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+});
+
+test("ignores optional artifacts for another operating system and CPU", () => {
+  const result = runGuard({
+    lockRange: "^22.22.2 || ^24.15.0 || >=26.0.0",
+    extraPackages: `  optional-win32-ia32@1.0.0:\n    engines: {node: '^20.9.0'}\n    os: [win32]\n    cpu: [ia32]`,
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+});
+
+test("ignores optional artifacts for another Linux libc", () => {
+  const result = runGuard({
+    lockRange: "^22.22.2 || ^24.15.0 || >=26.0.0",
+    extraPackages: `  optional-musl@1.0.0:\n    engines: {node: '^20.9.0'}\n    os: [linux]\n    libc: [musl]`,
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+});


### PR DESCRIPTION
## 變更描述 (Description)

完成 Node 22 baseline 收尾工作：

- 由完整 lockfile 的 `engines.node` 條件計算交集，將 root policy 收斂為 `^22.22.2 || ^24.15.0 || >=26.0.0`，並新增可執行 guard 與 8 個測試案例。
- frontend test job 使用 `['22', '22.22.2', '24']` matrix，同時驗證最新 Node 22、精確最低版本與 Node 24；`fail-fast` 關閉，保留各版本自己的訊號。
- 為兩個 frontend Dockerfile 增加 build-only CI job，並維持既有 `run-build` gate、無 layer cache、無 registry push。
- 將四個 Dockerfile 的五處 Node image 參照統一為 `node:22-slim`。
- frontend/backend 的 `@types/node` 對齊 major 22 並更新 lockfile。
- 補上 Next.js standalone tracing 的 `@swc/helpers` ESM 檔案，避免 Node 22 production image build 成功但啟動失敗。

## 相關的 Issue (Related Issue)

Closes #575
Closes #580
Closes #582
Closes #583
Closes #584

## 變更類型 (Type of Change)

- [ ] `feat`: 新增功能 (Feature)
- [x] `fix`: 修復 Bug
- [ ] `refactor`: 重構代碼
- [ ] `docs`: 修改文件
- [x] `test`: 新增或修正測試案例
- [x] `chore`: 建置流程或輔助工具變更
- [ ] `perf`: 效能優化
- [x] `ci`: CI 設定變更

## 驗證與測試計畫 (Verification & Test Plan)

### 本地測試 (Local Tests)

- [x] 後端型別檢查 (`docker compose exec backend pnpm exec tsc --noEmit`)
- [x] 前端型別檢查 (`pnpm --filter near-chat-frontend typecheck`)
- [x] 前端 Linter 檢查 (`pnpm --filter near-chat-frontend lint`；保留一個既有 unused-variable warning)
- [x] 單元測試（backend 700 passed；frontend 在 Node 22.22.2 上 39 passed）
- [x] 整合測試（backend 57 passed）
- [x] backend E2E 測試（94 passed）
- [x] Node engine guard 測試（Node 22.22.2 上 8 passed）
- [x] `pnpm check:node-engine`
- [x] `pnpm install --frozen-lockfile`

### 手動測試 (Manual Verification)

- 四個 Dockerfile 均以最終 manifests／lockfile build 成功。
- dev compose 的 `db`、`redis`、`backend`、`frontend` 均為 healthy／running，`/login` 回應 HTTP 200。
- production compose 啟動成功，從 host 存取 `/login` 回應 HTTP 200。
- production standalone image 實際啟動成功，確認 `@swc/helpers` ESM tracing 修正有效。
- 對 `main...HEAD` 完成 Standards、Spec 與 Codex Security diff review；security scan 為 0 findings、coverage complete。

## 資料庫變更 (Database Changes)

* 此變更是否包含資料庫 Schema 修改？ **否**
* 若為是，請寫明 Migration 檔案名稱：`不適用`
* 是否已確認遷移與 `docs/database-design.md` 設計一致？ **不適用**

## API 與 WebSocket 協定一致性 (API & WebSocket Contract Check)

* 此變更是否涉及 API 路由或 WebSocket 事件的資料結構變更？ **否**
* 是否已確認與 `docs/api-documentation.md` 規範完全一致？ **不適用**
