### PR TITLE
refactor(ci): remove duplicate browser gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,10 +172,6 @@ jobs:
             browser_required=true
           fi
 
-          if [[ "$BACKEND_CHANGED" == "true" ]]; then
-            browser_required=true
-          fi
-
           # The database lane verifies the same code the backend lane builds, so
           # it follows the backend decision rather than a filter of its own.
           if [[ "$EVENT_NAME" == "workflow_dispatch" || "$BACKEND_CHANGED" == "true" ]]; then


### PR DESCRIPTION
## 摘要
- 移除 `browser_required` 的重複 backend-only 判斷
- 保留單一條件涵蓋 workflow dispatch、frontend 與 backend 變更
- 保留 full-stack realtime bootstrap waiters，避免 navigation remount race

## 驗證
- `pnpm run build`
- `pnpm run test:node-engine`（8/8 passed）
- `pnpm --filter near-chat-frontend run lint`（0 errors，既有 1 warning）
- `pnpm --filter near-chat-frontend run typecheck`
- `git diff --check`
