### PR TITLE
fix(backend): deliver SIGTERM to the production backend process (#586)

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -118,6 +118,107 @@ jobs:
           echo "migrate exit code: $exit_code"
           [[ "$exit_code" == "0" ]]
 
+      # docker-compose.release.yml overrides the backend command, so until issue
+      # #586 nothing here — or anywhere — ran the image's *own* CMD. That is the
+      # command docker-compose.prod.yml inherits, and it left dash at PID 1,
+      # where the kernel discards SIGTERM: `docker stop` was a no-op that ended
+      # in SIGKILL with the drain never entered. Both argv forms are probed,
+      # because the reasoning that says the release form is safe is the same
+      # reasoning about a shell layer that produced the bug.
+      #
+      # Runs after the migrate assertion above, so the schema is already at head
+      # and each probe's own `migrate:up` is the no-op that step 'Assert
+      # re-applying the bundle is a no-op' proves it to be.
+      - name: Assert SIGTERM drains the backend instead of SIGKILLing it
+        run: |
+          set -euo pipefail
+          # Derived rather than hardcoded to the compose project name, so a
+          # project rename does not silently detach the probe from the database.
+          net="$(docker inspect -f '{{range $k, $v := .NetworkSettings.Networks}}{{$k}}{{end}}' \
+            "$(docker compose --env-file "$RUNNER_TEMP/release.env" \
+              -f docker-compose.release.yml ps -q db)")"
+
+          probe () {
+            local name="$1"; shift
+            echo "::group::SIGTERM probe: ${name} [$*]"
+            # Publishes no port: 4005 belongs to the compose backend. Not --rm,
+            # because the exit code has to survive the container.
+            docker run -d --name "$name" --network "$net" \
+              -e DATABASE_URL=postgresql://near:near@db:5432/near_chat \
+              -e JWT_SECRET=ci-only-value-not-a-real-secret \
+              -e CORS_ORIGINS=http://localhost:3005 \
+              near-chat-backend:ci "$@" >/dev/null
+
+            # Signalling early would prove nothing: SIGTERM is legitimately
+            # ignored while migrations run and while the module body evaluates,
+            # before src/index.ts installs the handler.
+            local ready=0
+            for _ in $(seq 60); do
+              if docker logs "$name" 2>&1 | grep -q 'successfully listening'; then ready=1; break; fi
+              sleep 1
+            done
+            if [[ "$ready" != 1 ]]; then
+              echo "::endgroup::"
+              echo "::error::${name} never started listening, so its SIGTERM behaviour could not be tested"
+              docker logs "$name" 2>&1 | tail -50
+              return 1
+            fi
+
+            # -t 30 matches stop_grace_period. Docker's 10s default is roughly
+            # the drain's own worst case, which would make a slow drain and a
+            # container that ignores the signal entirely indistinguishable.
+            local start=$SECONDS
+            docker stop -t 30 "$name" >/dev/null
+            local elapsed=$(( SECONDS - start ))
+            local code logs
+            code="$(docker inspect -f '{{.State.ExitCode}}' "$name")"
+            logs="$(docker logs "$name" 2>&1)"
+            echo "exit code ${code} after ${elapsed}s"
+            echo "::endgroup::"
+
+            # 'Realtime server shutting down' is logged by publisher.shutdown(),
+            # the first step of the drain, so it separates "the signal never
+            # arrived" from "the drain ran but did not finish in time".
+            local drained=0
+            grep -q 'Realtime server shutting down' <<<"$logs" && drained=1
+
+            if [[ "$code" != 0 ]]; then
+              if [[ "$drained" == 1 ]]; then
+                echo "::error::${name} entered its drain but exited ${code}: the drain outlived stop_grace_period"
+              elif [[ "$code" == 137 ]]; then
+                echo "::error::${name} exited 137: SIGTERM never reached the application and it was SIGKILLed. A shell left at PID 1 ignores the signal — check for 'exec' in backend/Dockerfile.prod's CMD (issue #586)."
+              else
+                echo "::error::${name} exited ${code}: a shell or init took SIGTERM and the application never saw it"
+              fi
+              tail -50 <<<"$logs"
+              return 1
+            fi
+
+            # Exit 0 on its own only says the process stopped; the marker is what
+            # proves the handler is what stopped it.
+            if [[ "$drained" != 1 ]]; then
+              echo "::error::${name} exited 0 without logging its shutdown, so the drain did not run"
+              tail -50 <<<"$logs"
+              return 1
+            fi
+
+            # With no clients connected the drain is sub-second. This only catches
+            # one that quietly waits out a timeout instead of exiting.
+            if (( elapsed > 20 )); then
+              echo "::error::${name} took ${elapsed}s to stop; the drain is not exiting on its own"
+              return 1
+            fi
+          }
+
+          # No command override: the image's own CMD, the one prod inherits.
+          probe sigterm-probe-image-cmd
+          # The argv docker-compose.release.yml pins.
+          probe sigterm-probe-release-cmd bun src/index.ts
+
+      - name: Remove the SIGTERM probe containers
+        if: always()
+        run: docker rm -f sigterm-probe-image-cmd sigterm-probe-release-cmd >/dev/null 2>&1 || true
+
       - name: Assert the backend serves HTTP
         run: |
           set -euo pipefail

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -72,4 +72,18 @@ COPY --chown=bun:bun backend/tsconfig.json ./tsconfig.json
 EXPOSE 4000
 ENV NODE_ENV=production
 
-CMD ["sh", "-c", "bun run migrate:up && bun src/index.ts"]
+# `exec` is load-bearing, not style. `/bin/sh` here is dash, and the `&&` stops
+# it from exec-optimising the tail, so without `exec` dash stays PID 1 and runs
+# bun as a child. dash never forwards signals, and the kernel discards signals
+# with a default disposition sent to PID 1 — so `docker stop` was a no-op: the
+# container ignored SIGTERM, ran until the grace period expired and died on
+# SIGKILL (exit 137), with src/index.ts's SIGTERM drain never entering. `exec`
+# replaces dash with bun, so the application is PID 1 and receives the signal
+# itself (issue #586).
+#
+# SIGTERM is still ignored while `migrate:up` runs, because dash is PID 1 for
+# that window. That is safe and deliberately not worked around: migrations run
+# in one transaction under a session-scoped advisory lock (src/models/migrate.ts),
+# so a SIGKILL mid-migration rolls back and frees the lock with nothing half
+# applied.
+CMD ["sh", "-c", "bun run migrate:up && exec bun src/index.ts"]

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -30,6 +30,17 @@ const server = createBunRuntimeServer({ app: honoApp, engine: realtime.engine })
 const app = createHttpCompatibilityServer(honoApp);
 const io = realtime.io;
 
+/**
+ * Outer bound on the shutdown drain, in milliseconds.
+ *
+ * Kept strictly between the drain's step-wise worst case (10s HTTP force-stop +
+ * 2s presence + 2s Redis) and the 30s `stop_grace_period` that
+ * docker-compose.prod.yml and docker-compose.release.yml set, so a drain that
+ * hangs still exits on its own before the orchestrator resorts to SIGKILL.
+ * Changing any of those three numbers means revisiting this one.
+ */
+const SHUTDOWN_DEADLINE_MS = 20_000;
+
 if (require.main === module) {
   // Only the real entrypoint validates: importing the app (as the E2E suite
   // does) must not decide whether this environment is fit to serve traffic.
@@ -63,6 +74,22 @@ if (require.main === module) {
     shuttingDown = true;
     stopJobs();
     publisher.shutdown(signal);
+    // Every step below is individually bounded — 10s to force the HTTP drain
+    // (bootstrap/realtime.ts), 2s for presence, 2s for Redis — but the chain as a
+    // whole was not: each bound is enforced by a timer, and the HTTP one is
+    // `unref`'d, so a step that never settles strands the callbacks after it and
+    // nothing here would ever call `process.exit`. This deadline is the outer
+    // guarantee, and is the reason the container can promise it exits on its own
+    // rather than waiting to be SIGKILLed. It sits above the ~14s step-wise worst
+    // case and below the 30s `stop_grace_period` the compose files set, so the
+    // process always wins the race against the orchestrator (issue #586).
+    const deadline = setTimeout(() => {
+      console.error('Shutdown deadline exceeded, exiting anyway', {
+        signal,
+        deadlineMs: SHUTDOWN_DEADLINE_MS,
+      });
+      process.exit(0);
+    }, SHUTDOWN_DEADLINE_MS);
     // Redis is released last, inside the drain callback. `publisher.shutdown`
     // above disconnects every socket, which runs the disconnect handlers — and
     // those are the writes that release presence leases, so Redis has to still
@@ -77,9 +104,19 @@ if (require.main === module) {
       // Presence first: `stop()` hands back every lease this instance holds, so
       // a redeploy does not leave its users showing online for the rest of the
       // lease TTL. It needs Redis, which is why `redis.close()` waits for it.
-      void presence
-        .stop()
-        .finally(() => redis.close().finally(() => process.exit(0)));
+      //
+      // Postgres is deliberately not closed here. `Bun.SQL.close()` waits on
+      // in-flight queries with no bound of its own, which would put an unbounded
+      // step on the one path whose whole design property is being bounded — and
+      // it would buy nothing: the pool holds no lease or advisory lock at steady
+      // state, and `process.exit(0)` drops the sockets for Postgres to reap
+      // immediately. Do not "complete" the drain by adding it.
+      void presence.stop().finally(() =>
+        redis.close().finally(() => {
+          clearTimeout(deadline);
+          process.exit(0);
+        }),
+      );
     });
   };
   process.once('SIGTERM', () => shutdown('SIGTERM'));

--- a/backend/tests/unit/deploy/releaseComposeRuntime.test.ts
+++ b/backend/tests/unit/deploy/releaseComposeRuntime.test.ts
@@ -122,6 +122,40 @@ function resolveInRunner(target: string): { inImage: boolean; onDisk: boolean } 
   };
 }
 
+/**
+ * The runner stage's own `CMD`, as an argv array.
+ *
+ * A compose service with no `command:` runs this instead, so it is just as much
+ * a startup command as the ones spelled out in the compose files — and until
+ * issue #586 it was the one nothing checked.
+ */
+function runnerCmd(): string[] {
+  const { lines } = runnerStage();
+  let last: string | undefined;
+  for (const line of lines) {
+    const match = /^CMD\s+(.+)$/i.exec(line.trim());
+    if (match) last = match[1]!;
+  }
+  if (last === undefined) throw new Error('Dockerfile.prod runner stage has no CMD');
+  // Only the exec form is parseable, and it is the only form that reaches the
+  // kernel without a shell of Docker's own choosing in the way.
+  if (!last.startsWith('[')) throw new Error(`Dockerfile.prod CMD is not in exec form: ${last}`);
+  return JSON.parse(last) as string[];
+}
+
+/**
+ * `["sh", "-c", "a && b"]` -> `[["a"], ["b"]]`, or null when argv is not a shell
+ * wrapper. Each segment is the argv of one command the container really runs.
+ */
+function shellSegments(argv: string[]): string[][] | null {
+  const isShell = argv[0] === 'sh' || argv[0] === '/bin/sh';
+  if (!isShell || argv[1] !== '-c' || typeof argv[2] !== 'string') return null;
+  return argv[2]
+    .split('&&')
+    .map((segment) => segment.trim().split(/\s+/))
+    .filter((segment) => segment.length > 0 && segment[0] !== '');
+}
+
 function composeServices(file: string): Record<string, { image?: string; command?: unknown }> {
   const parsed = Bun.YAML.parse(readFileSync(path.join(repoRoot, file), 'utf8')) as {
     services?: Record<string, { image?: string; command?: unknown }>;
@@ -139,10 +173,13 @@ function backendImageCommands(): Array<{ id: string; command: unknown }> {
       // ${BACKEND_IMAGE}. Either way only the backend/migrate services run it.
       const usesBackendImage = service.image?.includes('BACKEND_IMAGE') ?? ['backend', 'migrate'].includes(name);
       if (!usesBackendImage) continue;
-      // No `command:` at all means the image's own CMD runs, which is by
-      // construction in sync with the Dockerfile and needs no guarding here.
-      if (service.command === undefined) continue;
-      found.push({ id: `${file}:${name}`, command: service.command });
+      // A service with no `command:` runs the image's own CMD. This used to be
+      // skipped as "in sync with the Dockerfile by construction" — that
+      // assumption is exactly what let issue #586 through, because the CMD
+      // itself was the broken part and docker-compose.prod.yml's backend is the
+      // one service that inherits it. Check the CMD in its place instead.
+      const command = service.command ?? runnerCmd();
+      found.push({ id: service.command === undefined ? `${file}:${name} (image CMD)` : `${file}:${name}`, command });
     }
   }
 
@@ -180,6 +217,7 @@ describe('compose commands against the backend production image', () => {
     expect(backendImageCommands().map((entry) => entry.id)).toEqual([
       'docker-compose.release.yml:migrate',
       'docker-compose.release.yml:backend',
+      'docker-compose.prod.yml:backend (image CMD)',
     ]);
   });
 
@@ -193,35 +231,90 @@ describe('compose commands against the backend production image', () => {
       });
 
       const argv = (Array.isArray(command) ? command : []) as string[];
+      const segments = shellSegments(argv);
+      // A shell wrapper is tolerable only if it hands the container off before
+      // the long-running command; each `&&` segment is then checked as its own
+      // argv. Without one, `argv` is already the single command.
+      const commands = segments ?? [argv];
 
-      it('invokes bun, the only interpreter in the runner stage', () => {
-        expect(argv[0]).toBe('bun');
-      });
+      if (segments) {
+        it('execs its last command, so the application ends up as PID 1', () => {
+          // The container's process tree decides whether SIGTERM is ever seen.
+          // `/bin/sh` here is dash, which does not forward signals, and the
+          // kernel discards default-disposition signals aimed at PID 1 — so a
+          // shell left at PID 1 makes `docker stop` a no-op: SIGTERM is ignored,
+          // the grace period expires and the container dies on SIGKILL with
+          // src/index.ts's drain never entered (issue #586).
+          expect(segments.at(-1)![0]).toBe('exec');
 
-      it('resolves to a package script or a file the runner stage contains', () => {
-        if (argv[1] === 'run') {
-          const script = argv[2]!;
-          expect(Object.keys(backendPackageJson.scripts)).toContain(script);
+          // Only the last one: an earlier `exec` would replace the shell before
+          // the commands after it could run at all.
+          for (const segment of segments.slice(0, -1)) {
+            expect(segment[0]).not.toBe('exec');
+          }
+        });
+      }
 
-          // The script itself must also be bun-only: `bun run migrate:up` is no
-          // better than `pnpm run migrate:up` if migrate:up shells out to node.
-          const body = backendPackageJson.scripts[script]!;
-          expect(body).toMatch(/^bun\s/);
+      for (const [index, segment] of commands.entries()) {
+        // `exec bun src/index.ts` is checked as `bun src/index.ts`; the exec
+        // itself is asserted above.
+        const words = segment[0] === 'exec' ? segment.slice(1) : segment;
+        const label = commands.length > 1 ? `part ${index + 1}: ${segment.join(' ')}` : segment.join(' ');
 
-          // And the path *inside* the script has to ship too, or moving
-          // src/models/migrate.ts would break the container while this test
-          // stayed green.
-          const scriptTarget = scriptPathArgument(body);
-          expect(scriptTarget).toBeDefined();
-          expect(resolveInRunner(scriptTarget!)).toEqual({ inImage: true, onDisk: true });
-          return;
-        }
+        describe(label, () => {
+          it('invokes bun, the only interpreter in the runner stage', () => {
+            expect(words[0]).toBe('bun');
+          });
 
-        // Otherwise bun is handed a path directly, which must live under a
-        // directory the runner stage actually copied in. `dist/backend/src/index.js`
-        // failed exactly here: nothing in the runner stage creates a dist/.
-        expect(resolveInRunner(argv[1]!)).toEqual({ inImage: true, onDisk: true });
-      });
+          it('resolves to a package script or a file the runner stage contains', () => {
+            if (words[1] === 'run') {
+              const script = words[2]!;
+              expect(Object.keys(backendPackageJson.scripts)).toContain(script);
+
+              // The script itself must also be bun-only: `bun run migrate:up` is no
+              // better than `pnpm run migrate:up` if migrate:up shells out to node.
+              const body = backendPackageJson.scripts[script]!;
+              expect(body).toMatch(/^bun\s/);
+
+              // And the path *inside* the script has to ship too, or moving
+              // src/models/migrate.ts would break the container while this test
+              // stayed green.
+              const scriptTarget = scriptPathArgument(body);
+              expect(scriptTarget).toBeDefined();
+              expect(resolveInRunner(scriptTarget!)).toEqual({ inImage: true, onDisk: true });
+              return;
+            }
+
+            // Otherwise bun is handed a path directly, which must live under a
+            // directory the runner stage actually copied in. `dist/backend/src/index.js`
+            // failed exactly here: nothing in the runner stage creates a dist/.
+            expect(resolveInRunner(words[1]!)).toEqual({ inImage: true, onDisk: true });
+          });
+        });
+      }
+    });
+  }
+});
+
+/**
+ * The stop budget the drain in src/index.ts depends on. Docker's default grace
+ * period is 10s; the drain's own worst case is ~14s (10s to force the HTTP
+ * drain, 2s for presence leases, 2s for Redis), so at the default a slow drain
+ * is SIGKILLed part-way through handing presence leases back (issue #586).
+ */
+describe('backend stop grace period', () => {
+  for (const file of ['docker-compose.release.yml', 'docker-compose.prod.yml']) {
+    it(`${file} gives the backend longer than its own drain`, () => {
+      const services = composeServices(file) as Record<string, { stop_grace_period?: string }>;
+      const grace = services.backend?.stop_grace_period;
+      expect(grace).toBeDefined();
+
+      const seconds = /^(\d+)s$/.exec(grace!);
+      expect(seconds).not.toBeNull();
+      // Above the 20s deadline src/index.ts arms, which is itself above the
+      // ~14s step-wise worst case, so the process always exits before Docker
+      // reaches for SIGKILL.
+      expect(Number(seconds![1])).toBeGreaterThan(20);
     });
   }
 });

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -115,6 +115,21 @@ services:
         condition: service_started
     volumes:
       - ${UPLOADS_MOUNT_SOURCE:-app_uploads}:/app/uploads
+    # Matches docker-compose.release.yml: Docker's 10s default is under this
+    # backend's own worst-case drain (10s to force the HTTP drain, then up to 2s
+    # for presence leases and 2s for Redis), so at the default a slow drain is
+    # SIGKILLed exactly while handing leases back. 30s clears that ~14s and stays
+    # above the 20s shutdown deadline src/index.ts arms (issue #586).
+    #
+    # No `init: true` here, deliberately. The application is PID 1 — see the CMD
+    # in backend/Dockerfile.prod — and installs its own SIGTERM handler, and it
+    # spawns no child processes, so there is nothing for an init to reap. tini
+    # would only insert itself between the orchestrator and the application, and
+    # Docker runs it without `-g`, so it signals just its direct child. That is
+    # actively worse here: with a shell still in between it would have produced a
+    # fast, clean-looking exit 143 while the drain never ran, hiding #586 rather
+    # than fixing it.
+    stop_grace_period: 30s
 
   frontend:
     build:

--- a/docker-compose.release.yml
+++ b/docker-compose.release.yml
@@ -75,6 +75,15 @@ services:
     volumes:
       - ${UPLOADS_MOUNT_SOURCE:-app_uploads}:/app/uploads
     command: ["bun", "src/index.ts"]
+    # Docker's default is 10s, which is under this backend's own worst-case
+    # drain: src/index.ts forces the HTTP drain after 10s, then spends up to 2s
+    # handing presence leases back and up to 2s closing Redis. At the default a
+    # slow drain is SIGKILLed exactly while releasing those leases, leaving users
+    # showing online until PRESENCE_TTL_MS expires — the outcome presence.stop()
+    # exists to avoid. 30s clears that ~14s worst case and stays above the 20s
+    # shutdown deadline src/index.ts arms, so the process always exits itself
+    # first (issue #586).
+    stop_grace_period: 30s
 
   frontend:
     image: ${FRONTEND_IMAGE:?FRONTEND_IMAGE is required}

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -149,7 +149,13 @@ announced online only on the first connection anywhere and offline only when the
 last one goes. `PRESENCE_TTL_MS` bounds how long a crashed instance keeps its
 users showing as online: nothing runs on a dead process to hand the leases back,
 so only the expiry does it. Every lease is refreshed three times per TTL, and a
-graceful shutdown hands them all back rather than waiting the TTL out.
+graceful shutdown hands them all back rather than waiting the TTL out. That last
+part only holds if SIGTERM actually reaches the process: the container has to
+leave the application at PID 1 (hence the `exec` in `backend/Dockerfile.prod`'s
+CMD) and allow enough time for the drain to finish (hence
+`stop_grace_period: 30s` on the backend service). Get either wrong and the
+container is SIGKILLed with its leases still held, which looks exactly like a
+crashed instance — see docs/RELEASE.md for the full stop contract.
 `INSTANCE_ID` names this process in that hash; left unset one is generated per
 start, which is fine unless your orchestrator already has a stable per-replica
 name to reuse. Per-field TTLs need **Redis 7.4 or newer** — against an older

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -82,6 +82,16 @@ The Compose bundle starts PostgreSQL, runs `bun run migrate:up` once from the pi
 
 Apply an upgraded bundle with `up -d`, not `restart`: `docker compose restart backend` does not re-evaluate `depends_on`, so it never runs the `migrate` service and would leave the backend on an unmigrated schema.
 
+### Stopping and redeploying the backend
+
+`docker compose stop`, `down`, and the stop half of `up -d` on a changed service all send SIGTERM to the backend, which drains rather than dying where it stands: it stops accepting new work, disconnects realtime sessions, waits for in-flight HTTP requests, hands back the presence leases this instance holds so its users are not left showing online until `PRESENCE_TTL_MS` expires, closes Redis, and exits 0. Every step is bounded, and a drain that stalls anyway gives up after 20s and exits on its own.
+
+`stop_grace_period` is therefore set to `30s` on the backend service, above both that deadline and the drain's own ~14s worst case. Docker's default is 10s, which lands in the middle of the drain and cuts it off exactly while presence leases are being released. If you write your own Compose or move the backend to another orchestrator, carry the 30s over — the application cannot honour the shutdown contract without it.
+
+Two windows are exempt by design and need no handling: the container ignores SIGTERM while `migrate:up` runs and while the process is still starting up, before the handler is installed. Migrations run in a single transaction under a session-scoped advisory lock, so a container killed in that window rolls back with nothing half-applied and no lock left behind.
+
+The backend service deliberately sets no `init: true`. The application is PID 1 and installs its own handler, and it spawns no child processes, so there is nothing for an init to reap. Adding tini would put it between Docker and the application, and Docker runs it without `-g`, so it signals only its direct child — with a shell in between that produces a fast, clean-looking exit 143 while the drain never runs. It is not a substitute for the application-level handler.
+
 Bundles published before `v2.1.1` inclusive carry a `docker-compose.release.yml` whose backend commands (`pnpm run migrate:up`, `node dist/backend/src/index.js`) do not exist in the backend image they pin. Published tags are immutable, so those archives cannot be corrected in place — to deploy one of them, replace the two `command:` entries with the bun-only forms above.
 
 For production deployments, keep `BACKEND_IMAGE` and `FRONTEND_IMAGE` pinned to the manifest's digest references. The frontend image is built with `http://localhost:4005` as the default API URL; the existing frontend runtime logic maps the standard `3005`/`4005` host ports, while a different public topology requires a separately configured build.

--- a/docs/ZH-TW/DEVELOPMENT.md
+++ b/docs/ZH-TW/DEVELOPMENT.md
@@ -135,7 +135,12 @@ typing indication TTL 與握手名額保留時間；與其他後端變數一樣�
 而 `online` 只在全域第一條連線建立時發送、`offline` 只在最後一條消失時發送。
 `PRESENCE_TTL_MS` 界定「某個 instance 當掉後，它的使用者最多被誤顯示成在線多
 久」：行程已死就沒有人能把 lease 還回去，只剩過期能清掉它。後端每個 TTL 內會
-續約三次，而正常關機會主動把 lease 全數交還，不需要等 TTL 到期。`INSTANCE_ID`
+續約三次，而正常關機會主動把 lease 全數交還，不需要等 TTL 到期。但這件事成立的
+前提是 SIGTERM 真的送達行程：container 必須讓應用程式位於 PID 1（因此
+`backend/Dockerfile.prod` 的 CMD 使用 `exec`），也必須留足夠時間讓 drain 完成
+（因此 backend service 設定 `stop_grace_period: 30s`）。兩者只要有一項不對，
+container 就會在 lease 尚未交還時被 SIGKILL，外觀上與「instance 當掉」完全相同
+——完整的關機約定見 docs/ZH-TW/RELEASE.md。`INSTANCE_ID`
 是本行程在該 hash 中的名稱；留空時每次啟動自行產生一個，除非編排器本來就有穩
 定的 per-replica 名稱可以沿用，否則不需要設定。欄位層級的 TTL 需要
 **Redis 7.4 以上** —— 對更舊的伺服器寫入會失敗，後端會記錄一次版本需求，

--- a/docs/ZH-TW/RELEASE.md
+++ b/docs/ZH-TW/RELEASE.md
@@ -82,6 +82,16 @@ Compose bundle 會啟動 PostgreSQL，使用固定版本的 backend image 執行
 
 升級 bundle 時請使用 `up -d`，不要用 `restart`：`docker compose restart backend` 不會重新評估 `depends_on`，因此不會執行 `migrate` service，會讓 backend 跑在尚未套用 migration 的 schema 上。
 
+### 停止與重新部署 backend
+
+`docker compose stop`、`down`，以及 `up -d` 對已變更 service 所做的停止動作，都會對 backend 送出 SIGTERM。Backend 收到後會執行 drain 而不是直接中止：停止接受新工作、中斷 realtime 連線、等待處理中的 HTTP request 完成、交還本 instance 持有的 presence lease（避免使用者一直顯示為上線直到 `PRESENCE_TTL_MS` 到期）、關閉 Redis，最後以 exit code 0 結束。每一步都有時間上限；若 drain 仍然卡住，會在 20 秒後自行放棄並結束。
+
+因此 backend service 的 `stop_grace_period` 設為 `30s`，同時高於該 20 秒 deadline 與 drain 本身約 14 秒的最壞情況。Docker 預設值為 10 秒，正好落在 drain 中間，會在交還 presence lease 的過程中把它切斷。若你自行撰寫 Compose 或改用其他 orchestrator，請一併帶上這個 30 秒設定——少了它，應用程式無法履行上述關機約定。
+
+有兩個時間窗刻意不予處理，也不需要處理：`migrate:up` 執行期間，以及 process 尚在啟動、handler 還沒註冊之前，container 會忽略 SIGTERM。Migration 在單一 transaction 中執行，並持有 session-scoped advisory lock，因此在該時間窗被強制終止時會完整 rollback，不會留下套用到一半的 schema 或殘留的 lock。
+
+Backend service 刻意不設定 `init: true`。應用程式本身即為 PID 1 並註冊自己的 handler，且不會產生任何子行程，沒有需要 init 回收的 zombie process。加上 tini 只會讓它卡在 Docker 與應用程式之間，而 Docker 執行 tini 時不帶 `-g`，只會將訊號送給它的直接子行程——若中間仍隔著一層 shell，結果會是快速、看似正常的 exit 143，實際上 drain 從未執行。它不能取代應用層的 handler。
+
 `v2.1.1`（含）以前發布的 bundle，其 `docker-compose.release.yml` 中 backend 的啟動命令（`pnpm run migrate:up`、`node dist/backend/src/index.js`）在它所固定的 backend image 中並不存在。已發布的 tag 不可變更，因此這些 archive 無法就地修正——若要部署這些版本，請自行將該兩個 `command:` 改為上述 bun-only 形式。
 
 正式部署應把 `BACKEND_IMAGE` 與 `FRONTEND_IMAGE` 固定為 manifest 記錄的 digest 參照。Frontend image 預設以 `http://localhost:4005` 建置 API URL；現有前端 runtime 邏輯會對標準 `3005`／`4005` host port 做對應，若公開拓撲不同，需另行設定建置參數。


### PR DESCRIPTION
## 變更描述 (Description)

Production backend 從來沒有真正執行過它的 shutdown drain。

`backend/Dockerfile.prod` 的 CMD 是 `sh -c "bun run migrate:up && bun src/index.ts"`。因為中間的 `&&`，dash 不會對最後一個命令做 exec 最佳化，於是 **dash 一直是 PID 1，bun 只是它的子行程**。dash 不會轉送訊號，而 kernel 又會丟棄送給 PID 1、且採預設處置方式的訊號——因此 `docker stop` 實際上是 no-op：container 完全忽略 SIGTERM，一路跑到 grace period 結束才被 SIGKILL（exit 137），`src/index.ts` 的 drain 一次都沒有進入過，presence lease 也從未交還。

`docker-compose.prod.yml` 的 backend 沒有 `command:`，因此繼承這個 CMD；`docker-compose.release.yml:77` 則以 exec form 覆寫，所以 bun 在 release 是 PID 1、不受影響。這正是本 issue 要求解決的 prod／release 行為不一致。

### 對 issue 原始描述的更正

原 issue 的三項前提中有兩項在目前 `main` 上並不成立，這裡一併記錄（本次執行實際驗證）：

- 「`backend/src` 沒有註冊 SIGTERM handler」— **不成立**。`backend/src/index.ts:85-86` 早已註冊 `SIGTERM`／`SIGINT`，且完整執行 `stopJobs()` → `publisher.shutdown()` → `server.close()` → `presence.stop()` → `redis.close()`。它由 #542（commit `a56cabe`，2026-08-18）加入，比本 issue 建立時間早六天。
- 「Bun 不會替應用程式處理 SIGTERM」— **不成立**，且是誤判。bun 在自己是 PID 1 時可以正常收到 SIGTERM；`backend/tests/unit/bootstrap/redisStartup.test.ts:84-110` 已經在實際 spawn `bun src/index.ts` 後送出 SIGTERM 並斷言 exit code 為 0，該測試通過。
- 「prod／release compose 沒有 `init: true`」— **成立**，但見下方說明。

真正的缺陷比原描述更窄：不是「缺少 handler」，而是**訊號根本沒送到已經存在的 handler**。

### 變更內容

1. **`backend/Dockerfile.prod`**：最後一個命令加上 `exec`，讓 bun 取代 dash 成為 PID 1，訊號直接送達應用程式。
2. **`docker-compose.prod.yml` 與 `docker-compose.release.yml`**：backend 加上 `stop_grace_period: 30s`。Docker 預設的 10 秒低於 drain 自身約 14 秒的最壞情況（10s 強制結束 HTTP drain ＋ 2s presence ＋ 2s Redis），會剛好在交還 presence lease 的過程中把 container 砍掉。這一項與 `exec` 同等重要：少了它，修好的 drain 仍會被中途截斷。
3. **`backend/src/index.ts`**：為 drain 加上端到端的 20 秒 deadline。原本每一步各自有 timer，但 HTTP 那個 timer 是 `unref`'d 的，只要有一步永不 settle，後面的 callback 就全被卡住，`process.exit` 永遠不會被呼叫。20 秒位於「step-wise 最壞情況」與「grace period」之間，確保行程一定比 orchestrator 先結束。同時補上註解說明 **Postgres 為何刻意不關閉**（`Bun.SQL.close()` 會無上限地等待進行中的查詢，會在唯一講究「有界」的路徑上放進一個無界步驟，而且沒有任何好處）。
4. **`backend/tests/unit/deploy/releaseComposeRuntime.test.ts`**：原本對「沒有 `command:` 的 service」直接略過，理由是「image 的 CMD 依建構方式必然與 Dockerfile 同步」——這個豁免正是讓本 bug 溜過去的原因，因為壞掉的就是 CMD 本身。改為在該情況下回退檢查 runner stage 的 CMD，並新增：最後一段必須是 `exec`、前面各段不得是 `exec`、以及兩份 compose 的 `stop_grace_period` 必須大於 20 秒。
5. **`.github/workflows/ci-backend.yml`**：在既有的 `release-compose` job 內新增實機驗證。

### 關於 `init: true`

**刻意不加**，並已在文件寫明理由。應用程式現在就是 PID 1 且自帶 handler，也不會產生任何子行程，沒有需要 init 回收的 zombie。更關鍵的是：Docker 執行 tini 時不帶 `-g`，只會把訊號送給直接子行程——在中間仍隔著一層 shell 的情況下，加上 `init: true` 會產生**快速、看起來很正常的 exit 143，而 drain 依然沒有執行**，等於把 #586 藏起來而不是修好。文件中也註明它不能取代應用層 handler。

## 相關的 Issue (Related Issue)

Closes #586

## 變更類型 (Type of Change)

- [ ] `feat`: 新增功能 (Feature)
- [x] `fix`: 修復 Bug
- [ ] `refactor`: 重構代碼
- [x] `docs`: 修改文件
- [x] `test`: 新增或修正測試案例
- [ ] `chore`: 建置流程或輔助工具變更
- [ ] `perf`: 效能優化
- [x] `ci`: CI 設定變更

## 驗證與測試計畫 (Verification & Test Plan)

### 本地測試 (Local Tests)

- [x] 後端型別檢查（`pnpm exec tsc --noEmit`，直接於 repo 執行，exit 0）
- [x] 後端 Linter（`pnpm run lint`，通過）
- [x] 單元測試（`pnpm run test:unit`：**708 pass / 0 fail**，橫跨 50 個檔案）
- [x] `backend/tests/unit/deploy/releaseComposeRuntime.test.ts`：19 pass / 0 fail
- [x] `backend/tests/unit/bootstrap/redisStartup.test.ts`：2 pass / 0 fail（實際 spawn backend、送 SIGTERM、斷言 exit 0）
- [ ] 前端型別檢查／Linter：本次未變更任何 frontend 檔案，故未執行
- [ ] 整合測試：本環境無 Docker，未執行；需由 reviewer 或 CI 執行

**本環境沒有 Docker**，因此新增的 CI 步驟（實際建置 production image 並送出 SIGTERM）**尚未在真實 container 中跑過，需由 CI 驗證**。為降低「推一個壞掉的 workflow」的風險，已改用下列方式先行驗證：

### 手動測試 (Manual Verification)

**1. 以 PID 1 語意重現缺陷（`unshare -rpf --mount-proc`，`/bin/sh -> dash`）**

```
Case A（目前的 CMD 形狀）：sh -c "true && bash child"
  namespace PID 1 = sh，子行程存在
  -> 送出 SIGTERM 後 3 秒，PID 1 仍在執行 -> 訊號遭忽略
     （Docker 此時會等滿 grace period 再 SIGKILL，即 exit 137）

Case C（本 PR 的修法）：sh -c "true && exec bash child"
  namespace PID 1 = bash（應用程式取代了 shell）
  -> CHILD: got SIGTERM, exiting 0
  -> PID 1 exit code = 0
```

這也修正了一個細節：dash 在 PID 1 時是**完全忽略** SIGTERM，而不是自己以 143 結束再遺棄 bun，所以實際觀察到的 container exit code 是 **137**。

**2. 證明新測試不是空轉**：暫時還原 `exec` 與 `stop_grace_period` 後重跑，確認確實失敗：

```
(fail) ... docker-compose.prod.yml:backend (image CMD) > execs its last command,
       so the application ends up as PID 1     [Received: "bun"]
(fail) backend stop grace period > docker-compose.prod.yml gives the backend
       longer than its own drain               [Received: undefined]
 17 pass, 2 fail
```

還原修正後回到 19 pass / 0 fail。

**3. 以 stub `docker` 乾跑新的 CI 步驟**，確認四種情境的控制流程與錯誤訊息都正確：

| 情境 | 結果 |
|------|------|
| `good`（exit 0 ＋ drain log） | 通過，exit status 0 |
| `deaf`（exit 137、無 drain log） | 失敗，訊息指向「SIGTERM 從未送達，檢查 CMD 的 `exec`」 |
| `slowdrain`（exit 137、有 drain log） | 失敗，訊息指向「drain 超過 stop_grace_period」 |
| `noboot`（從未 listening） | 失敗，訊息指出無法測試 SIGTERM 行為 |

新 CI 步驟的設計重點：兩種 argv 形式都測（image 自身的 CMD ＝ prod 路徑，以及 release 覆寫的 `bun src/index.ts`）；送訊號前先等 `successfully listening`，避免打在「migration 中／handler 尚未註冊」這兩個本來就會忽略 SIGTERM 的時間窗而造成 flaky；使用 `docker stop -t 30` 對齊 `stop_grace_period`，因為預設的 10 秒與 drain 最壞情況相當，會讓「drain 慢」和「完全沒收到訊號」無法區分；除了 exit code 之外一併檢查 `Realtime server shutting down` 這行 log，才能證明是 handler 讓它停下來的，而不是它剛好停了。

## 資料庫變更 (Database Changes)

* 此變更是否包含資料庫 Schema 修改？ **否**
* 若為是，請寫明 Migration 檔案名稱：不適用
* 是否已確認遷移與 docs/database-design.md 設計一致？ 不適用

## API 與 WebSocket 協定一致性 (API & WebSocket Contract Check)

* 此變更是否涉及 API 路由或 WebSocket 事件的資料結構變更？ **否**
* 是否已確認與 docs/api-documentation.md 規範完全一致？ **是**（未觸及任何 route 或 event payload）

## Advisor 重點意見

- **`stop_grace_period` 與 `exec` 同等重要**。只加 `exec` 只是「修好一半」：drain 最壞情況約 14 秒，超過 Docker 預設的 10 秒，會剛好在交還 presence lease 時被 SIGKILL，而那正是 `presence.stop()` 存在的目的。此問題原本被 shell bug 掩蓋，一旦 `exec` 落地就會浮現。
- **drain 並非端到端有界**。`bootstrap/realtime.ts:139-142` 的 forceStop timer 是 `unref`'d 的；unref 的 timer 依定義可以不觸發，一旦不觸發，其後的 `presence.stop()`、`redis.close()`、`process.exit(0)` 全部不會執行。因此加上外層 deadline。
- **`init: true` 會讓問題更難發現**，理由如上；建議以「說明為何不採用」來滿足該驗收條件。
- **不要在 drain 中關閉 Postgres**：`Bun.SQL.close()` 預設等待進行中的查詢且無上限，而 `publisher.shutdown()` 觸發的 disconnect handler 會產生 fire-and-forget 的 presence 寫入，正好是它會卡住等待的對象。
- **dev stack（`docker-compose.yml:167`）有相同形狀但不宜一併處理**：`exec pnpm run dev` 會讓 **pnpm** 成為 PID 1，等於依賴 pnpm 對 `bun --watch` 的訊號轉送，且牽涉 hot-reload 的重啟機制，是另一個問題而非同一個問題的延伸。本 PR 未更動 dev stack，以符合「不破壞既有 development stack 啟動與 hot-reload 行為」的驗收條件。

## 驗收條件對照

- [x] 明確定義 production backend 收到 SIGTERM 時的預期 shutdown 行為 → `docs/RELEASE.md`／`docs/ZH-TW/RELEASE.md` 新增「停止與重新部署 backend」
- [x] prod 與 release compose 行為一致 → 兩者現在都讓應用程式成為 PID 1，且 `stop_grace_period` 相同；僅存的差異（migration 執行位置）已在文件說明
- [x] backend 收到 SIGTERM 後正常停止，而非等 timeout 被 SIGKILL → `exec` ＋ `stop_grace_period` ＋ 20 秒 deadline
- [x] 長生命週期資源正確停止並釋放 → HTTP drain／Socket.IO／presence lease／Redis 皆在 drain 中處理；Postgres 刻意不關閉並附理由
- [x] 新增自動化測試或 CI 驗證 → 靜態 contract test ＋ CI 實機 SIGTERM 探測（**CI 實機部分待 CI 驗證**）
- [x] 不破壞既有 development stack → 未更動 `docker-compose.yml`
- [x] 若採用 `init: true` 需說明其用途 → 選擇不採用，並說明原因與它為何不能取代應用層 handler

Generated with Claude Code (https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdnYAby3nztS4XSczmmPe5)_