### PR TITLE
chore: ignore local git worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ yarn-error.log*
 .agents/
 .gemini/
 .codex/
+/.worktrees/
 
 # MCP server (local tool, not for repo)
 mcp/


### PR DESCRIPTION
## 摘要
- 將本機 Git worktree 目錄加入 `.gitignore`
- 避免 worktree 內容被誤列為 repository 變更

## 驗證
- `pnpm run build`
- `pnpm run test:node-engine`
- `git diff --check`
