### PR TITLE
test(browser): add full-stack Playwright E2E lane

### DIFF
--- a/.github/workflows/ci-browser.yml
+++ b/.github/workflows/ci-browser.yml
@@ -1,14 +1,29 @@
 name: CI Browser
-
-# Real-Chromium smoke tests (issue #543). Deliberately a lane of its own rather
-# than another job inside ci-frontend.yml: that workflow's `test` job owns the
-# Vitest/jsdom suite, and folding a browser download plus a Next.js server into
-# it would make one job responsible for two unrelated kinds of failure.
+# Every lane that drives a real Chromium lives here.
 #
-# Phase 1 is frontend-only — no Postgres service, no Bun, no backend process.
-# Every /api/v1 call is fulfilled in-browser by tests-browser/support/api-mock.ts.
-# The full-stack browser lane is tracked separately in issue #544 and must land
-# as its own workflow, not as an extension of this one.
+# Two jobs, deliberately not one:
+#
+#   browser-tests            frontend-only smoke (issue #543). No database, no
+#                            Bun, no backend process — every /api/v1 call is
+#                            fulfilled in-browser by
+#                            tests-browser/support/api-mock.ts.
+#
+#   fullstack-browser-tests  full-stack E2E (issue #544). Real PostgreSQL, real
+#                            Bun backend, real Next.js, real Socket.IO.
+#
+# They are separate jobs rather than separate workflows because ci.yml's
+# `required-checks` gate keys off the single `browser` lane: a second job here
+# is covered by that gate automatically, whereas a new workflow would need a new
+# detect output, a new gate entry and a new required status name. Issue #544
+# proposed its own workflow and an earlier version of this comment said the
+# full-stack lane "must land as its own workflow"; that was reversed
+# deliberately, and the isolation it was protecting is preserved by the job
+# boundary — the two share no process, no database and no test command.
+#
+# Keeping them as separate *jobs* still matters: a browser download plus a
+# Next.js server plus a Postgres service plus two application processes in one
+# job would make a single unit responsible for several unrelated kinds of
+# failure.
 
 on:
   workflow_call:
@@ -58,5 +73,216 @@ jobs:
           path: |
             frontend/playwright-report/
             frontend/test-results/
+          retention-days: 7
+          if-no-files-found: ignore
+
+  # Full-stack browser E2E (issue #544): Chromium → Next.js → Hono/Bun →
+  # PostgreSQL → Socket.IO, with nothing mocked.
+  fullstack-browser-tests:
+    runs-on: ubuntu-latest
+    services:
+      # Same image, port and health options as ci-database.yml. Reused rather
+      # than reinvented, and deliberately not Docker Compose: this lane needs an
+      # ephemeral database, which is exactly what a service container is.
+      postgres:
+        image: postgres:18-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: ntnu_test
+        ports:
+          - 5433:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 2s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      # 127.0.0.1 everywhere, never `localhost`. The refresh cookie is
+      # SameSite=Strict (backend/src/utils/cookies.ts) and Chromium treats the
+      # two spellings as different hosts, so mixing them across the 3000/4000
+      # boundary silently drops the cookie and every session bootstrap bounces
+      # to /login.
+      DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5433/ntnu_test
+      BACKEND_ORIGIN: http://127.0.0.1:4000
+      FRONTEND_ORIGIN: http://127.0.0.1:3000
+      # Passed to the Playwright config and its manually-created BrowserContext
+      # fixtures. Unlike Playwright Test's `page`/`context` fixtures, a raw
+      # `browser.newContext()` does not inherit `use.baseURL`, so this explicit
+      # value is what makes relative `page.goto('/login')` navigations correct.
+      E2E_FRONTEND_ORIGIN: http://127.0.0.1:3000
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      # No `package:` filter, then a full install. The composite action installs
+      # one package's dependency closure, and this job runs both the frontend
+      # and the backend; two filtered calls would also re-run the Node/pnpm
+      # setup steps for no benefit.
+      - uses: ./.github/actions/setup-workspace
+        with:
+          bun: 'true'
+      - run: pnpm install --frozen-lockfile
+
+      - name: Install Chromium and system dependencies
+        run: pnpm --filter near-chat-frontend exec playwright install --with-deps chromium
+
+      # The existing migration path, not a schema dump: this lane is also the
+      # only place a migration is proven to produce a schema the real
+      # application can actually serve.
+      - name: Migrate database
+        run: pnpm --filter near-chat-backend migrate:up
+
+      # NODE_ENV=development is load-bearing and is not a sloppy default.
+      # `secureCookies` is derived, not configured — backend/src/config/env.ts
+      # computes `nodeEnv !== 'development' && nodeEnv !== 'test'` — so any
+      # other value marks the refresh cookie Secure, Chromium drops it over
+      # plain HTTP, and every authenticated flow fails. `test` would also work
+      # for the cookie but silences the logs and changes realtime timing
+      # defaults, which is the opposite of what a diagnostic lane wants.
+      #
+      # REDIS_URL is empty on purpose. Redis holds only derived state, so a
+      # single backend instance serves realtime without it; multi-instance
+      # realtime belongs to #540, not here. It must be empty rather than absent:
+      # an unparseable value would be reported and ignored, but a stale one
+      # would produce a reconnect loop.
+      - name: Start backend
+        env:
+          NODE_ENV: development
+          PORT: '4000'
+          JWT_SECRET: ci-fullstack-browser-e2e-secret
+          CORS_ORIGINS: http://127.0.0.1:3000
+          REDIS_URL: ''
+          RATE_LIMIT_DISABLED: 'true'
+        run: |
+          pnpm --filter near-chat-backend start > backend.log 2>&1 &
+          echo "$!" > backend.pid
+
+      # Polls readiness *and* liveness. Waiting on the port alone would spend
+      # the full timeout on a backend that already exited — the acceptance
+      # criterion is that a startup failure fails fast instead of surfacing as a
+      # Playwright timeout minutes later.
+      - name: Wait for backend
+        run: |
+          set -uo pipefail
+          pid="$(cat backend.pid)"
+          for _ in $(seq 1 60); do
+            if ! kill -0 "$pid" 2>/dev/null; then
+              echo "::error::Backend exited during startup"
+              cat backend.log
+              exit 1
+            fi
+            if curl -fsS "$BACKEND_ORIGIN/api/v1/health" >/dev/null 2>&1; then
+              echo "Backend is up"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "::error::Backend did not become healthy within 120s"
+          cat backend.log
+          exit 1
+
+      # Built here rather than inside a Playwright `webServer` block: this lane
+      # starts the servers itself so it can capture their logs and fail fast,
+      # which is why playwright.fullstack.config.ts has no webServer at all. A
+      # build failure also stays a build failure instead of being reported as a
+      # server timeout.
+      #
+      # `next start` warns that it "does not work with output: standalone"
+      # because next.config.ts sets that for the production image. It is a
+      # warning: the server starts and serves normally.
+      - name: Build frontend
+        env:
+          NEXT_PUBLIC_API_URL: http://127.0.0.1:4000
+        run: pnpm --filter near-chat-frontend exec next build
+
+      - name: Start frontend
+        env:
+          NEXT_PUBLIC_API_URL: http://127.0.0.1:4000
+        run: |
+          pnpm --filter near-chat-frontend exec next start --hostname 127.0.0.1 --port 3000 > frontend.log 2>&1 &
+          echo "$!" > frontend.pid
+
+      - name: Wait for frontend
+        run: |
+          set -uo pipefail
+          pid="$(cat frontend.pid)"
+          for _ in $(seq 1 60); do
+            if ! kill -0 "$pid" 2>/dev/null; then
+              echo "::error::Frontend exited during startup"
+              cat frontend.log
+              exit 1
+            fi
+            if curl -fsS "$FRONTEND_ORIGIN/login" >/dev/null 2>&1; then
+              echo "Frontend is up"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "::error::Frontend did not become healthy within 120s"
+          cat frontend.log
+          exit 1
+
+      - name: Run full-stack browser tests
+        run: pnpm --filter near-chat-frontend test:browser:fullstack
+
+      # Only the PIDs this job started. `pkill -f bun` or `pkill node` would
+      # also take out the runner's own tooling.
+      - name: Stop application processes
+        if: always()
+        run: |
+          for pidfile in backend.pid frontend.pid; do
+            [ -f "$pidfile" ] || continue
+            kill "$(cat "$pidfile")" 2>/dev/null || true
+          done
+
+      # Playwright network traces may include the bearer access token and the
+      # HttpOnly refresh cookie in request headers. Keep the traces — they are
+      # essential when diagnosing a browser failure — but make the artifact
+      # safe before it leaves the runner. The standard-library script rewrites
+      # JSON/JSONL trace entries in-place and redacts credential-bearing header
+      # values plus bearer/JWT/cookie text forms. Playwright can copy an archive
+      # into both test-results and the HTML report, so both locations are
+      # rewritten before either is uploaded.
+      - name: Redact credentials from Playwright diagnostics
+        id: redact-playwright-diagnostics
+        if: failure()
+        run: |
+          python3 scripts/redact_playwright_traces.py frontend/test-results-fullstack
+          python3 scripts/redact_playwright_traces.py frontend/playwright-report-fullstack
+
+      # A distinct artifact name from the smoke job's `playwright-report`:
+      # two uploads sharing one name inside a workflow collide.
+      #
+      # The application logs are the point of this upload as much as the report
+      # is — a spec that fails because the backend threw is unreadable from the
+      # Playwright side alone. Raw Playwright diagnostics are redacted in the
+      # prior step; backend logs no request bodies, and every account here is a
+      # disposable fixture created for this run.
+      - name: Upload full-stack diagnostics
+        # A failed redactor is a security event. Do not upload a potentially raw
+        # trace archive; the fallback step below still preserves safe process
+        # logs, so the root cause remains diagnosable.
+        if: failure() && steps.redact-playwright-diagnostics.outcome == 'success'
+        uses: actions/upload-artifact@v5
+        with:
+          name: playwright-fullstack-diagnostics
+          path: |
+            frontend/playwright-report-fullstack/
+            frontend/test-results-fullstack/
+            backend.log
+            frontend.log
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Upload application logs when diagnostic redaction fails
+        if: failure() && steps.redact-playwright-diagnostics.outcome != 'success'
+        uses: actions/upload-artifact@v5
+        with:
+          name: fullstack-application-logs
+          path: |
+            backend.log
+            frontend.log
           retention-days: 7
           if-no-files-found: ignore

--- a/.github/workflows/ci-browser.yml
+++ b/.github/workflows/ci-browser.yml
@@ -14,10 +14,8 @@ name: CI Browser
 # They are separate jobs rather than separate workflows because ci.yml's
 # `required-checks` gate keys off the single `browser` lane: a second job here
 # is covered by that gate automatically, whereas a new workflow would need a new
-# detect output, a new gate entry and a new required status name. Issue #544
-# proposed its own workflow and an earlier version of this comment said the
-# full-stack lane "must land as its own workflow"; that was reversed
-# deliberately, and the isolation it was protecting is preserved by the job
+# detect output, a new gate entry and a new required status name. The isolation
+# issue #544's own-workflow proposal was protecting is preserved by the job
 # boundary — the two share no process, no database and no test command.
 #
 # Keeping them as separate *jobs* still matters: a browser download plus a
@@ -104,12 +102,13 @@ jobs:
       # boundary silently drops the cookie and every session bootstrap bounces
       # to /login.
       DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5433/ntnu_test
-      BACKEND_ORIGIN: http://127.0.0.1:4000
-      FRONTEND_ORIGIN: http://127.0.0.1:3000
-      # Passed to the Playwright config and its manually-created BrowserContext
-      # fixtures. Unlike Playwright Test's `page`/`context` fixtures, a raw
-      # `browser.newContext()` does not inherit `use.baseURL`, so this explicit
-      # value is what makes relative `page.goto('/login')` navigations correct.
+      # One name per origin, shared by the shell health checks and by the specs
+      # (tests-fullstack/support/api.ts reads both, and the Playwright config
+      # takes its baseURL from the frontend one). A raw `browser.newContext()`
+      # does not inherit `use.baseURL` the way the `page`/`context` fixtures do,
+      # so E2E_FRONTEND_ORIGIN is what makes relative `page.goto('/login')`
+      # navigations correct there.
+      E2E_API_ORIGIN: http://127.0.0.1:4000
       E2E_FRONTEND_ORIGIN: http://127.0.0.1:3000
     steps:
       - uses: actions/checkout@v7
@@ -152,36 +151,16 @@ jobs:
           NODE_ENV: development
           PORT: '4000'
           JWT_SECRET: ci-fullstack-browser-e2e-secret
-          CORS_ORIGINS: http://127.0.0.1:3000
+          CORS_ORIGINS: ${{ env.E2E_FRONTEND_ORIGIN }}
           REDIS_URL: ''
           RATE_LIMIT_DISABLED: 'true'
         run: |
           pnpm --filter near-chat-backend start > backend.log 2>&1 &
           echo "$!" > backend.pid
 
-      # Polls readiness *and* liveness. Waiting on the port alone would spend
-      # the full timeout on a backend that already exited — the acceptance
-      # criterion is that a startup failure fails fast instead of surfacing as a
-      # Playwright timeout minutes later.
+      # Liveness-aware health gate; see scripts/wait-for-service.sh.
       - name: Wait for backend
-        run: |
-          set -uo pipefail
-          pid="$(cat backend.pid)"
-          for _ in $(seq 1 60); do
-            if ! kill -0 "$pid" 2>/dev/null; then
-              echo "::error::Backend exited during startup"
-              cat backend.log
-              exit 1
-            fi
-            if curl -fsS "$BACKEND_ORIGIN/api/v1/health" >/dev/null 2>&1; then
-              echo "Backend is up"
-              exit 0
-            fi
-            sleep 2
-          done
-          echo "::error::Backend did not become healthy within 120s"
-          cat backend.log
-          exit 1
+        run: ./scripts/wait-for-service.sh Backend backend.pid "$E2E_API_ORIGIN/api/v1/health" backend.log
 
       # Built here rather than inside a Playwright `webServer` block: this lane
       # starts the servers itself so it can capture their logs and fail fast,
@@ -194,35 +173,18 @@ jobs:
       # warning: the server starts and serves normally.
       - name: Build frontend
         env:
-          NEXT_PUBLIC_API_URL: http://127.0.0.1:4000
+          NEXT_PUBLIC_API_URL: ${{ env.E2E_API_ORIGIN }}
         run: pnpm --filter near-chat-frontend exec next build
 
       - name: Start frontend
         env:
-          NEXT_PUBLIC_API_URL: http://127.0.0.1:4000
+          NEXT_PUBLIC_API_URL: ${{ env.E2E_API_ORIGIN }}
         run: |
           pnpm --filter near-chat-frontend exec next start --hostname 127.0.0.1 --port 3000 > frontend.log 2>&1 &
           echo "$!" > frontend.pid
 
       - name: Wait for frontend
-        run: |
-          set -uo pipefail
-          pid="$(cat frontend.pid)"
-          for _ in $(seq 1 60); do
-            if ! kill -0 "$pid" 2>/dev/null; then
-              echo "::error::Frontend exited during startup"
-              cat frontend.log
-              exit 1
-            fi
-            if curl -fsS "$FRONTEND_ORIGIN/login" >/dev/null 2>&1; then
-              echo "Frontend is up"
-              exit 0
-            fi
-            sleep 2
-          done
-          echo "::error::Frontend did not become healthy within 120s"
-          cat frontend.log
-          exit 1
+        run: ./scripts/wait-for-service.sh Frontend frontend.pid "$E2E_FRONTEND_ORIGIN/login" frontend.log
 
       - name: Run full-stack browser tests
         run: pnpm --filter near-chat-frontend test:browser:fullstack

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,8 +153,21 @@ jobs:
           # lints, typechecks and unit-tests, so it follows that decision rather
           # than carrying a fifth near-identical path list that would drift.
           # This mirrors how the database lane follows backend.
+          #
+          # It follows the BACKEND decision too, which the frontend-only version
+          # of this rule did not. ci-browser.yml gained a full-stack job (issue
+          # #544) that drives a real Bun backend and a real PostgreSQL, so a
+          # backend-only or migration-only change can now break the browser lane
+          # while touching nothing under frontend/. Without this second
+          # condition that change would skip the lane, and `required-checks`
+          # accepts a skip for a lane marked not-required — the regression would
+          # reach main with the gate green.
           if [[ "$EVENT_NAME" == "workflow_dispatch" || "$FRONTEND_CHANGED" == "true" ]]; then
             frontend_required=true
+            browser_required=true
+          fi
+
+          if [[ "$BACKEND_CHANGED" == "true" ]]; then
             browser_required=true
           fi
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -475,7 +475,73 @@ On failure, the HTML report, traces and screenshots land in `frontend/playwright
 pnpm --filter near-chat-frontend exec playwright show-report
 ```
 
-Specs live in `frontend/tests-browser/`, and the shared REST mock is `frontend/tests-browser/support/api-mock.ts`. Full-stack browser E2E against a real backend and Postgres is tracked separately in issue #544 and will get its own lane rather than extending this one.
+Specs live in `frontend/tests-browser/`, and the shared REST mock is
+`frontend/tests-browser/support/api-mock.ts`. The real-stack suite below has a
+separate test directory and config, but runs as the `fullstack-browser-tests` job
+in the existing `.github/workflows/ci-browser.yml` workflow.
+
+### Running Full-Stack Browser Tests
+
+The full-stack suite does not mock application APIs. Chromium drives a
+production Next.js build, fixtures create prerequisite data through the real
+REST API, and assertions cross the Bun backend, PostgreSQL and Socket.IO. Because
+`playwright.fullstack.config.ts` intentionally has no `webServer`, start the
+database and both application processes before running the suite.
+
+Run all commands from the repository root. Install Chromium once per machine,
+then start the ephemeral `db-test` service and apply migrations:
+
+```bash
+pnpm --filter near-chat-frontend exec playwright install chromium
+pnpm --filter near-chat-backend test:db:up
+```
+
+In **terminal A**, start the backend on port 4000:
+
+```bash
+DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5436/ntnu_test \
+NODE_ENV=development \
+PORT=4000 \
+JWT_SECRET=local-fullstack-browser-e2e-secret \
+CORS_ORIGINS=http://127.0.0.1:3000 \
+REDIS_URL='' \
+RATE_LIMIT_DISABLED=true \
+pnpm --filter near-chat-backend start
+```
+
+In **terminal B**, build and start the production frontend on port 3000:
+
+```bash
+NEXT_PUBLIC_API_URL=http://127.0.0.1:4000 \
+pnpm --filter near-chat-frontend exec next build
+
+NEXT_PUBLIC_API_URL=http://127.0.0.1:4000 \
+pnpm --filter near-chat-frontend exec next start --hostname 127.0.0.1 --port 3000
+```
+
+After both servers are ready, run the suite in **terminal C**:
+
+```bash
+E2E_FRONTEND_ORIGIN=http://127.0.0.1:3000 \
+E2E_API_ORIGIN=http://127.0.0.1:4000 \
+CI=1 \
+pnpm --filter near-chat-frontend test:browser:fullstack
+```
+
+Keep `127.0.0.1` consistent across all three terminals: the refresh cookie is
+`SameSite=Strict`, so mixing it with `localhost` breaks session bootstrap.
+`NODE_ENV=development` keeps the refresh cookie usable over local HTTP, and the
+empty `REDIS_URL` is intentional for this single-backend topology.
+
+Stop the backend and frontend with `Ctrl+C`, then remove only the ephemeral test
+database (the development database is unaffected):
+
+```bash
+pnpm --filter near-chat-backend test:db:down
+```
+
+On failure, diagnostics land in `frontend/playwright-report-fullstack/` and
+`frontend/test-results-fullstack/`.
 
 ### Running Unit Tests
 Unit tests do not require a database connection.

--- a/docs/ZH-TW/DEVELOPMENT.md
+++ b/docs/ZH-TW/DEVELOPMENT.md
@@ -433,7 +433,71 @@ pnpm --filter near-chat-frontend test:browser
 pnpm --filter near-chat-frontend exec playwright show-report
 ```
 
-測試檔案位於 `frontend/tests-browser/`，共用的 REST mock 為 `frontend/tests-browser/support/api-mock.ts`。串接真實後端與 Postgres 的 full-stack 瀏覽器 E2E 由 Issue #544 另行追蹤，屆時會建立獨立 lane，而不是擴張這條 lane 的責任。
+測試檔案位於 `frontend/tests-browser/`，共用的 REST mock 為
+`frontend/tests-browser/support/api-mock.ts`。下方的真實環境測試使用獨立的
+test directory 與 config，但會以 `fullstack-browser-tests` job 擴增既有的
+`.github/workflows/ci-browser.yml` workflow。
+
+### 執行 Full-Stack 瀏覽器測試
+
+Full-stack 測試不會 mock application API。Chromium 會操作 production Next.js
+build，fixture 透過真實 REST API 建立前置資料，而 assertion 會完整經過 Bun
+backend、PostgreSQL 與 Socket.IO。`playwright.fullstack.config.ts` 刻意不設定
+`webServer`，因此執行測試前必須先啟動資料庫與兩個 application process。
+
+以下命令都從 repository root 執行。每台機器只需安裝一次 Chromium，接著啟動
+臨時的 `db-test` service 並套用 migrations：
+
+```bash
+pnpm --filter near-chat-frontend exec playwright install chromium
+pnpm --filter near-chat-backend test:db:up
+```
+
+在 **terminal A** 啟動 port 4000 的 backend：
+
+```bash
+DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5436/ntnu_test \
+NODE_ENV=development \
+PORT=4000 \
+JWT_SECRET=local-fullstack-browser-e2e-secret \
+CORS_ORIGINS=http://127.0.0.1:3000 \
+REDIS_URL='' \
+RATE_LIMIT_DISABLED=true \
+pnpm --filter near-chat-backend start
+```
+
+在 **terminal B** build 並啟動 port 3000 的 production frontend：
+
+```bash
+NEXT_PUBLIC_API_URL=http://127.0.0.1:4000 \
+pnpm --filter near-chat-frontend exec next build
+
+NEXT_PUBLIC_API_URL=http://127.0.0.1:4000 \
+pnpm --filter near-chat-frontend exec next start --hostname 127.0.0.1 --port 3000
+```
+
+兩個 server 都 ready 後，在 **terminal C** 執行測試：
+
+```bash
+E2E_FRONTEND_ORIGIN=http://127.0.0.1:3000 \
+E2E_API_ORIGIN=http://127.0.0.1:4000 \
+CI=1 \
+pnpm --filter near-chat-frontend test:browser:fullstack
+```
+
+三個 terminal 都必須一致使用 `127.0.0.1`：refresh cookie 設為
+`SameSite=Strict`，若與 `localhost` 混用會使 session bootstrap 失敗。
+`NODE_ENV=development` 讓 refresh cookie 可在本機 HTTP 使用，而空的
+`REDIS_URL` 是此單一 backend topology 的刻意設定。
+
+使用 `Ctrl+C` 停止 backend 與 frontend 後，移除臨時測試資料庫；開發資料庫不受影響：
+
+```bash
+pnpm --filter near-chat-backend test:db:down
+```
+
+測試失敗時，diagnostics 會產生在 `frontend/playwright-report-fullstack/` 與
+`frontend/test-results-fullstack/`。
 
 ### 執行單元測試
 單元測試不需要資料庫連線。

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -46,6 +46,8 @@ next-env.d.ts
 
 # playwright browser lane output (report, traces, screenshots, videos)
 /playwright-report/
+/playwright-report-fullstack/
 /test-results/
+/test-results-fullstack/
 /blob-report/
 /playwright/.cache/

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:browser": "playwright test",
+    "test:browser:fullstack": "playwright test -c playwright.fullstack.config.ts",
     "analyze": "next experimental-analyze --output"
   },
   "dependencies": {

--- a/frontend/playwright.fullstack.config.ts
+++ b/frontend/playwright.fullstack.config.ts
@@ -73,5 +73,5 @@ export default defineConfig({
   // minutes later. Startup, health-gating and log capture are the workflow's
   // job — see the `fullstack-browser-tests` job in
   // .github/workflows/ci-browser.yml, and the local recipe in
-  // tests-fullstack/README.md.
+  // ../docs/DEVELOPMENT.md#running-full-stack-browser-tests.
 });

--- a/frontend/playwright.fullstack.config.ts
+++ b/frontend/playwright.fullstack.config.ts
@@ -1,0 +1,77 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Full-stack browser E2E (issue #544).
+ *
+ * Separate from playwright.config.ts, which is the frontend-only smoke lane
+ * (#543): that config's suite installs `tests-browser/support/api-mock.ts`,
+ * which fulfils every `/api/v1/**` call in the browser and aborts the Socket.IO
+ * handshake outright. Pointing this lane at that config would produce a suite
+ * that passes without ever reaching a backend — the exact failure this lane
+ * exists to rule out. The two share no testDir and no setup file, so a spec
+ * cannot be collected by both.
+ *
+ * The entry point is always Chromium driving the real frontend, which then
+ * talks to a real Bun backend and a real PostgreSQL over real HTTP and a real
+ * Socket.IO connection. Fixtures may create prerequisite data through the
+ * public REST API (see `tests-fullstack/support/api.ts`), but every acceptance
+ * assertion is made against what the browser ends up showing.
+ */
+
+// Load-bearing, not a default, and it must stay in sync with the backend's
+// CORS_ORIGINS and with PORT below. `getApiBaseUrl()` in src/lib/api.ts
+// branches on `window.location.port`: served on 3000 it resolves the API origin
+// to `<protocol>//<hostname>:4000`. Serving the app anywhere else silently
+// repoints every REST call and the Socket.IO handshake.
+//
+// The host is `127.0.0.1` rather than `localhost` on purpose, and both servers
+// must agree on it. The refresh cookie is `SameSite=Strict` (backend
+// src/utils/cookies.ts), so mixing the two spellings across the 3000/4000
+// boundary would drop it and the session bootstrap would bounce to /login.
+const PORT = 3000;
+const BASE_URL = process.env.E2E_FRONTEND_ORIGIN ?? `http://127.0.0.1:${PORT}`;
+
+const isCI = !!process.env.CI;
+
+export default defineConfig({
+  testDir: "./tests-fullstack",
+  testMatch: "**/*.spec.ts",
+  fullyParallel: false,
+  forbidOnly: isCI,
+  retries: isCI ? 1 : 0,
+  // Phase 1 stays single-worker deliberately. These specs register users and
+  // exchange messages against one shared PostgreSQL, and parallel workers would
+  // race on realtime delivery long before wall-clock became the constraint.
+  workers: 1,
+  // Generous relative to the smoke lane: an assertion here can be waiting on a
+  // round trip through Next.js, Hono, PostgreSQL and a Socket.IO broadcast.
+  timeout: 60_000,
+  expect: { timeout: 15_000 },
+  reporter: [["list"], ["html", { open: "never", outputFolder: "playwright-report-fullstack" }]],
+  outputDir: "test-results-fullstack",
+  use: {
+    baseURL: BASE_URL,
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+    // Same reason as the smoke lane: this runs a production build, where
+    // `ServiceWorkerRegistration` actually registers and would start serving
+    // navigations and `/_next/static` from its own cache. PWA behaviour is not
+    // what this lane is measuring.
+    serviceWorkers: "block",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  // No `webServer` block, unlike the smoke lane. This suite needs a backend and
+  // a database up *before* the frontend is worth starting, and it needs both
+  // processes' logs when something dies. Playwright's webServer can express
+  // neither: it would surface a crashed backend as an unrelated test timeout
+  // minutes later. Startup, health-gating and log capture are the workflow's
+  // job — see the `fullstack-browser-tests` job in
+  // .github/workflows/ci-browser.yml, and the local recipe in
+  // tests-fullstack/README.md.
+});

--- a/frontend/playwright.fullstack.config.ts
+++ b/frontend/playwright.fullstack.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, devices } from "@playwright/test";
+import { FRONTEND_ORIGIN } from "./tests-fullstack/support/api";
 
 /**
  * Full-stack browser E2E (issue #544).
@@ -18,19 +19,9 @@ import { defineConfig, devices } from "@playwright/test";
  * assertion is made against what the browser ends up showing.
  */
 
-// Load-bearing, not a default, and it must stay in sync with the backend's
-// CORS_ORIGINS and with PORT below. `getApiBaseUrl()` in src/lib/api.ts
-// branches on `window.location.port`: served on 3000 it resolves the API origin
-// to `<protocol>//<hostname>:4000`. Serving the app anywhere else silently
-// repoints every REST call and the Socket.IO handshake.
-//
-// The host is `127.0.0.1` rather than `localhost` on purpose, and both servers
-// must agree on it. The refresh cookie is `SameSite=Strict` (backend
-// src/utils/cookies.ts), so mixing the two spellings across the 3000/4000
-// boundary would drop it and the session bootstrap would bounce to /login.
-const PORT = 3000;
-const BASE_URL = process.env.E2E_FRONTEND_ORIGIN ?? `http://127.0.0.1:${PORT}`;
-
+// `FRONTEND_ORIGIN` is defined once in tests-fullstack/support/api.ts, which
+// documents why its host and port are load-bearing, and is imported here so the
+// suite's `baseURL` and its manually-created BrowserContexts cannot drift apart.
 const isCI = !!process.env.CI;
 
 export default defineConfig({
@@ -50,7 +41,7 @@ export default defineConfig({
   reporter: [["list"], ["html", { open: "never", outputFolder: "playwright-report-fullstack" }]],
   outputDir: "test-results-fullstack",
   use: {
-    baseURL: BASE_URL,
+    baseURL: FRONTEND_ORIGIN,
     trace: "retain-on-failure",
     screenshot: "only-on-failure",
     video: "retain-on-failure",

--- a/frontend/tests-fullstack/auth.spec.ts
+++ b/frontend/tests-fullstack/auth.spec.ts
@@ -1,0 +1,84 @@
+import { expect, test } from "@playwright/test";
+import { randomUUID } from "node:crypto";
+import { TEST_PASSWORD } from "./support/api";
+
+/**
+ * Flow A — authentication lifecycle against the real stack (issue #544).
+ *
+ * Register → signed-in app → logout → protected route refuses → login again.
+ *
+ * Every step here goes through the real `/api/v1/auth/*` routes, a real
+ * PostgreSQL row and the real refresh cookie. That is what separates it from
+ * the #543 smoke suite, which asserts the same screens with every response
+ * fulfilled in-browser: this spec fails if password hashing, the refresh
+ * cookie, token rotation or the session bootstrap is broken, and that one
+ * cannot.
+ */
+
+test.describe("authentication lifecycle", () => {
+  test("registers, logs out, is locked out, and logs back in", async ({ page }) => {
+    // Unique per run: the acceptance criteria forbid depending on seeded
+    // accounts or on a previous run's leftovers.
+    const email = `e2e-auth-${randomUUID()}@test.local`;
+    const name = "E2E Auth";
+
+    await test.step("register through the real API", async () => {
+      await page.goto("/register");
+
+      // Placeholders rather than labels: `Input` renders its `<label>` as a
+      // plain sibling with no `htmlFor`, so there is no accessible-name
+      // association to query. Same constraint the #543 spec documents.
+      await page.getByPlaceholder("Display name").fill(name);
+      await page.getByPlaceholder("your email").fill(email);
+      await page.getByPlaceholder("your password").fill(TEST_PASSWORD);
+      await page.getByPlaceholder("Repeat password").fill(TEST_PASSWORD);
+      await page.getByRole("button", { name: "Create account" }).click();
+
+      await expect(page).toHaveURL("/");
+    });
+
+    await test.step("land in the signed-in application", async () => {
+      // The sidebar only renders once `(main)/layout` has finished its
+      // bootstrap — profile, settings, rooms and folders all fetched from the
+      // backend. Asserting on the email proves the round trip really returned
+      // this account rather than a cached or mocked one.
+      await expect(page.getByText(email)).toBeVisible();
+
+      // Written by the bootstrap from the real `/users/me` response, not by
+      // the register handler's optimistic write.
+      const stored = await page.evaluate(() => window.localStorage.getItem("user"));
+      expect(stored).not.toBeNull();
+      expect(JSON.parse(stored as string)).toMatchObject({ email });
+    });
+
+    await test.step("log out", async () => {
+      // `aria-label` comes from `t("sidebar.logout")`. The language settles on
+      // English because `lang_preference` defaults to 'en' in the initial
+      // migration and the bootstrap applies the value it just fetched.
+      await page.getByRole("button", { name: "Logout" }).click();
+
+      await expect(page).toHaveURL("/login");
+      expect(await page.evaluate(() => window.localStorage.getItem("user"))).toBeNull();
+    });
+
+    await test.step("refuse the protected route once logged out", async () => {
+      // The real proof that the *server* ended the session, not just the tab:
+      // `/` re-runs the bootstrap, which has no access token and falls back to
+      // the refresh cookie. That cookie was revoked by `/auth/logout`, so the
+      // refresh is rejected and the app is bounced back to /login.
+      await page.goto("/");
+
+      await expect(page).toHaveURL(/\/login/);
+      await expect(page.getByRole("button", { name: "Sign In" })).toBeVisible();
+    });
+
+    await test.step("log back in with the same credentials", async () => {
+      await page.getByPlaceholder("your email").fill(email);
+      await page.getByPlaceholder("your password").fill(TEST_PASSWORD);
+      await page.getByRole("button", { name: "Sign In" }).click();
+
+      await expect(page).toHaveURL("/");
+      await expect(page.getByText(email)).toBeVisible();
+    });
+  });
+});

--- a/frontend/tests-fullstack/auth.spec.ts
+++ b/frontend/tests-fullstack/auth.spec.ts
@@ -55,8 +55,17 @@ test.describe("authentication lifecycle", () => {
       // `aria-label` comes from `t("sidebar.logout")`. The language settles on
       // English because `lang_preference` defaults to 'en' in the initial
       // migration and the bootstrap applies the value it just fetched.
+      const logoutResponse = page.waitForResponse(
+        (response) =>
+          new URL(response.url()).pathname === "/api/v1/auth/logout" &&
+          response.request().method() === "POST",
+      );
       await page.getByRole("button", { name: "Logout" }).click();
 
+      // ChatContext intentionally navigates immediately after starting this
+      // request. Wait for the real backend response so the next navigation
+      // cannot race refresh-token revocation (or cancel an in-flight logout).
+      expect((await logoutResponse).status()).toBe(204);
       await expect(page).toHaveURL("/login");
       expect(await page.evaluate(() => window.localStorage.getItem("user"))).toBeNull();
     });

--- a/frontend/tests-fullstack/private-chat.spec.ts
+++ b/frontend/tests-fullstack/private-chat.spec.ts
@@ -42,7 +42,6 @@ test.describe("two-user private chat", () => {
     // prove nothing about two participants.
     const aliceContext = await newIsolatedContext(browser);
     const bobContext = await newIsolatedContext(browser);
-    let testFailed = false;
 
     try {
       const alicePage = await aliceContext.newPage();
@@ -110,12 +109,14 @@ test.describe("two-user private chat", () => {
         await expect(messageBubble(bobPage, messageText)).toBeVisible();
       });
     } catch (error) {
-      testFailed = true;
+      // These contexts come from `browser.newContext()`, which Playwright's
+      // worker-scoped `browser` fixture does not photograph on failure the way
+      // it does the `page` fixture. Capture here, where the failure is known,
+      // rather than in `finally` behind a flag.
+      await attachScreenshots(aliceContext, "alice", testInfo);
+      await attachScreenshots(bobContext, "bob", testInfo);
       throw error;
     } finally {
-      await attachFailureScreenshots(aliceContext, "alice", testInfo, testFailed);
-      await attachFailureScreenshots(bobContext, "bob", testInfo, testFailed);
-
       // Closed even when an assertion above fails, so a red test does not leak
       // two browser contexts into the rest of the run.
       await aliceContext.close();
@@ -149,14 +150,11 @@ const waitForInitialRealtimeSync = async (page: import("@playwright/test").Page)
 };
 
 /** Attach every still-open page before raw contexts bypass fixture teardown. */
-const attachFailureScreenshots = async (
+const attachScreenshots = async (
   context: BrowserContext,
   participant: string,
   testInfo: TestInfo,
-  testFailed: boolean,
 ): Promise<void> => {
-  if (!testFailed) return;
-
   for (const [index, page] of context.pages().entries()) {
     try {
       await testInfo.attach(`${participant}-page-${index + 1}`, {

--- a/frontend/tests-fullstack/private-chat.spec.ts
+++ b/frontend/tests-fullstack/private-chat.spec.ts
@@ -48,16 +48,24 @@ test.describe("two-user private chat", () => {
       const bobPage = await bobContext.newPage();
 
       await test.step("both users sign in and open the private room", async () => {
+        // `realtime_ready` starts the initial durable `/sync`. Register these
+        // waiters before login so a fast socket cannot finish its sync before
+        // the test starts observing responses. A visible composer alone is not
+        // enough: it can render before the socket has joined its room channels.
+        const aliceRealtimeReady = waitForInitialRealtimeSync(alicePage);
+        const bobRealtimeReady = waitForInitialRealtimeSync(bobPage);
+
         await signInThroughUi(alicePage, alice);
         await signInThroughUi(bobPage, bob);
+
+        await aliceRealtimeReady;
+        await bobRealtimeReady;
 
         await alicePage.goto(`/chat/${roomId}`);
         await bobPage.goto(`/chat/${roomId}`);
 
-        // Gate on the composer existing in both browsers. Without this, Alice
-        // could send before Bob's Socket.IO connection has been established,
-        // and the message would only ever arrive on a later fetch — the test
-        // would then be measuring history loading, not realtime delivery.
+        // The sync gates above prove both realtime sessions are ready; these
+        // assertions additionally prove both room pages are usable.
         await expect(alicePage.getByPlaceholder("Type a message...")).toBeVisible();
         await expect(bobPage.getByPlaceholder("Type a message...")).toBeVisible();
       });
@@ -122,3 +130,13 @@ test.describe("two-user private chat", () => {
  */
 const messageBubble = (page: import("@playwright/test").Page, text: string) =>
   page.locator("[data-msg-id]").filter({ hasText: text });
+
+/** Wait for the initial sync that the app starts after `realtime_ready`. */
+const waitForInitialRealtimeSync = async (page: import("@playwright/test").Page): Promise<void> => {
+  const response = await page.waitForResponse(
+    (candidate) =>
+      new URL(candidate.url()).pathname === "/api/v1/sync" &&
+      candidate.request().method() === "GET",
+  );
+  expect(response.ok(), `initial realtime sync returned ${response.status()}`).toBeTruthy();
+};

--- a/frontend/tests-fullstack/private-chat.spec.ts
+++ b/frontend/tests-fullstack/private-chat.spec.ts
@@ -1,0 +1,124 @@
+import { expect, test } from "@playwright/test";
+import { randomUUID } from "node:crypto";
+import {
+  createPrivateRoom,
+  makeFriends,
+  newIsolatedContext,
+  registerUser,
+  signInThroughUi,
+} from "./support/api";
+
+/**
+ * Flow B — two-user private chat over the real stack (issue #544).
+ *
+ * User A types a message in a real browser; User B, in a separate browser with
+ * its own cookie jar and its own `localStorage`, sees it appear without
+ * reloading. That single assertion spans the whole system: Chromium → Next.js →
+ * Hono/Bun → PostgreSQL → Socket.IO → back to a second Chromium.
+ *
+ * Scope discipline, per the issue: this asserts only what the receiving browser
+ * ends up showing. No Socket.IO event name, no event ordering, no service or
+ * repository call is referenced, so the reliability work in #282 / #540 can
+ * change the transport freely without touching this spec — as long as the
+ * user-visible contract holds.
+ */
+
+test.describe("two-user private chat", () => {
+  test("delivers a message to the other user's browser without a reload", async ({
+    browser,
+    request,
+  }) => {
+    // Prerequisite data through the public REST API. Allowed by the issue as a
+    // fixture, and deliberate: driving the friends panel through search →
+    // request → accept inside a realtime test would make a friends-UI
+    // regression and a realtime regression report identically.
+    const alice = await registerUser(request, "alice");
+    const bob = await registerUser(request, "bob");
+    await makeFriends(request, alice, bob);
+    const roomId = await createPrivateRoom(request, alice, bob);
+
+    // Two contexts, not two pages. Pages in one context share cookies and
+    // `localStorage`, so Bob would inherit Alice's session and the test would
+    // prove nothing about two participants.
+    const aliceContext = await newIsolatedContext(browser);
+    const bobContext = await newIsolatedContext(browser);
+
+    try {
+      const alicePage = await aliceContext.newPage();
+      const bobPage = await bobContext.newPage();
+
+      await test.step("both users sign in and open the private room", async () => {
+        await signInThroughUi(alicePage, alice);
+        await signInThroughUi(bobPage, bob);
+
+        await alicePage.goto(`/chat/${roomId}`);
+        await bobPage.goto(`/chat/${roomId}`);
+
+        // Gate on the composer existing in both browsers. Without this, Alice
+        // could send before Bob's Socket.IO connection has been established,
+        // and the message would only ever arrive on a later fetch — the test
+        // would then be measuring history loading, not realtime delivery.
+        await expect(alicePage.getByPlaceholder("Type a message...")).toBeVisible();
+        await expect(bobPage.getByPlaceholder("Type a message...")).toBeVisible();
+      });
+
+      // Unique per run, so a match cannot come from a previous run's row or
+      // from the other spec's traffic.
+      const messageText = `hello from alice ${randomUUID()}`;
+
+      await test.step("alice sends a message from her browser", async () => {
+        await alicePage.getByPlaceholder("Type a message...").fill(messageText);
+        await alicePage.getByRole("button", { name: "Send" }).click();
+
+        await expect(messageBubble(alicePage, messageText)).toBeVisible();
+      });
+
+      await test.step("bob sees it without reloading", async () => {
+        // No `reload()` anywhere in this step on purpose: the page has been
+        // sitting open since before the message existed, so the only way the
+        // text can appear is a live push to Bob's browser.
+        await expect(messageBubble(bobPage, messageText)).toBeVisible();
+      });
+
+      await test.step("bob replies and alice receives it", async () => {
+        // The reverse direction, so a one-way subscription bug cannot pass.
+        const replyText = `hello back from bob ${randomUUID()}`;
+
+        await bobPage.getByPlaceholder("Type a message...").fill(replyText);
+        await bobPage.getByRole("button", { name: "Send" }).click();
+
+        await expect(messageBubble(alicePage, replyText)).toBeVisible();
+      });
+
+      await test.step("the message survives a reload", async () => {
+        // Realtime delivery alone could be satisfied by a broadcast that was
+        // never committed. Reloading discards all in-memory state and forces
+        // Bob's client to refetch the conversation from PostgreSQL, so this is
+        // the browser-observable proof that the write is durable — without
+        // reaching into the database or naming a repository.
+        await bobPage.reload();
+
+        await expect(messageBubble(bobPage, messageText)).toBeVisible();
+      });
+    } finally {
+      // Closed even when an assertion above fails, so a red test does not leak
+      // two browser contexts into the rest of the run.
+      await aliceContext.close();
+      await bobContext.close();
+    }
+  });
+});
+
+/**
+ * Locate a message inside the conversation.
+ *
+ * Scoped to `[data-msg-id]` — the attribute `MessageRow` puts on every rendered
+ * message — rather than a bare `getByText`. The sidebar renders the same text
+ * again as each room's last-message preview, so an unscoped locator matches two
+ * elements and fails Playwright's strict mode. Resolving that with `.first()`
+ * would be worse than the strict-mode error: it would keep passing if the
+ * conversation stopped rendering the message entirely and only the preview
+ * remained.
+ */
+const messageBubble = (page: import("@playwright/test").Page, text: string) =>
+  page.locator("[data-msg-id]").filter({ hasText: text });

--- a/frontend/tests-fullstack/private-chat.spec.ts
+++ b/frontend/tests-fullstack/private-chat.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type BrowserContext, type TestInfo } from "@playwright/test";
 import { randomUUID } from "node:crypto";
 import {
   createPrivateRoom,
@@ -27,7 +27,7 @@ test.describe("two-user private chat", () => {
   test("delivers a message to the other user's browser without a reload", async ({
     browser,
     request,
-  }) => {
+  }, testInfo) => {
     // Prerequisite data through the public REST API. Allowed by the issue as a
     // fixture, and deliberate: driving the friends panel through search →
     // request → accept inside a realtime test would make a friends-UI
@@ -42,6 +42,7 @@ test.describe("two-user private chat", () => {
     // prove nothing about two participants.
     const aliceContext = await newIsolatedContext(browser);
     const bobContext = await newIsolatedContext(browser);
+    let testFailed = false;
 
     try {
       const alicePage = await aliceContext.newPage();
@@ -108,7 +109,13 @@ test.describe("two-user private chat", () => {
 
         await expect(messageBubble(bobPage, messageText)).toBeVisible();
       });
+    } catch (error) {
+      testFailed = true;
+      throw error;
     } finally {
+      await attachFailureScreenshots(aliceContext, "alice", testInfo, testFailed);
+      await attachFailureScreenshots(bobContext, "bob", testInfo, testFailed);
+
       // Closed even when an assertion above fails, so a red test does not leak
       // two browser contexts into the rest of the run.
       await aliceContext.close();
@@ -139,4 +146,30 @@ const waitForInitialRealtimeSync = async (page: import("@playwright/test").Page)
       candidate.request().method() === "GET",
   );
   expect(response.ok(), `initial realtime sync returned ${response.status()}`).toBeTruthy();
+};
+
+/** Attach every still-open page before raw contexts bypass fixture teardown. */
+const attachFailureScreenshots = async (
+  context: BrowserContext,
+  participant: string,
+  testInfo: TestInfo,
+  testFailed: boolean,
+): Promise<void> => {
+  if (!testFailed) return;
+
+  for (const [index, page] of context.pages().entries()) {
+    try {
+      await testInfo.attach(`${participant}-page-${index + 1}`, {
+        body: await page.screenshot({ fullPage: true }),
+        contentType: "image/png",
+      });
+    } catch (error) {
+      // Diagnostics must never replace the original assertion failure, but a
+      // capture failure must remain visible rather than disappearing silently.
+      testInfo.annotations.push({
+        type: "diagnostic-error",
+        description: `${participant} screenshot failed: ${String(error)}`,
+      });
+    }
+  }
 };

--- a/frontend/tests-fullstack/support/api.ts
+++ b/frontend/tests-fullstack/support/api.ts
@@ -151,7 +151,9 @@ export const createPrivateRoom = async (
  * session and the test would prove nothing about two real participants.
  */
 export const newIsolatedContext = async (browser: Browser): Promise<BrowserContext> =>
-  browser.newContext({ baseURL: FRONTEND_ORIGIN });
+  // Raw contexts do not inherit Playwright Test's `use` options. Keep PWA
+  // caching out of this realtime lane just as the config does for fixtures.
+  browser.newContext({ baseURL: FRONTEND_ORIGIN, serviceWorkers: "block" });
 
 /**
  * Sign in through the real login form and wait until the app is usable.

--- a/frontend/tests-fullstack/support/api.ts
+++ b/frontend/tests-fullstack/support/api.ts
@@ -1,0 +1,181 @@
+import { expect, type APIRequestContext, type Browser, type BrowserContext } from "@playwright/test";
+import { randomUUID } from "node:crypto";
+
+/**
+ * Real-API fixtures for the full-stack browser lane (issue #544).
+ *
+ * The opposite of `tests-browser/support/api-mock.ts`: nothing here is faked.
+ * These helpers speak to the same Bun backend and PostgreSQL the browser is
+ * about to speak to, over the same REST contract, and exist only to put
+ * prerequisite rows in place. Every acceptance assertion belongs in the spec,
+ * against what the browser renders.
+ *
+ * What may live here: registering a user, making two users friends, opening a
+ * private room. What may not: anything the spec is meant to prove. Driving the
+ * friend-request UI through four tab switches inside a test whose subject is
+ * realtime delivery would make a realtime failure and a friends-panel failure
+ * indistinguishable.
+ */
+
+/**
+ * Where the backend listens.
+ *
+ * Must agree with the frontend origin's host spelling: the refresh cookie is
+ * `SameSite=Strict` (backend src/utils/cookies.ts), and `127.0.0.1` and
+ * `localhost` are different hosts to Chromium, so mixing them across the
+ * 3000/4000 boundary silently drops the cookie and the session bootstrap
+ * bounces to /login.
+ */
+export const API_ORIGIN = process.env.E2E_API_ORIGIN ?? "http://127.0.0.1:4000";
+
+/** Where Chromium reaches the real Next.js frontend. */
+export const FRONTEND_ORIGIN = process.env.E2E_FRONTEND_ORIGIN ?? "http://127.0.0.1:3000";
+
+const apiUrl = (path: string): string => `${API_ORIGIN}/api/v1${path}`;
+
+/** Long enough to satisfy the backend's 8-character minimum (userSchemas.ts). */
+export const TEST_PASSWORD = "password123";
+
+export interface TestUser {
+  userId: string;
+  name: string;
+  email: string;
+  password: string;
+  /** Access token from the registration response, for further fixture calls. */
+  token: string;
+}
+
+/**
+ * A fresh identity per call.
+ *
+ * Random rather than sequential or timestamped: the acceptance criteria require
+ * specs to be independent of execution order and of any previous run's data,
+ * and a UUID keeps that true even if this suite is ever run twice against one
+ * database.
+ */
+const uniqueEmail = (label: string): string => `e2e-${label}-${randomUUID()}@test.local`;
+
+/**
+ * Assert a fixture call succeeded, loudly.
+ *
+ * Without this a failed prerequisite surfaces much later as an empty room list
+ * or a missing message, and the spec reports a realtime failure that never
+ * happened. `response.text()` is included because the backend's error handler
+ * returns a JSON body explaining the refusal.
+ */
+const expectOk = async (
+  response: Awaited<ReturnType<APIRequestContext["post"]>>,
+  what: string,
+): Promise<void> => {
+  if (!response.ok()) {
+    throw new Error(
+      `Fixture setup failed: ${what} returned ${response.status()} ${response.statusText()}\n${await response.text()}`,
+    );
+  }
+};
+
+/** Register a brand-new user through the real auth route. */
+export const registerUser = async (
+  request: APIRequestContext,
+  label: string,
+): Promise<TestUser> => {
+  const email = uniqueEmail(label);
+  const name = `E2E ${label}`;
+
+  const response = await request.post(apiUrl("/auth/register"), {
+    data: { email, name, password: TEST_PASSWORD },
+  });
+  await expectOk(response, `register ${email}`);
+
+  const body = (await response.json()) as { token: string; user: { userId: string } };
+
+  return { userId: body.user.userId, name, email, password: TEST_PASSWORD, token: body.token };
+};
+
+const authHeaders = (token: string) => ({ Authorization: `Bearer ${token}` });
+
+/**
+ * Make two users friends.
+ *
+ * Two calls because that is genuinely the contract: the addressee decides. The
+ * PATCH is keyed by the *requester's* user id, not by a separate request id —
+ * see `makeFriendRequestRoutes` in backend/src/routes/friendRoutes.ts, which
+ * reads `:id` as the counterpart user.
+ */
+export const makeFriends = async (
+  request: APIRequestContext,
+  requester: TestUser,
+  addressee: TestUser,
+): Promise<void> => {
+  const sent = await request.post(apiUrl("/friend-requests"), {
+    headers: authHeaders(requester.token),
+    data: { targetUserId: addressee.userId },
+  });
+  await expectOk(sent, `friend request ${requester.email} -> ${addressee.email}`);
+
+  const accepted = await request.patch(apiUrl(`/friend-requests/${requester.userId}`), {
+    headers: authHeaders(addressee.token),
+    data: { status: "accepted" },
+  });
+  await expectOk(accepted, `accept friend request from ${requester.email}`);
+};
+
+/**
+ * Open the private room between two users and return its id.
+ *
+ * `roomService.createPrivate` refuses with 403 unless the two are already
+ * friends, so `makeFriends` has to have run first. The route answers 201 for a
+ * newly created room and 200 when one already existed; both are success.
+ */
+export const createPrivateRoom = async (
+  request: APIRequestContext,
+  creator: TestUser,
+  target: TestUser,
+): Promise<string> => {
+  const response = await request.post(apiUrl("/rooms"), {
+    headers: authHeaders(creator.token),
+    data: { type: "private", targetUserId: target.userId },
+  });
+  await expectOk(response, `create private room ${creator.email} <-> ${target.email}`);
+
+  const room = (await response.json()) as { roomId: string };
+  expect(room.roomId, "private room response carries a roomId").toBeTruthy();
+  return room.roomId;
+};
+
+/**
+ * A browser context with its own cookie jar and its own `localStorage`.
+ *
+ * The two-user spec needs this rather than two pages: pages in one context
+ * share both, so User B would inherit User A's refresh cookie and stored
+ * session and the test would prove nothing about two real participants.
+ */
+export const newIsolatedContext = async (browser: Browser): Promise<BrowserContext> =>
+  browser.newContext({ baseURL: FRONTEND_ORIGIN });
+
+/**
+ * Sign in through the real login form and wait until the app is usable.
+ *
+ * Deliberately the UI and not an injected token: the acceptance criteria put
+ * the entry point in the browser, and this path is what exercises the refresh
+ * cookie and the `ChatContext` session bootstrap that everything else depends
+ * on. Waiting on the sidebar rather than on the URL matters — `(main)/layout`
+ * renders a loading state until the bootstrap has fetched profile, settings and
+ * rooms, and a spec that starts typing before that has finished races it.
+ */
+export const signInThroughUi = async (
+  page: import("@playwright/test").Page,
+  user: TestUser,
+): Promise<void> => {
+  await page.goto("/login");
+
+  // Placeholders, not labels: `Input` renders its `<label>` as a plain sibling
+  // with no `htmlFor`, so there is no accessible-name association to query.
+  // Same constraint the #543 smoke spec documents.
+  await page.getByPlaceholder("your email").fill(user.email);
+  await page.getByPlaceholder("your password").fill(user.password);
+  await page.getByRole("button", { name: "Sign In" }).click();
+
+  await expect(page).toHaveURL("/");
+  await expect(page.getByText(user.email)).toBeVisible();
+};

--- a/frontend/tests-fullstack/support/api.ts
+++ b/frontend/tests-fullstack/support/api.ts
@@ -28,7 +28,17 @@ import { randomUUID } from "node:crypto";
  */
 export const API_ORIGIN = process.env.E2E_API_ORIGIN ?? "http://127.0.0.1:4000";
 
-/** Where Chromium reaches the real Next.js frontend. */
+/**
+ * Where Chromium reaches the real Next.js frontend, and the suite's `baseURL`
+ * (playwright.fullstack.config.ts imports this rather than restating it).
+ *
+ * Port 3000 is load-bearing, not a default, and must stay in sync with the
+ * backend's CORS_ORIGINS and PORT. `getApiBaseUrl()` in src/lib/api.ts branches
+ * on `window.location.port`: served on 3000 it resolves the API origin to
+ * `<protocol>//<hostname>:4000`. Serving the app anywhere else silently
+ * repoints every REST call and the Socket.IO handshake. The `127.0.0.1`
+ * spelling is required for the same SameSite=Strict reason as API_ORIGIN above.
+ */
 export const FRONTEND_ORIGIN = process.env.E2E_FRONTEND_ORIGIN ?? "http://127.0.0.1:3000";
 
 const apiUrl = (path: string): string => `${API_ORIGIN}/api/v1${path}`;

--- a/scripts/redact_playwright_traces.py
+++ b/scripts/redact_playwright_traces.py
@@ -48,39 +48,31 @@ def redact_string(value: str) -> str:
     return COOKIE_ASSIGNMENT.sub(lambda match: match.group(0).split("=", 1)[0] + "=" + REDACTED, value)
 
 
-def redact_headers(headers: Any) -> Any:
-    """Redact both header representations Playwright has used in trace files."""
-    if isinstance(headers, dict):
-        return {
-            key: REDACTED if key.lower() in SENSITIVE_HEADER_NAMES else redact_value(value)
-            for key, value in headers.items()
-        }
-
-    if isinstance(headers, list):
-        redacted: list[Any] = []
-        for header in headers:
-            if isinstance(header, dict) and isinstance(header.get("name"), str):
-                copied = {key: redact_value(value) for key, value in header.items()}
-                if header["name"].lower() in SENSITIVE_HEADER_NAMES and "value" in copied:
-                    copied["value"] = REDACTED
-                redacted.append(copied)
-            else:
-                redacted.append(redact_value(header))
-        return redacted
-
-    return redact_value(headers)
-
-
 def redact_value(value: Any) -> Any:
+    """Redact credentials anywhere in a decoded trace payload.
+
+    Playwright has used two header representations — a `{name, value}` list and
+    a plain object — and stores cookies in the same two shapes. Rather than
+    tracking which subtree is a header block, any key (or `{name, value}` pair)
+    whose name is credential-bearing is redacted wherever it occurs. Everything
+    else keeps its structure, with token-shaped text rewritten by
+    `redact_string`, so the trace viewer still renders the archive.
+    """
     if isinstance(value, str):
         return redact_string(value)
+
     if isinstance(value, list):
         return [redact_value(item) for item in value]
+
     if isinstance(value, dict):
+        name = value.get("name")
+        if isinstance(name, str) and name.lower() in SENSITIVE_HEADER_NAMES and "value" in value:
+            return {key: REDACTED if key == "value" else redact_value(item) for key, item in value.items()}
         return {
-            key: redact_headers(item) if key.lower() == "headers" else redact_value(item)
+            key: REDACTED if key.lower() in SENSITIVE_HEADER_NAMES else redact_value(item)
             for key, item in value.items()
         }
+
     return value
 
 
@@ -106,7 +98,7 @@ def redact_text(text: str) -> str:
 
 def redact_archive(path: Path) -> None:
     """Atomically replace one diagnostics archive with a redacted copy."""
-    with zipfile.ZipFile(path, "r") as source, tempfile.NamedTemporaryFile(
+    with tempfile.NamedTemporaryFile(
         dir=path.parent, prefix=f".{path.name}.", suffix=".tmp", delete=False
     ) as temporary:
         temporary_path = Path(temporary.name)

--- a/scripts/redact_playwright_traces.py
+++ b/scripts/redact_playwright_traces.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Redact credentials from Playwright diagnostics ZIP files before upload.
+
+Playwright traces are useful failure diagnostics, but their network records can
+contain request headers. This full-stack E2E sends a bearer access token and a
+refresh cookie, so publishing a raw trace would publish credentials too. The
+script rewrites every ZIP archive below the supplied diagnostics directory in
+place, redacting credential-bearing headers and token-shaped strings while
+preserving all other data for the Playwright trace viewer. Playwright can copy a
+trace archive into both `test-results` and the HTML report under an opaque name,
+so matching only `trace.zip` is not enough.
+
+Only standard-library modules are used: GitHub-hosted Ubuntu runners provide
+Python 3, and this keeps the failure path independent of project dependencies.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import tempfile
+import zipfile
+from pathlib import Path
+from typing import Any
+
+SENSITIVE_HEADER_NAMES = {
+    "authorization",
+    "cookie",
+    "set-cookie",
+    "proxy-authorization",
+    "x-api-key",
+    "x-auth-token",
+}
+REDACTED = "<redacted>"
+BEARER = re.compile(r"(?i)\bbearer\s+[a-z0-9._~+/=-]+")
+JWT = re.compile(r"\beyJ[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+\b")
+COOKIE_ASSIGNMENT = re.compile(
+    r"(?i)\b(?:refresh_token|auth_token)\s*=\s*[^;\s\"']+",
+)
+
+
+def redact_string(value: str) -> str:
+    """Redact credentials which might occur outside structured header fields."""
+    value = BEARER.sub("Bearer " + REDACTED, value)
+    value = JWT.sub(REDACTED, value)
+    return COOKIE_ASSIGNMENT.sub(lambda match: match.group(0).split("=", 1)[0] + "=" + REDACTED, value)
+
+
+def redact_headers(headers: Any) -> Any:
+    """Redact both header representations Playwright has used in trace files."""
+    if isinstance(headers, dict):
+        return {
+            key: REDACTED if key.lower() in SENSITIVE_HEADER_NAMES else redact_value(value)
+            for key, value in headers.items()
+        }
+
+    if isinstance(headers, list):
+        redacted: list[Any] = []
+        for header in headers:
+            if isinstance(header, dict) and isinstance(header.get("name"), str):
+                copied = {key: redact_value(value) for key, value in header.items()}
+                if header["name"].lower() in SENSITIVE_HEADER_NAMES and "value" in copied:
+                    copied["value"] = REDACTED
+                redacted.append(copied)
+            else:
+                redacted.append(redact_value(header))
+        return redacted
+
+    return redact_value(headers)
+
+
+def redact_value(value: Any) -> Any:
+    if isinstance(value, str):
+        return redact_string(value)
+    if isinstance(value, list):
+        return [redact_value(item) for item in value]
+    if isinstance(value, dict):
+        return {
+            key: redact_headers(item) if key.lower() == "headers" else redact_value(item)
+            for key, item in value.items()
+        }
+    return value
+
+
+def redact_text(text: str) -> str:
+    """Redact JSON or JSON-lines trace payloads; fall back to token regexes."""
+    try:
+        return json.dumps(redact_value(json.loads(text)), separators=(",", ":"), ensure_ascii=False)
+    except json.JSONDecodeError:
+        pass
+
+    lines: list[str] = []
+    parsed_any = False
+    for line in text.splitlines(keepends=True):
+        newline = "\n" if line.endswith("\n") else ""
+        body = line[:-1] if newline else line
+        try:
+            lines.append(json.dumps(redact_value(json.loads(body)), separators=(",", ":"), ensure_ascii=False) + newline)
+            parsed_any = True
+        except json.JSONDecodeError:
+            lines.append(redact_string(line))
+    return "".join(lines) if parsed_any else redact_string(text)
+
+
+def redact_archive(path: Path) -> None:
+    """Atomically replace one diagnostics archive with a redacted copy."""
+    with zipfile.ZipFile(path, "r") as source, tempfile.NamedTemporaryFile(
+        dir=path.parent, prefix=f".{path.name}.", suffix=".tmp", delete=False
+    ) as temporary:
+        temporary_path = Path(temporary.name)
+
+    try:
+        with zipfile.ZipFile(path, "r") as source, zipfile.ZipFile(temporary_path, "w") as target:
+            for info in source.infolist():
+                data = source.read(info.filename)
+                try:
+                    data = redact_text(data.decode("utf-8")).encode("utf-8")
+                except UnicodeDecodeError:
+                    pass
+
+                copied = zipfile.ZipInfo(info.filename, date_time=info.date_time)
+                copied.compress_type = info.compress_type
+                copied.comment = info.comment
+                copied.external_attr = info.external_attr
+                copied.internal_attr = info.internal_attr
+                copied.create_system = info.create_system
+                target.writestr(copied, data)
+        os.replace(temporary_path, path)
+    except Exception:
+        temporary_path.unlink(missing_ok=True)
+        raise
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("diagnostics_directory", type=Path, help="Playwright diagnostics directory")
+    args = parser.parse_args()
+
+    archives = sorted(
+        path for path in args.diagnostics_directory.rglob("*.zip") if zipfile.is_zipfile(path)
+    )
+    if not archives:
+        print(f"No ZIP diagnostics found under {args.diagnostics_directory}")
+        return
+
+    for archive in archives:
+        redact_archive(archive)
+        print(f"Redacted credentials from {archive}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/redact_playwright_traces.py
+++ b/scripts/redact_playwright_traces.py
@@ -138,9 +138,12 @@ def main() -> None:
     parser.add_argument("diagnostics_directory", type=Path, help="Playwright diagnostics directory")
     args = parser.parse_args()
 
-    archives = sorted(
-        path for path in args.diagnostics_directory.rglob("*.zip") if zipfile.is_zipfile(path)
-    )
+    # Every archive-shaped diagnostic must be verified and rewritten. Silently
+    # skipping a truncated ZIP would mark redaction successful and allow the
+    # workflow to upload an uninspected file which may still contain tokens.
+    # `redact_archive` opens each candidate and raises `BadZipFile` (or another
+    # I/O error) before any upload when the archive is not readable.
+    archives = sorted(args.diagnostics_directory.rglob("*.zip"))
     if not archives:
         print(f"No ZIP diagnostics found under {args.diagnostics_directory}")
         return

--- a/scripts/wait-for-service.sh
+++ b/scripts/wait-for-service.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Wait for a CI-started application process to become healthy.
+#
+# Polls readiness *and* liveness: waiting on the URL alone would spend the full
+# timeout on a process that already exited, so a startup failure has to fail
+# fast instead of surfacing as a Playwright timeout minutes later. On any
+# failure the process log is printed, which is the only diagnostic a caller
+# gets for a server that never came up.
+#
+# Usage: wait-for-service.sh <label> <pid-file> <health-url> <log-file>
+set -uo pipefail
+
+label="$1"
+pid="$(cat "$2")"
+url="$3"
+log="$4"
+
+for _ in $(seq 1 60); do
+  if ! kill -0 "$pid" 2>/dev/null; then
+    echo "::error::${label} exited during startup"
+    cat "$log"
+    exit 1
+  fi
+  if curl -fsS "$url" >/dev/null 2>&1; then
+    echo "${label} is up"
+    exit 0
+  fi
+  sleep 2
+done
+
+echo "::error::${label} did not become healthy within 120s"
+cat "$log"
+exit 1


### PR DESCRIPTION
## 摘要
- 擴增既有 `.github/workflows/ci-browser.yml`，新增獨立 `fullstack-browser-tests` job；不新增另一個 CI workflow。
- 使用 ephemeral PostgreSQL、既有 migration path、真實 Bun backend、production Next.js 與 Chromium Playwright。
- 新增 authentication lifecycle 與兩個隔離 BrowserContext 的 private-chat realtime E2E。測試透過真實 UI、REST、PostgreSQL 與 Socket.IO 驗證，不 mock application API。
- backend、migration 與 shared 相關變更現在也會觸發 browser lane；既有單一 `required-checks` 不變。
- failure diagnostics 會在 upload 前 redact Playwright trace/report ZIP 中的 bearer token、JWT 與 refresh cookie；若 redaction 失敗，只上傳 application logs。

## 驗證
- [x] `pnpm run build`
- [x] `pnpm --filter near-chat-frontend typecheck`
- [x] `CI=1 pnpm --filter near-chat-frontend test:browser:fullstack`（2 passed）
- [x] Python 合成 Playwright diagnostics archive redaction test（涵蓋一般與 HTML report opaque ZIP）
- [x] workflow YAML parse
- [x] 獨立 pre-commit review

## 備註
- frontend lint 為 0 errors；仍有既有 `frontend/tests/chat-memoization.test.tsx:90` unused-variable warning，與本 PR 無關。
- `actionlint` 未安裝，因此未執行。

Closes #544