### PR TITLE
refactor(test): remove unsafe E2E any types

### DIFF
--- a/backend/tests/e2e/routes/admin.e2e.test.ts
+++ b/backend/tests/e2e/routes/admin.e2e.test.ts
@@ -1,11 +1,13 @@
+import type { Hono } from 'hono';
 import { describe, it, expect, beforeAll, beforeEach } from 'bun:test';
 import { request } from '../../helpers/http';
 import { resetDb } from '../../helpers/resetDb';
+import type { AdminHealthResponse, AuthResponse, AdminLogsResponse, AdminMetricsResponse, AdminSlowQueriesResponse } from '../../helpers/responseTypes';
 import { testPool } from '../../helpers/testPool';
 import { createLogger, recentLogs } from '../../../src/utils/logger';
 import { slowQueries } from '../../../src/utils/slowQueryStore';
 
-let app: any;
+let app: Hono;
 
 beforeAll(async () => {
   process.env.DATABASE_URL = process.env.DATABASE_URL_TEST;
@@ -14,7 +16,7 @@ beforeAll(async () => {
 });
 
 const registerUser = async (email: string): Promise<{ token: string; userId: string }> => {
-  const res = await request(app).post('/api/v1/auth/register').send({
+  const res = await request(app).post<AuthResponse>('/api/v1/auth/register').send({
     name: 'Admin Gate User',
     email,
     password: 'Password123!',
@@ -38,7 +40,7 @@ describe('Admin gate E2E', () => {
   });
 
   it('rejects an unauthenticated request with 401', async () => {
-    const res = await request(app).get('/api/v1/admin/health');
+    const res = await request(app).get<AdminHealthResponse>('/api/v1/admin/health');
     expect(res.status).toBe(401);
   });
 
@@ -46,7 +48,7 @@ describe('Admin gate E2E', () => {
     const { token } = await registerUser('plain@example.com');
 
     const res = await request(app)
-      .get('/api/v1/admin/health')
+      .get<AdminHealthResponse>('/api/v1/admin/health')
       .set('Authorization', `Bearer ${token}`);
 
     expect(res.status).toBe(403);
@@ -58,7 +60,7 @@ describe('Admin gate E2E', () => {
     await promote(userId);
 
     const res = await request(app)
-      .get('/api/v1/admin/health')
+      .get<AdminHealthResponse>('/api/v1/admin/health')
       .set('Authorization', `Bearer ${token}`);
 
     expect(res.status).toBe(200);
@@ -78,14 +80,14 @@ describe('Admin gate E2E', () => {
     await promote(userId);
 
     const allowed = await request(app)
-      .get('/api/v1/admin/health')
+      .get<AdminHealthResponse>('/api/v1/admin/health')
       .set('Authorization', `Bearer ${token}`);
     expect(allowed.status).toBe(200);
 
     await testPool`UPDATE users SET is_admin = false WHERE user_id = ${userId}`;
 
     const denied = await request(app)
-      .get('/api/v1/admin/health')
+      .get<AdminHealthResponse>('/api/v1/admin/health')
       .set('Authorization', `Bearer ${token}`);
     expect(denied.status).toBe(403);
   });
@@ -96,7 +98,7 @@ describe('Admin gate E2E', () => {
     await testPool`UPDATE users SET deleted_at = NOW() WHERE user_id = ${userId}`;
 
     const res = await request(app)
-      .get('/api/v1/admin/health')
+      .get<AdminHealthResponse>('/api/v1/admin/health')
       .set('Authorization', `Bearer ${token}`);
 
     // authMiddleware rejects the deleted account first; the admin gate is a
@@ -148,8 +150,8 @@ describe('Admin monitoring endpoints E2E', () => {
     adminToken = token;
   });
 
-  const asAdmin = (path: string) =>
-    request(app).get(path).set('Authorization', `Bearer ${adminToken}`);
+  const asAdmin = <T>(path: string) =>
+    request(app).get<T>(path).set('Authorization', `Bearer ${adminToken}`);
 
   it('refuses every endpoint without authentication', async () => {
     for (const path of ENDPOINTS) {
@@ -161,7 +163,7 @@ describe('Admin monitoring endpoints E2E', () => {
     const { token } = await registerUser('monitor-plain@example.com');
 
     for (const path of ENDPOINTS) {
-      const res = await request(app).get(path).set('Authorization', `Bearer ${token}`);
+      const res = await request(app).get<{ code: string }>(path).set('Authorization', `Bearer ${token}`);
       expect(res.status).toBe(403);
       expect(res.body.code).toBe('FORBIDDEN');
     }
@@ -176,7 +178,7 @@ describe('Admin monitoring endpoints E2E', () => {
   });
 
   it('reports request and process metrics', async () => {
-    const res = await asAdmin('/api/v1/admin/metrics');
+    const res = await asAdmin<AdminMetricsResponse>('/api/v1/admin/metrics');
 
     expect(res.status).toBe(200);
     expect(res.body.requests.totalRequests).toBeGreaterThan(0);
@@ -198,10 +200,10 @@ describe('Admin monitoring endpoints E2E', () => {
   });
 
   it('counts the failed admin attempts it just served', async () => {
-    const before = (await asAdmin('/api/v1/admin/metrics')).body.requests.statusClasses['4xx'];
+    const before = (await asAdmin<AdminMetricsResponse>('/api/v1/admin/metrics')).body.requests.statusClasses['4xx'];
     await request(app).get('/api/v1/admin/metrics');
 
-    const after = (await asAdmin('/api/v1/admin/metrics')).body.requests.statusClasses['4xx'];
+    const after = (await asAdmin<AdminMetricsResponse>('/api/v1/admin/metrics')).body.requests.statusClasses['4xx'];
 
     // Proves the endpoint reads the live buffer the timing middleware feeds,
     // rather than a snapshot taken at startup.
@@ -211,7 +213,7 @@ describe('Admin monitoring endpoints E2E', () => {
   it('returns the recent log buffer, oldest first', async () => {
     seedLogs(5);
 
-    const res = await asAdmin('/api/v1/admin/logs');
+    const res = await asAdmin<AdminLogsResponse>('/api/v1/admin/logs');
 
     expect(res.status).toBe(200);
     expect(res.body.retained).toBeGreaterThanOrEqual(5);
@@ -232,8 +234,8 @@ describe('Admin monitoring endpoints E2E', () => {
   it('honours ?limit= and rejects one the buffer cannot satisfy', async () => {
     seedLogs(5);
 
-    const full = await asAdmin('/api/v1/admin/logs');
-    const limited = await asAdmin('/api/v1/admin/logs?limit=2');
+    const full = await asAdmin<AdminLogsResponse>('/api/v1/admin/logs');
+    const limited = await asAdmin<AdminLogsResponse>('/api/v1/admin/logs?limit=2');
 
     expect(limited.status).toBe(200);
     expect(limited.body.entries).toHaveLength(2);
@@ -264,7 +266,7 @@ describe('Admin monitoring endpoints E2E', () => {
     });
     noisy.info({ password: 'hunter2', refreshToken: 'rt-secret' }, 'seeded credential record');
 
-    const res = await asAdmin('/api/v1/admin/logs');
+    const res = await asAdmin<AdminLogsResponse>('/api/v1/admin/logs');
 
     const body = JSON.stringify(res.body);
     expect(body).toInclude('seeded credential record');
@@ -276,7 +278,7 @@ describe('Admin monitoring endpoints E2E', () => {
   it('returns the slow-query buffer with the threshold that defines it', async () => {
     seedSlowQueries(3);
 
-    const res = await asAdmin('/api/v1/admin/slow-queries');
+    const res = await asAdmin<AdminSlowQueriesResponse>('/api/v1/admin/slow-queries');
 
     expect(res.status).toBe(200);
     expect(res.body.thresholdMs).toBeGreaterThan(0);
@@ -292,7 +294,7 @@ describe('Admin monitoring endpoints E2E', () => {
       expect(record.at).toBeGreaterThan(0);
     }
 
-    const limited = await asAdmin('/api/v1/admin/slow-queries?limit=1');
+    const limited = await asAdmin<AdminSlowQueriesResponse>('/api/v1/admin/slow-queries?limit=1');
     expect(limited.body.queries).toHaveLength(1);
     expect((await asAdmin('/api/v1/admin/slow-queries?limit=0')).status).toBe(400);
   });

--- a/backend/tests/e2e/routes/apiRoutes.e2e.test.ts
+++ b/backend/tests/e2e/routes/apiRoutes.e2e.test.ts
@@ -1,14 +1,16 @@
+import type { Hono } from 'hono';
 import { describe, it, expect, beforeAll, beforeEach } from 'bun:test';
 import { request } from '../../helpers/http';
 import { resetDb } from '../../helpers/resetDb';
+import type { AuthResponse, RoomResponse, UserProfileResponse } from '../../helpers/responseTypes';
 import { testPool } from '../../helpers/testPool';
 
-let app: any;
+let app: Hono;
 
 const registerUser = async (name = 'E2E User') => {
   const email = `e2e-${Date.now()}-${Math.random().toString(16).slice(2)}@example.com`;
   const response = await request(app)
-    .post('/api/v1/auth/register')
+    .post<AuthResponse>('/api/v1/auth/register')
     .send({ email, name, password: 'password123' })
     .expect(201);
 
@@ -40,7 +42,7 @@ describe('API routes E2E', () => {
     const email = `auth-${Date.now()}@example.com`;
 
     const register = await request(app)
-      .post('/api/v1/auth/register')
+      .post<AuthResponse>('/api/v1/auth/register')
       .send({ email, name: 'Auth User', password: 'password123' })
       .expect(201);
     expect(register.headers['x-content-type-options']).toBe('nosniff');
@@ -88,7 +90,7 @@ describe('API routes E2E', () => {
     const user = await registerUser('Searchable User');
 
     await request(app)
-      .get('/api/v1/users/me')
+      .get<UserProfileResponse>('/api/v1/users/me')
       .set('Authorization', `Bearer ${user.token}`)
       .expect(200)
       .expect((response) => {
@@ -96,7 +98,7 @@ describe('API routes E2E', () => {
       });
 
     await request(app)
-      .patch('/api/v1/users/me')
+      .patch<UserProfileResponse>('/api/v1/users/me')
       .set('Authorization', `Bearer ${user.token}`)
       .send({ name: 'Updated User' })
       .expect(200)
@@ -105,7 +107,7 @@ describe('API routes E2E', () => {
       });
 
     await request(app)
-      .get('/api/v1/users?q=Updated')
+      .get<UserProfileResponse[]>('/api/v1/users?q=Updated')
       .set('Authorization', `Bearer ${user.token}`)
       .expect(200)
       .expect((response) => {
@@ -117,7 +119,7 @@ describe('API routes E2E', () => {
     const user = await registerUser();
 
     await request(app)
-      .get('/api/v1/rooms')
+      .get<RoomResponse[]>('/api/v1/rooms')
       .set('Authorization', `Bearer ${user.token}`)
       .expect(200)
       .expect((response) => {
@@ -125,14 +127,14 @@ describe('API routes E2E', () => {
       });
 
     const roomResponse = await request(app)
-      .post('/api/v1/rooms')
+      .post<RoomResponse>('/api/v1/rooms')
       .set('Authorization', `Bearer ${user.token}`)
       .send({ type: 'group', name: 'E2E Room' })
       .expect(201);
     const roomId = roomResponse.body.roomId as string;
 
     await request(app)
-      .get('/api/v1/rooms')
+      .get<RoomResponse[]>('/api/v1/rooms')
       .set('Authorization', `Bearer ${user.token}`)
       .expect(200)
       .expect((response) => {
@@ -140,7 +142,7 @@ describe('API routes E2E', () => {
       });
 
     await request(app)
-      .get(`/api/v1/rooms/${roomId}`)
+      .get<RoomResponse>(`/api/v1/rooms/${roomId}`)
       .set('Authorization', `Bearer ${user.token}`)
       .expect(200)
       .expect((response) => {
@@ -148,7 +150,7 @@ describe('API routes E2E', () => {
       });
 
     await request(app)
-      .patch(`/api/v1/rooms/${roomId}`)
+      .patch<RoomResponse>(`/api/v1/rooms/${roomId}`)
       .set('Authorization', `Bearer ${user.token}`)
       .send({ name: 'Renamed E2E Room' })
       .expect(200)
@@ -168,7 +170,7 @@ describe('API routes E2E', () => {
       .expect(403);
 
     await request(app)
-      .get(`/api/v1/rooms/${roomId}/messages`)
+      .get<unknown[]>(`/api/v1/rooms/${roomId}/messages`)
       .set('Authorization', `Bearer ${user.token}`)
       .expect(200)
       .expect((response) => {
@@ -177,8 +179,8 @@ describe('API routes E2E', () => {
   });
 
   it('rejects unauthenticated protected routes', async () => {
-    await request(app).get('/api/v1/users/me').expect(401);
-    await request(app).get('/api/v1/rooms').expect(401);
+    await request(app).get<UserProfileResponse>('/api/v1/users/me').expect(401);
+    await request(app).get<RoomResponse[]>('/api/v1/rooms').expect(401);
     await request(app).get('/api/v1/rooms/room-1/messages').expect(401);
   });
 });

--- a/backend/tests/e2e/routes/attachment.e2e.test.ts
+++ b/backend/tests/e2e/routes/attachment.e2e.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect, beforeEach, afterAll } from 'bun:test';
+import { describe, it, expect, beforeEach } from 'bun:test';
 import { request } from '../../helpers/http';
 import { honoApp as app } from '../../../src/index';
 import { testPool } from '../../helpers/testPool';
 import { resetDb } from '../../helpers/resetDb';
+import type { AttachmentResponse, AuthResponse, RoomResponse } from '../../helpers/responseTypes';
 import path from 'path';
 import fs from 'fs/promises';
 
@@ -16,7 +17,7 @@ describe('Attachment E2E', () => {
     await resetDb();
 
     const regRes = await request(app)
-      .post('/api/v1/auth/register')
+      .post<AuthResponse>('/api/v1/auth/register')
       .send({
         name: 'Attachment User',
         email: 'attachment@test.com',
@@ -26,7 +27,7 @@ describe('Attachment E2E', () => {
     userId = regRes.body.user.userId;
 
     const roomRes = await request(app)
-      .post('/api/v1/rooms')
+      .post<RoomResponse>('/api/v1/rooms')
       .set('Authorization', `Bearer ${userToken}`)
       .send({
         type: 'group',
@@ -43,7 +44,7 @@ describe('Attachment E2E', () => {
 
   it('should upload an attachment successfully', async () => {
     const res = await request(app)
-      .post('/api/v1/attachments')
+      .post<AttachmentResponse>('/api/v1/attachments')
       .set('Authorization', `Bearer ${userToken}`)
       .attach('file', Buffer.from('test file content'), 'test.txt');
 
@@ -56,7 +57,7 @@ describe('Attachment E2E', () => {
 
   it('should return 400 if no file is provided', async () => {
     const res = await request(app)
-      .post('/api/v1/attachments')
+      .post<AttachmentResponse>('/api/v1/attachments')
       .set('Authorization', `Bearer ${userToken}`);
 
     expect(res.status).toBe(400);
@@ -64,14 +65,14 @@ describe('Attachment E2E', () => {
 
   it('should fetch metadata for an unassigned attachment uploaded by the user', async () => {
     const uploadRes = await request(app)
-      .post('/api/v1/attachments')
+      .post<AttachmentResponse>('/api/v1/attachments')
       .set('Authorization', `Bearer ${userToken}`)
       .attach('file', Buffer.from('test metadata file'), 'meta.txt');
 
     const attachmentId = uploadRes.body.attachmentId;
 
     const getRes = await request(app)
-      .get(`/api/v1/attachments/${attachmentId}`)
+      .get<AttachmentResponse>(`/api/v1/attachments/${attachmentId}`)
       .set('Authorization', `Bearer ${userToken}`)
       .set('Accept', 'application/json');
 
@@ -82,7 +83,7 @@ describe('Attachment E2E', () => {
 
   it('should fetch metadata for an attachment linked to a room message if user is in that room', async () => {
     const uploadRes = await request(app)
-      .post('/api/v1/attachments')
+      .post<AttachmentResponse>('/api/v1/attachments')
       .set('Authorization', `Bearer ${userToken}`)
       .attach('file', Buffer.from('room attachment content'), 'room_file.txt');
 
@@ -93,7 +94,7 @@ describe('Attachment E2E', () => {
     `;
 
     const getRes = await request(app)
-      .get(`/api/v1/attachments/${attachmentId}`)
+      .get<AttachmentResponse>(`/api/v1/attachments/${attachmentId}`)
       .set('Authorization', `Bearer ${userToken}`)
       .set('Accept', 'application/json');
 

--- a/backend/tests/e2e/routes/attachmentCompression.e2e.test.ts
+++ b/backend/tests/e2e/routes/attachmentCompression.e2e.test.ts
@@ -1,9 +1,11 @@
+import type { Hono } from 'hono';
 import { describe, it, expect, beforeAll, beforeEach } from 'bun:test';
-import { request } from '../../helpers/http';
+import { request, type HttpRequest } from '../../helpers/http';
 import sharp from 'sharp';
 import { resetDb } from '../../helpers/resetDb';
+import type { AttachmentResponse, AuthResponse } from '../../helpers/responseTypes';
 
-let app: any;
+let app: Hono;
 
 beforeAll(async () => {
   process.env.DATABASE_URL = process.env.DATABASE_URL_TEST;
@@ -19,7 +21,7 @@ describe('Attachment compression E2E', () => {
 
   beforeEach(async () => {
     await resetDb();
-    const res = await request(app).post('/api/v1/auth/register').send({
+    const res = await request(app).post<AuthResponse>('/api/v1/auth/register').send({
       name: 'ImgUser',
       email: 'attachment-compression@test.com',
       password: 'Password123!',
@@ -27,8 +29,8 @@ describe('Attachment compression E2E', () => {
     token = res.body.accessToken ?? res.body.token;
   });
 
-  const readBody = (req: any) =>
-    req.buffer(true).parse((r: any, cb: any) => {
+  const readBody = (req: HttpRequest<Buffer>) =>
+    req.buffer(true).parse((r, cb) => {
       const chunks: Buffer[] = [];
       r.on('data', (chunk: Buffer) => chunks.push(Buffer.from(chunk)));
       r.on('end', () => cb(null, Buffer.concat(chunks)));
@@ -42,7 +44,7 @@ describe('Attachment compression E2E', () => {
       .toBuffer();
 
     const uploadRes = await request(app)
-      .post('/api/v1/attachments')
+      .post<AttachmentResponse>('/api/v1/attachments')
       .set('Authorization', `Bearer ${token}`)
       .attach('file', png, 'photo.png');
 
@@ -52,7 +54,7 @@ describe('Attachment compression E2E', () => {
 
     const downloadRes = await readBody(
       request(app)
-        .get(`/api/v1/attachments/${uploadRes.body.attachmentId}`)
+        .get<Buffer>(`/api/v1/attachments/${uploadRes.body.attachmentId}`)
         .set('Authorization', `Bearer ${token}`),
     );
 
@@ -66,7 +68,7 @@ describe('Attachment compression E2E', () => {
 
   it('leaves a non-image attachment untouched', async () => {
     const uploadRes = await request(app)
-      .post('/api/v1/attachments')
+      .post<AttachmentResponse>('/api/v1/attachments')
       .set('Authorization', `Bearer ${token}`)
       .attach('file', Buffer.from('plain text content'), 'notes.txt');
 

--- a/backend/tests/e2e/routes/auth.e2e.test.ts
+++ b/backend/tests/e2e/routes/auth.e2e.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, beforeAll, beforeEach } from 'bun:test';
+import type { Hono } from 'hono';
 import { request } from '../../helpers/http';
 import { resetDb } from '../../helpers/resetDb';
+import type { AuthResponse, UserProfileResponse } from '../../helpers/responseTypes';
 
-let app: any;
+let app: Hono;
 
 beforeAll(async () => {
   process.env.DATABASE_URL = process.env.DATABASE_URL_TEST;
@@ -16,28 +18,28 @@ describe('Auth E2E', () => {
   });
 
   it('should register a new user successfully', async () => {
-    const res = await request(app).post('/api/v1/auth/register').send({
+    const res = await request(app).post<AuthResponse>('/api/v1/auth/register').send({
       name: 'Test User',
       email: 'test@example.com',
       password: 'Password123!',
     });
     if (res.status !== 201) throw new Error("RES: " + JSON.stringify(res.body));
     expect(res.body.token).toBeDefined();
-    expect((res.headers['set-cookie'] as any)?.join(';')).toContain('refresh_token=');
-    expect((res.headers['set-cookie'] as any)?.join(';')).toContain('HttpOnly');
-    expect((res.headers['set-cookie'] as any)?.join(';')).toContain('SameSite=Strict');
+    expect((res.headers['set-cookie'] as string[] | undefined)?.join(';')).toContain('refresh_token=');
+    expect((res.headers['set-cookie'] as string[] | undefined)?.join(';')).toContain('HttpOnly');
+    expect((res.headers['set-cookie'] as string[] | undefined)?.join(';')).toContain('SameSite=Strict');
     expect(res.body.user).toBeDefined();
     expect(res.body.user.name).toBe('Test User');
   });
 
   it('should fail registration if email is duplicate', async () => {
-    await request(app).post('/api/v1/auth/register').send({
+    await request(app).post<AuthResponse>('/api/v1/auth/register').send({
       name: 'Test User',
       email: 'test@example.com',
       password: 'Password123!',
     });
-    
-    const res = await request(app).post('/api/v1/auth/register').send({
+
+    const res = await request(app).post<{ message: string }>('/api/v1/auth/register').send({
       name: 'Another User',
       email: 'test@example.com',
       password: 'Password123!',
@@ -47,23 +49,23 @@ describe('Auth E2E', () => {
   });
 
   it('should login an existing user', async () => {
-    await request(app).post('/api/v1/auth/register').send({
+    await request(app).post<AuthResponse>('/api/v1/auth/register').send({
       name: 'Test User',
       email: 'test@example.com',
       password: 'Password123!',
     });
 
-    const res = await request(app).post('/api/v1/auth/login').send({
+    const res = await request(app).post<AuthResponse>('/api/v1/auth/login').send({
       email: 'test@example.com',
       password: 'Password123!',
     });
     expect(res.status).toBe(200);
     expect(res.body.token).toBeDefined();
-    expect((res.headers['set-cookie'] as any)?.join(';')).toContain('refresh_token=');
+    expect((res.headers['set-cookie'] as string[] | undefined)?.join(';')).toContain('refresh_token=');
   });
 
   it('should authenticate protected routes with the auth header', async () => {
-    const register = await request(app).post('/api/v1/auth/register').send({
+    const register = await request(app).post<AuthResponse>('/api/v1/auth/register').send({
       name: 'Cookie User',
       email: 'cookie@example.com',
       password: 'Password123!',
@@ -71,37 +73,37 @@ describe('Auth E2E', () => {
     const token = register.body.token;
     const cookie = register.headers['set-cookie'];
 
-    const me = await request(app).get('/api/v1/users/me').set('Authorization', `Bearer ${token}`);
+    const me = await request(app).get<UserProfileResponse>('/api/v1/users/me').set('Authorization', `Bearer ${token}`);
     expect(me.status).toBe(200);
     expect(me.body.name).toBe('Cookie User');
 
     const logout = await request(app).post('/api/v1/auth/logout').set('Cookie', cookie).set('Authorization', `Bearer ${token}`);
     expect(logout.status).toBe(204);
-    expect((logout.headers['set-cookie'] as any)?.join(';')).toContain('refresh_token=');
+    expect((logout.headers['set-cookie'] as string[] | undefined)?.join(';')).toContain('refresh_token=');
   });
 
   it('should refresh access token using refresh token cookie', async () => {
-    const register = await request(app).post('/api/v1/auth/register').send({
+    const register = await request(app).post<AuthResponse>('/api/v1/auth/register').send({
       name: 'Refresh User',
       email: 'refresh@example.com',
       password: 'Password123!',
     });
     const cookie = register.headers['set-cookie'];
 
-    const res = await request(app).post('/api/v1/auth/refresh').set('Cookie', cookie);
+    const res = await request(app).post<AuthResponse>('/api/v1/auth/refresh').set('Cookie', cookie);
     expect(res.status).toBe(200);
     expect(res.body.token).toBeDefined();
-    expect((res.headers['set-cookie'] as any)?.join(';')).toContain('refresh_token=');
+    expect((res.headers['set-cookie'] as string[] | undefined)?.join(';')).toContain('refresh_token=');
   });
 
   it('should fail login with incorrect password', async () => {
-    await request(app).post('/api/v1/auth/register').send({
+    await request(app).post<AuthResponse>('/api/v1/auth/register').send({
       name: 'Test User',
       email: 'test@example.com',
       password: 'Password123!',
     });
 
-    const res = await request(app).post('/api/v1/auth/login').send({
+    const res = await request(app).post<{ message: string }>('/api/v1/auth/login').send({
       email: 'test@example.com',
       password: 'WrongPassword!',
     });

--- a/backend/tests/e2e/routes/emergencyContacts.e2e.test.ts
+++ b/backend/tests/e2e/routes/emergencyContacts.e2e.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterAll } from 'bun:test';
 import { request } from '../../helpers/http';
 import { honoApp as app } from '../../../src/index';
 import { resetDb } from '../../helpers/resetDb';
+import type { AuthResponse, EmergencyContactResponse } from '../../helpers/responseTypes';
 import { testPool } from '../../helpers/testPool';
 
 describe('Emergency Contacts E2E', () => {
@@ -14,13 +15,13 @@ describe('Emergency Contacts E2E', () => {
     await resetDb();
 
     const u1 = await request(app)
-      .post('/api/v1/auth/register')
+      .post<AuthResponse>('/api/v1/auth/register')
       .send({ name: 'User One', email: 'user1@test.com', password: 'password123' });
     token1 = u1.body.token;
     user1Id = u1.body.user.userId;
 
     const u2 = await request(app)
-      .post('/api/v1/auth/register')
+      .post<AuthResponse>('/api/v1/auth/register')
       .send({ name: 'User Two', email: 'user2@test.com', password: 'password123' });
     token2 = u2.body.token;
     user2Id = u2.body.user.userId;
@@ -29,14 +30,14 @@ describe('Emergency Contacts E2E', () => {
   it('should manage emergency contacts lifecycle', async () => {
     // 1. Initially empty
     const listInitial = await request(app)
-      .get('/api/v1/users/me/emergency-contacts')
+      .get<EmergencyContactResponse[]>('/api/v1/users/me/emergency-contacts')
       .set('Authorization', `Bearer ${token1}`);
     expect(listInitial.status).toBe(200);
     expect(listInitial.body).toEqual([]);
 
     // 2. Add contact
     const addRes = await request(app)
-      .post('/api/v1/users/me/emergency-contacts')
+      .post<EmergencyContactResponse>('/api/v1/users/me/emergency-contacts')
       .set('Authorization', `Bearer ${token1}`)
       .send({
         contactId: user2Id,
@@ -49,7 +50,7 @@ describe('Emergency Contacts E2E', () => {
 
     // 3. List contains added contact
     const listAfterAdd = await request(app)
-      .get('/api/v1/users/me/emergency-contacts')
+      .get<EmergencyContactResponse[]>('/api/v1/users/me/emergency-contacts')
       .set('Authorization', `Bearer ${token1}`);
     expect(listAfterAdd.status).toBe(200);
     expect(listAfterAdd.body).toHaveLength(1);
@@ -57,7 +58,7 @@ describe('Emergency Contacts E2E', () => {
 
     // 4. Update message (upsert)
     const updateRes = await request(app)
-      .post('/api/v1/users/me/emergency-contacts')
+      .post<EmergencyContactResponse>('/api/v1/users/me/emergency-contacts')
       .set('Authorization', `Bearer ${token1}`)
       .send({
         contactId: user2Id,
@@ -74,7 +75,7 @@ describe('Emergency Contacts E2E', () => {
 
     // 6. List empty again
     const listAfterDel = await request(app)
-      .get('/api/v1/users/me/emergency-contacts')
+      .get<EmergencyContactResponse[]>('/api/v1/users/me/emergency-contacts')
       .set('Authorization', `Bearer ${token1}`);
     expect(listAfterDel.status).toBe(200);
     expect(listAfterDel.body).toEqual([]);
@@ -82,7 +83,7 @@ describe('Emergency Contacts E2E', () => {
 
   it('should reject self-contact creation', async () => {
     const res = await request(app)
-      .post('/api/v1/users/me/emergency-contacts')
+      .post<EmergencyContactResponse>('/api/v1/users/me/emergency-contacts')
       .set('Authorization', `Bearer ${token1}`)
       .send({
         contactId: user1Id,
@@ -93,7 +94,7 @@ describe('Emergency Contacts E2E', () => {
 
   it('should check inactivity threshold and suppress duplicate alerts', async () => {
     await request(app)
-      .post('/api/v1/users/me/emergency-contacts')
+      .post<EmergencyContactResponse>('/api/v1/users/me/emergency-contacts')
       .set('Authorization', `Bearer ${token1}`)
       .send({
         contactId: user2Id,

--- a/backend/tests/e2e/routes/folder.e2e.test.ts
+++ b/backend/tests/e2e/routes/folder.e2e.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from 'bun:test';
 import { request } from '../../helpers/http';
 import { honoApp as app } from '../../../src/index';
 import { resetDb } from '../../helpers/resetDb';
+import type { AuthResponse, FolderResponse, RoomResponse } from '../../helpers/responseTypes';
 
 describe('Folder E2E', () => {
   let token: string;
@@ -12,7 +13,7 @@ describe('Folder E2E', () => {
     await resetDb();
     
     // Create user
-    const res = await request(app).post('/api/v1/auth/register').send({
+    const res = await request(app).post<AuthResponse>('/api/v1/auth/register').send({
       name: 'User',
       email: 'user@example.com',
       password: 'Password123!',
@@ -22,7 +23,7 @@ describe('Folder E2E', () => {
 
     // Create room
     const roomRes = await request(app)
-      .post('/api/v1/rooms')
+      .post<RoomResponse>('/api/v1/rooms')
       .set('Authorization', `Bearer ${token}`)
       .send({ type: 'group', name: 'Test Room' });
     roomId = roomRes.body.roomId;
@@ -30,7 +31,7 @@ describe('Folder E2E', () => {
 
   it('should create a new folder', async () => {
     const res = await request(app)
-      .post('/api/v1/folders')
+      .post<FolderResponse>('/api/v1/folders')
       .set('Authorization', `Bearer ${token}`)
       .send({ name: 'My Folder' });
     expect(res.status).toBe(201);
@@ -40,12 +41,12 @@ describe('Folder E2E', () => {
 
   it('should list folders', async () => {
     await request(app)
-      .post('/api/v1/folders')
+      .post<FolderResponse>('/api/v1/folders')
       .set('Authorization', `Bearer ${token}`)
       .send({ name: 'Folder 1' });
 
     const res = await request(app)
-      .get('/api/v1/folders')
+      .get<FolderResponse[]>('/api/v1/folders')
       .set('Authorization', `Bearer ${token}`);
     expect(res.status).toBe(200);
     expect(res.body).toBeInstanceOf(Array);
@@ -56,7 +57,7 @@ describe('Folder E2E', () => {
 
   it('should delete a folder', async () => {
     const createRes = await request(app)
-      .post('/api/v1/folders')
+      .post<FolderResponse>('/api/v1/folders')
       .set('Authorization', `Bearer ${token}`)
       .send({ name: 'Folder to Delete' });
     const folderId = createRes.body.folderId;
@@ -67,14 +68,14 @@ describe('Folder E2E', () => {
     expect(deleteRes.status).toBe(204);
 
     const getRes = await request(app)
-      .get('/api/v1/folders')
+      .get<FolderResponse[]>('/api/v1/folders')
       .set('Authorization', `Bearer ${token}`);
     expect(getRes.body.length).toBe(0);
   });
 
   it('should move rooms into a folder', async () => {
     const createRes = await request(app)
-      .post('/api/v1/folders')
+      .post<FolderResponse>('/api/v1/folders')
       .set('Authorization', `Bearer ${token}`)
       .send({ name: 'Folder with Rooms' });
     const folderId = createRes.body.folderId;
@@ -86,25 +87,25 @@ describe('Folder E2E', () => {
     expect(moveRes.status).toBe(200);
 
     const getRes = await request(app)
-      .get('/api/v1/folders')
+      .get<FolderResponse[]>('/api/v1/folders')
       .set('Authorization', `Bearer ${token}`);
     expect(getRes.body[0].roomIds).toContain(roomId);
   });
 
   it('should reject moving rooms the user does not belong to into a folder', async () => {
-    const otherUser = await request(app).post('/api/v1/auth/register').send({
+    const otherUser = await request(app).post<AuthResponse>('/api/v1/auth/register').send({
       name: 'Other User',
       email: 'other@example.com',
       password: 'Password123!',
     });
 
     const otherRoom = await request(app)
-      .post('/api/v1/rooms')
+      .post<RoomResponse>('/api/v1/rooms')
       .set('Authorization', `Bearer ${otherUser.body.token}`)
       .send({ type: 'group', name: 'Other Room' });
 
     const createRes = await request(app)
-      .post('/api/v1/folders')
+      .post<FolderResponse>('/api/v1/folders')
       .set('Authorization', `Bearer ${token}`)
       .send({ name: 'Secure Folder' });
 

--- a/backend/tests/e2e/routes/friend.e2e.test.ts
+++ b/backend/tests/e2e/routes/friend.e2e.test.ts
@@ -3,35 +3,36 @@ import { request } from '../../helpers/http';
 import { honoApp as app } from '../../../src/index';
 import { resetDb } from '../../helpers/resetDb';
 import { testPool } from '../../helpers/testPool';
+import type { AuthResponse, AuthUser, BlockedUser, FriendListEntry, FriendRequestResponse, PendingFriendRequestResponse, RoomResponse } from '../../helpers/responseTypes';
 
 describe('Friend & Block E2E Integration Tests', () => {
   let tokenA: string;
-  let userA: any;
+  let userA: AuthUser;
   let tokenB: string;
-  let userB: any;
+  let userB: AuthUser;
   let tokenC: string;
-  let userC: any;
+  let userC: AuthUser;
 
   beforeEach(async () => {
     await resetDb();
 
     // Register User A
     const resA = await request(app)
-      .post('/api/v1/auth/register')
+      .post<AuthResponse>('/api/v1/auth/register')
       .send({ name: 'User A', email: 'usera@test.com', password: 'password123' });
     tokenA = resA.body.token;
     userA = resA.body.user;
 
     // Register User B
     const resB = await request(app)
-      .post('/api/v1/auth/register')
+      .post<AuthResponse>('/api/v1/auth/register')
       .send({ name: 'User B', email: 'userb@test.com', password: 'password123' });
     tokenB = resB.body.token;
     userB = resB.body.user;
 
     // Register User C
     const resC = await request(app)
-      .post('/api/v1/auth/register')
+      .post<AuthResponse>('/api/v1/auth/register')
       .send({ name: 'User C', email: 'userc@test.com', password: 'password123' });
     tokenC = resC.body.token;
     userC = resC.body.user;
@@ -41,7 +42,7 @@ describe('Friend & Block E2E Integration Tests', () => {
     it('should send, list, accept, and get friends', async () => {
       // 1. A sends friend request to B
       const sendRes = await request(app)
-        .post('/api/v1/friend-requests')
+        .post<FriendRequestResponse>('/api/v1/friend-requests')
         .set('Authorization', `Bearer ${tokenA}`)
         .send({ target_user_id: userB.userId });
 
@@ -52,7 +53,7 @@ describe('Friend & Block E2E Integration Tests', () => {
 
       // 2. B views pending requests
       const pendingRes = await request(app)
-        .get('/api/v1/friend-requests/pending')
+        .get<PendingFriendRequestResponse[]>('/api/v1/friend-requests/pending')
         .set('Authorization', `Bearer ${tokenB}`);
 
       expect(pendingRes.status).toBe(200);
@@ -61,7 +62,7 @@ describe('Friend & Block E2E Integration Tests', () => {
 
       // 3. B accepts friend request from A
       const acceptRes = await request(app)
-        .patch(`/api/v1/friend-requests/${userA.userId}`)
+        .patch<FriendRequestResponse>(`/api/v1/friend-requests/${userA.userId}`)
         .set('Authorization', `Bearer ${tokenB}`)
         .send({ status: 'accepted' });
 
@@ -70,7 +71,7 @@ describe('Friend & Block E2E Integration Tests', () => {
 
       // 4. A gets friends list (should include B)
       const friendsARes = await request(app)
-        .get('/api/v1/friends')
+        .get<FriendListEntry[]>('/api/v1/friends')
         .set('Authorization', `Bearer ${tokenA}`);
 
       expect(friendsARes.status).toBe(200);
@@ -79,7 +80,7 @@ describe('Friend & Block E2E Integration Tests', () => {
 
       // 5. B gets friends list (should include A)
       const friendsBRes = await request(app)
-        .get('/api/v1/friends')
+        .get<FriendListEntry[]>('/api/v1/friends')
         .set('Authorization', `Bearer ${tokenB}`);
 
       expect(friendsBRes.status).toBe(200);
@@ -90,17 +91,17 @@ describe('Friend & Block E2E Integration Tests', () => {
     it('should delete a friend and mark existing private room read-only', async () => {
       // Setup accepted friendship
       await request(app)
-        .post('/api/v1/friend-requests')
+        .post<FriendRequestResponse>('/api/v1/friend-requests')
         .set('Authorization', `Bearer ${tokenA}`)
         .send({ target_user_id: userB.userId });
 
       await request(app)
-        .patch(`/api/v1/friend-requests/${userA.userId}`)
+        .patch<FriendRequestResponse>(`/api/v1/friend-requests/${userA.userId}`)
         .set('Authorization', `Bearer ${tokenB}`)
         .send({ status: 'accepted' });
 
       const privateRoom = await request(app)
-        .post('/api/v1/rooms')
+        .post<RoomResponse>('/api/v1/rooms')
         .set('Authorization', `Bearer ${tokenA}`)
         .send({ type: 'private', targetUserId: userB.userId });
       expect(privateRoom.status).toBe(201);
@@ -119,25 +120,25 @@ describe('Friend & Block E2E Integration Tests', () => {
     it('should reject a friend request and not affect accepted friendships', async () => {
       // C sends request to B
       await request(app)
-        .post('/api/v1/friend-requests')
+        .post<FriendRequestResponse>('/api/v1/friend-requests')
         .set('Authorization', `Bearer ${tokenC}`)
         .send({ target_user_id: userB.userId });
 
       // B accepts C
       await request(app)
-        .patch(`/api/v1/friend-requests/${userC.userId}`)
+        .patch<FriendRequestResponse>(`/api/v1/friend-requests/${userC.userId}`)
         .set('Authorization', `Bearer ${tokenB}`)
         .send({ status: 'accepted' });
 
       // A sends request to B
       await request(app)
-        .post('/api/v1/friend-requests')
+        .post<FriendRequestResponse>('/api/v1/friend-requests')
         .set('Authorization', `Bearer ${tokenA}`)
         .send({ target_user_id: userB.userId });
 
       // B rejects A
       const res = await request(app)
-        .patch(`/api/v1/friend-requests/${userA.userId}`)
+        .patch<FriendRequestResponse>(`/api/v1/friend-requests/${userA.userId}`)
         .set('Authorization', `Bearer ${tokenB}`)
         .send({ status: 'rejected' });
 
@@ -146,7 +147,7 @@ describe('Friend & Block E2E Integration Tests', () => {
 
       // Check friends list for B, C should still be there
       const listRes = await request(app)
-        .get('/api/v1/friends')
+        .get<FriendListEntry[]>('/api/v1/friends')
         .set('Authorization', `Bearer ${tokenB}`);
       
       expect(listRes.status).toBe(200);
@@ -174,7 +175,7 @@ describe('Friend & Block E2E Integration Tests', () => {
 
       // C tries to friend A
       const res = await request(app)
-        .post('/api/v1/friend-requests')
+        .post<FriendRequestResponse>('/api/v1/friend-requests')
         .set('Authorization', `Bearer ${tokenC}`)
         .send({ target_user_id: userA.userId });
 
@@ -183,16 +184,16 @@ describe('Friend & Block E2E Integration Tests', () => {
 
     it('should mark existing private room read-only when blocking a friend', async () => {
       await request(app)
-        .post('/api/v1/friend-requests')
+        .post<FriendRequestResponse>('/api/v1/friend-requests')
         .set('Authorization', `Bearer ${tokenA}`)
         .send({ target_user_id: userB.userId });
       await request(app)
-        .patch(`/api/v1/friend-requests/${userA.userId}`)
+        .patch<FriendRequestResponse>(`/api/v1/friend-requests/${userA.userId}`)
         .set('Authorization', `Bearer ${tokenB}`)
         .send({ status: 'accepted' });
 
       const privateRoom = await request(app)
-        .post('/api/v1/rooms')
+        .post<RoomResponse>('/api/v1/rooms')
         .set('Authorization', `Bearer ${tokenA}`)
         .send({ type: 'private', targetUserId: userB.userId });
       expect(privateRoom.status).toBe(201); // created for the first time
@@ -210,16 +211,16 @@ describe('Friend & Block E2E Integration Tests', () => {
 
     it('should restore the friendship after unblocking a blocked friend', async () => {
       await request(app)
-        .post('/api/v1/friend-requests')
+        .post<FriendRequestResponse>('/api/v1/friend-requests')
         .set('Authorization', `Bearer ${tokenA}`)
         .send({ target_user_id: userB.userId });
       await request(app)
-        .patch(`/api/v1/friend-requests/${userA.userId}`)
+        .patch<FriendRequestResponse>(`/api/v1/friend-requests/${userA.userId}`)
         .set('Authorization', `Bearer ${tokenB}`)
         .send({ status: 'accepted' });
 
       const privateRoom = await request(app)
-        .post('/api/v1/rooms')
+        .post<RoomResponse>('/api/v1/rooms')
         .set('Authorization', `Bearer ${tokenA}`)
         .send({ type: 'private', targetUserId: userB.userId });
       expect(privateRoom.status).toBe(201);
@@ -231,7 +232,7 @@ describe('Friend & Block E2E Integration Tests', () => {
       expect(blockRes.status).toBe(201);
 
       const blockedFriends = await request(app)
-        .get('/api/v1/friends')
+        .get<FriendListEntry[]>('/api/v1/friends')
         .set('Authorization', `Bearer ${tokenA}`);
       expect(blockedFriends.status).toBe(200);
       expect(blockedFriends.body).toEqual([]);
@@ -242,7 +243,7 @@ describe('Friend & Block E2E Integration Tests', () => {
       expect(unblockRes.status).toBe(204);
 
       const restoredFriends = await request(app)
-        .get('/api/v1/friends')
+        .get<FriendListEntry[]>('/api/v1/friends')
         .set('Authorization', `Bearer ${tokenA}`);
       expect(restoredFriends.status).toBe(200);
       expect(restoredFriends.body).toHaveLength(1);
@@ -260,7 +261,7 @@ describe('Friend & Block E2E Integration Tests', () => {
         .send({ target_user_id: userC.userId });
 
       const res = await request(app)
-        .get('/api/v1/blocks')
+        .get<BlockedUser[]>('/api/v1/blocks')
         .set('Authorization', `Bearer ${tokenA}`);
 
       expect(res.status).toBe(200);
@@ -284,7 +285,7 @@ describe('Friend & Block E2E Integration Tests', () => {
       expect(unblockRes.status).toBe(204);
 
       const listRes = await request(app)
-        .get('/api/v1/blocks')
+        .get<BlockedUser[]>('/api/v1/blocks')
         .set('Authorization', `Bearer ${tokenA}`);
 
       expect(listRes.body.length).toBe(0);

--- a/backend/tests/e2e/routes/message.e2e.test.ts
+++ b/backend/tests/e2e/routes/message.e2e.test.ts
@@ -3,6 +3,7 @@ import { request } from '../../helpers/http';
 import { honoApp as app } from '../../../src/index';
 import { testPool } from '../../helpers/testPool';
 import { resetDb } from '../../helpers/resetDb';
+import type { AuthResponse, MessageResponse, RoomResponse } from '../../helpers/responseTypes';
 
 describe('Message E2E', () => {
   let token: string;
@@ -14,7 +15,7 @@ describe('Message E2E', () => {
 
     // Register User
     const regRes = await request(app)
-      .post('/api/v1/auth/register')
+      .post<AuthResponse>('/api/v1/auth/register')
       .send({
         name: 'Message User',
         email: 'msguser@test.com',
@@ -25,7 +26,7 @@ describe('Message E2E', () => {
 
     // Create Room
     const roomRes = await request(app)
-      .post('/api/v1/rooms')
+      .post<RoomResponse>('/api/v1/rooms')
       .set('Authorization', `Bearer ${token}`)
       .send({
         type: 'group',
@@ -41,7 +42,7 @@ describe('Message E2E', () => {
     `;
 
     const res = await request(app)
-      .get(`/api/v1/rooms/${roomId}/messages`)
+      .get<MessageResponse[]>(`/api/v1/rooms/${roomId}/messages`)
       .set('Authorization', `Bearer ${token}`);
     
     expect(res.status).toBe(200);
@@ -51,7 +52,7 @@ describe('Message E2E', () => {
   });
 
   it('should reject pending members when listing messages', async () => {
-    const pendingRes = await request(app).post('/api/v1/auth/register').send({
+    const pendingRes = await request(app).post<AuthResponse>('/api/v1/auth/register').send({
       name: 'Pending User',
       email: 'pending@example.com',
       password: 'Password123!',
@@ -64,7 +65,7 @@ describe('Message E2E', () => {
     `;
 
     const res = await request(app)
-      .get(`/api/v1/rooms/${roomId}/messages`)
+      .get<MessageResponse[]>(`/api/v1/rooms/${roomId}/messages`)
       .set('Authorization', `Bearer ${pendingRes.body.token}`);
 
     expect(res.status).toBe(403);
@@ -72,7 +73,7 @@ describe('Message E2E', () => {
 
   it('should hide pre-join messages when room viewHistory is false', async () => {
     const hiddenRoomRes = await request(app)
-      .post('/api/v1/rooms')
+      .post<RoomResponse>('/api/v1/rooms')
       .set('Authorization', `Bearer ${token}`)
       .send({
         type: 'group',
@@ -87,7 +88,7 @@ describe('Message E2E', () => {
       INSERT INTO messages (room_id, sender_id, content, sent_at) VALUES (${hiddenRoomId}, ${userId}, ${beforeContent}, ${beforeTime})
     `;
 
-    const newUserRes = await request(app).post('/api/v1/auth/register').send({
+    const newUserRes = await request(app).post<AuthResponse>('/api/v1/auth/register').send({
       name: 'New Member',
       email: 'new-member@example.com',
       password: 'Password123!',
@@ -107,7 +108,7 @@ describe('Message E2E', () => {
     `;
 
     const res = await request(app)
-      .get(`/api/v1/rooms/${hiddenRoomId}/messages`)
+      .get<MessageResponse[]>(`/api/v1/rooms/${hiddenRoomId}/messages`)
       .set('Authorization', `Bearer ${newUserRes.body.token}`);
 
     expect(res.status).toBe(200);

--- a/backend/tests/e2e/routes/realtimeRecovery.e2e.test.ts
+++ b/backend/tests/e2e/routes/realtimeRecovery.e2e.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, beforeEach } from 'bun:test';
-import { HttpRequest, request } from '../../helpers/http';
+import { request, type HttpRequest } from '../../helpers/http';
 import { honoApp as app } from '../../../src/index';
 import { resetDb } from '../../helpers/resetDb';
+import type { AuthResponse, MessageResponse, ReadPositionResponse, RoomResponse, SyncResponse } from '../../helpers/responseTypes';
 
 describe('Realtime recovery REST contract', () => {
   let token: string;
@@ -9,14 +10,14 @@ describe('Realtime recovery REST contract', () => {
 
   beforeEach(async () => {
     await resetDb();
-    const user = await request(app).post('/api/v1/auth/register').send({
+    const user = await request(app).post<AuthResponse>('/api/v1/auth/register').send({
       name: 'Recovery User',
       email: 'recovery@example.com',
       password: 'Password123!',
     });
     token = user.body.token;
     const room = await request(app)
-      .post('/api/v1/rooms')
+      .post<RoomResponse>('/api/v1/rooms')
       .set('Authorization', `Bearer ${token}`)
       .send({ type: 'group', name: 'Recovery Room' });
     roomId = room.body.roomId;
@@ -24,12 +25,12 @@ describe('Realtime recovery REST contract', () => {
 
   it('applies one create command once and recovers its durable change', async () => {
     const first = await request(app)
-      .post(`/api/v1/rooms/${roomId}/messages`)
+      .post<MessageResponse>(`/api/v1/rooms/${roomId}/messages`)
       .set('Authorization', `Bearer ${token}`)
       .set('Idempotency-Key', 'create-command-1')
       .send({ content: 'durable' });
     const second = await request(app)
-      .post(`/api/v1/rooms/${roomId}/messages`)
+      .post<MessageResponse>(`/api/v1/rooms/${roomId}/messages`)
       .set('Authorization', `Bearer ${token}`)
       .set('Idempotency-Key', 'create-command-1')
       .send({ content: 'different retry body' });
@@ -43,7 +44,7 @@ describe('Realtime recovery REST contract', () => {
     expect(first.body.revision).toBe(1);
 
     const sync = await request(app)
-      .get('/api/v1/sync?cursor=0&limit=100')
+      .get<SyncResponse>('/api/v1/sync?cursor=0&limit=100')
       .set('Authorization', `Bearer ${token}`);
     expect(sync.status).toBe(200);
     expect(sync.body.changes).toHaveLength(1);
@@ -55,13 +56,13 @@ describe('Realtime recovery REST contract', () => {
     });
 
     await request(app)
-      .patch(`/api/v1/rooms/${roomId}/messages/${first.body.messageId}`)
+      .patch<MessageResponse>(`/api/v1/rooms/${roomId}/messages/${first.body.messageId}`)
       .set('Authorization', `Bearer ${token}`)
       .set('If-Match', '1')
       .set('Idempotency-Key', 'create-followup-edit')
       .send({ content: 'changed later' });
     const createRetryAfterLaterEdit = await request(app)
-      .post(`/api/v1/rooms/${roomId}/messages`)
+      .post<MessageResponse>(`/api/v1/rooms/${roomId}/messages`)
       .set('Authorization', `Bearer ${token}`)
       .set('Idempotency-Key', 'create-command-1')
       .send({ content: 'still the original command' });
@@ -71,13 +72,13 @@ describe('Realtime recovery REST contract', () => {
 
   it('rejects stale revisions and exposes the conflict as 409', async () => {
     const created = await request(app)
-      .post(`/api/v1/rooms/${roomId}/messages`)
+      .post<MessageResponse>(`/api/v1/rooms/${roomId}/messages`)
       .set('Authorization', `Bearer ${token}`)
       .set('Idempotency-Key', 'create-command-2')
       .send({ content: 'before edit' });
 
     const edited = await request(app)
-      .patch(`/api/v1/rooms/${roomId}/messages/${created.body.messageId}`)
+      .patch<MessageResponse>(`/api/v1/rooms/${roomId}/messages/${created.body.messageId}`)
       .set('Authorization', `Bearer ${token}`)
       .set('If-Match', '1')
       .set('Idempotency-Key', 'edit-command-1')
@@ -86,7 +87,7 @@ describe('Realtime recovery REST contract', () => {
     expect(edited.body.revision).toBe(2);
 
     const stale = await request(app)
-      .patch(`/api/v1/rooms/${roomId}/messages/${created.body.messageId}`)
+      .patch<MessageResponse>(`/api/v1/rooms/${roomId}/messages/${created.body.messageId}`)
       .set('Authorization', `Bearer ${token}`)
       .set('If-Match', '1')
       .set('Idempotency-Key', 'edit-command-2')
@@ -97,20 +98,20 @@ describe('Realtime recovery REST contract', () => {
 
   it('keeps edit, recall, and read-position commands idempotent', async () => {
     const created = await request(app)
-      .post(`/api/v1/rooms/${roomId}/messages`)
+      .post<MessageResponse>(`/api/v1/rooms/${roomId}/messages`)
       .set('Authorization', `Bearer ${token}`)
       .set('Idempotency-Key', 'create-command-3')
       .send({ content: 'command target' });
     const messageId = created.body.messageId;
 
     const edited = await request(app)
-      .patch(`/api/v1/rooms/${roomId}/messages/${messageId}`)
+      .patch<MessageResponse>(`/api/v1/rooms/${roomId}/messages/${messageId}`)
       .set('Authorization', `Bearer ${token}`)
       .set('If-Match', '1')
       .set('Idempotency-Key', 'edit-command-3')
       .send({ content: 'edited once' });
     const editRetry = await request(app)
-      .patch(`/api/v1/rooms/${roomId}/messages/${messageId}`)
+      .patch<MessageResponse>(`/api/v1/rooms/${roomId}/messages/${messageId}`)
       .set('Authorization', `Bearer ${token}`)
       .set('If-Match', '1')
       .set('Idempotency-Key', 'edit-command-3')
@@ -122,13 +123,13 @@ describe('Realtime recovery REST contract', () => {
     expect(editRetry.body.revision).toBe(2);
 
     const laterEdit = await request(app)
-      .patch(`/api/v1/rooms/${roomId}/messages/${messageId}`)
+      .patch<MessageResponse>(`/api/v1/rooms/${roomId}/messages/${messageId}`)
       .set('Authorization', `Bearer ${token}`)
       .set('If-Match', '2')
       .set('Idempotency-Key', 'edit-command-3-later')
       .send({ content: 'edited later' });
     const editRetryAfterLaterEdit = await request(app)
-      .patch(`/api/v1/rooms/${roomId}/messages/${messageId}`)
+      .patch<MessageResponse>(`/api/v1/rooms/${roomId}/messages/${messageId}`)
       .set('Authorization', `Bearer ${token}`)
       .set('If-Match', '1')
       .set('Idempotency-Key', 'edit-command-3')
@@ -138,12 +139,12 @@ describe('Realtime recovery REST contract', () => {
     expect(editRetryAfterLaterEdit.body.revision).toBe(2);
 
     const recalled = await request(app)
-      .post(`/api/v1/rooms/${roomId}/messages/${messageId}/recall`)
+      .post<MessageResponse>(`/api/v1/rooms/${roomId}/messages/${messageId}/recall`)
       .set('Authorization', `Bearer ${token}`)
       .set('If-Match', '3')
       .set('Idempotency-Key', 'recall-command-3');
     const recallRetry = await request(app)
-      .post(`/api/v1/rooms/${roomId}/messages/${messageId}/recall`)
+      .post<MessageResponse>(`/api/v1/rooms/${roomId}/messages/${messageId}/recall`)
       .set('Authorization', `Bearer ${token}`)
       .set('If-Match', '3')
       .set('Idempotency-Key', 'recall-command-3');
@@ -153,12 +154,12 @@ describe('Realtime recovery REST contract', () => {
     expect(recallRetry.body.revision).toBe(4);
 
     const read = await request(app)
-      .put(`/api/v1/rooms/${roomId}/read-position`)
+      .put<ReadPositionResponse>(`/api/v1/rooms/${roomId}/read-position`)
       .set('Authorization', `Bearer ${token}`)
       .set('Idempotency-Key', 'read-command-3')
       .send({ messageId });
     const readRetry = await request(app)
-      .put(`/api/v1/rooms/${roomId}/read-position`)
+      .put<ReadPositionResponse>(`/api/v1/rooms/${roomId}/read-position`)
       .set('Authorization', `Bearer ${token}`)
       .set('Idempotency-Key', 'read-command-3')
       .send({ messageId });
@@ -171,20 +172,20 @@ describe('Realtime recovery REST contract', () => {
     // Every one of these used to reach a `uuid` comparison, raise 22P02 in
     // PostgreSQL, and surface as a 500 — a client mistake reported as an outage.
     const bad = 'not-a-uuid';
-    const auth = (req: HttpRequest) => req.set('Authorization', `Bearer ${token}`);
+    const auth = <T>(req: HttpRequest<T>) => req.set('Authorization', `Bearer ${token}`);
 
-    const list = await auth(request(app).get(`/api/v1/rooms/${bad}/messages`));
-    const create = await auth(request(app).post(`/api/v1/rooms/${bad}/messages`))
+    const list = await auth(request(app).get<MessageResponse[]>(`/api/v1/rooms/${bad}/messages`));
+    const create = await auth(request(app).post<MessageResponse>(`/api/v1/rooms/${bad}/messages`))
       .set('Idempotency-Key', 'bad-path-create')
       .send({ content: 'x' });
-    const edit = await auth(request(app).patch(`/api/v1/rooms/${bad}/messages/${bad}`))
+    const edit = await auth(request(app).patch<MessageResponse>(`/api/v1/rooms/${bad}/messages/${bad}`))
       .set('If-Match', '1')
       .set('Idempotency-Key', 'bad-path-edit')
       .send({ content: 'x' });
-    const recall = await auth(request(app).post(`/api/v1/rooms/${bad}/messages/${bad}/recall`))
+    const recall = await auth(request(app).post<MessageResponse>(`/api/v1/rooms/${bad}/messages/${bad}/recall`))
       .set('If-Match', '1')
       .set('Idempotency-Key', 'bad-path-recall');
-    const read = await auth(request(app).put(`/api/v1/rooms/${bad}/read-position`))
+    const read = await auth(request(app).put<ReadPositionResponse>(`/api/v1/rooms/${bad}/read-position`))
       .set('Idempotency-Key', 'bad-path-read')
       .send({ messageId: '00000000-0000-4000-8000-000000000000' });
 
@@ -196,7 +197,7 @@ describe('Realtime recovery REST contract', () => {
     // Without a schema this string reaches a `uuid` comparison, PostgreSQL
     // raises 22P02, and the generic handler reports a client mistake as a 500.
     const response = await request(app)
-      .put(`/api/v1/rooms/${roomId}/read-position`)
+      .put<ReadPositionResponse>(`/api/v1/rooms/${roomId}/read-position`)
       .set('Authorization', `Bearer ${token}`)
       .set('Idempotency-Key', 'read-command-malformed')
       .send({ messageId: 'not-a-uuid' });
@@ -206,14 +207,14 @@ describe('Realtime recovery REST contract', () => {
 
   it('keeps a no-op recall key out of the create and edit namespaces', async () => {
     const created = await request(app)
-      .post(`/api/v1/rooms/${roomId}/messages`)
+      .post<MessageResponse>(`/api/v1/rooms/${roomId}/messages`)
       .set('Authorization', `Bearer ${token}`)
       .set('Idempotency-Key', 'noop-target-create')
       .send({ content: 'recall me' });
     const messageId = created.body.messageId;
 
     const firstRecall = await request(app)
-      .post(`/api/v1/rooms/${roomId}/messages/${messageId}/recall`)
+      .post<MessageResponse>(`/api/v1/rooms/${roomId}/messages/${messageId}/recall`)
       .set('Authorization', `Bearer ${token}`)
       .set('If-Match', String(created.body.revision))
       .set('Idempotency-Key', 'noop-recall-first');
@@ -223,7 +224,7 @@ describe('Realtime recovery REST contract', () => {
     // so nothing is committed and no Message Change is published — but the key
     // is spent all the same.
     const secondRecall = await request(app)
-      .post(`/api/v1/rooms/${roomId}/messages/${messageId}/recall`)
+      .post<MessageResponse>(`/api/v1/rooms/${roomId}/messages/${messageId}/recall`)
       .set('Authorization', `Bearer ${token}`)
       .set('If-Match', String(firstRecall.body.revision))
       .set('Idempotency-Key', 'noop-recall-second');
@@ -233,7 +234,7 @@ describe('Realtime recovery REST contract', () => {
 
     // Replaying it stays a success and still reports the same message.
     const secondRecallRetry = await request(app)
-      .post(`/api/v1/rooms/${roomId}/messages/${messageId}/recall`)
+      .post<MessageResponse>(`/api/v1/rooms/${roomId}/messages/${messageId}/recall`)
       .set('Authorization', `Bearer ${token}`)
       .set('If-Match', String(firstRecall.body.revision))
       .set('Idempotency-Key', 'noop-recall-second');
@@ -244,19 +245,19 @@ describe('Realtime recovery REST contract', () => {
     // Create, edit and recall share one idempotency namespace, so the spent key
     // must not be usable for another operation.
     const reusedForCreate = await request(app)
-      .post(`/api/v1/rooms/${roomId}/messages`)
+      .post<MessageResponse>(`/api/v1/rooms/${roomId}/messages`)
       .set('Authorization', `Bearer ${token}`)
       .set('Idempotency-Key', 'noop-recall-second')
       .send({ content: 'should not be created' });
     expect(reusedForCreate.status).toBe(409);
 
     const other = await request(app)
-      .post(`/api/v1/rooms/${roomId}/messages`)
+      .post<MessageResponse>(`/api/v1/rooms/${roomId}/messages`)
       .set('Authorization', `Bearer ${token}`)
       .set('Idempotency-Key', 'noop-other-create')
       .send({ content: 'edit me' });
     const reusedForEdit = await request(app)
-      .patch(`/api/v1/rooms/${roomId}/messages/${other.body.messageId}`)
+      .patch<MessageResponse>(`/api/v1/rooms/${roomId}/messages/${other.body.messageId}`)
       .set('Authorization', `Bearer ${token}`)
       .set('If-Match', String(other.body.revision))
       .set('Idempotency-Key', 'noop-recall-second')
@@ -264,7 +265,7 @@ describe('Realtime recovery REST contract', () => {
     expect(reusedForEdit.status).toBe(409);
 
     const listed = await request(app)
-      .get(`/api/v1/rooms/${roomId}/messages`)
+      .get<MessageResponse[]>(`/api/v1/rooms/${roomId}/messages`)
       .set('Authorization', `Bearer ${token}`);
     expect(listed.body.map((message: { messageId: string }) => message.messageId).sort())
       .toEqual([messageId, other.body.messageId].sort());

--- a/backend/tests/e2e/routes/room.e2e.test.ts
+++ b/backend/tests/e2e/routes/room.e2e.test.ts
@@ -1,9 +1,11 @@
+import type { Hono } from 'hono';
 import { describe, it, expect, beforeAll, beforeEach } from 'bun:test';
 import { request } from '../../helpers/http';
 import sharp from 'sharp';
 import { resetDb } from '../../helpers/resetDb';
+import type { AuthResponse, RoomResponse, RoomListEntry } from '../../helpers/responseTypes';
 
-let app: any;
+let app: Hono;
 
 // Avatar uploads are decoded and re-encoded to WebP server-side, so the
 // fixture has to be a genuinely decodable image — a bare PNG magic-byte
@@ -30,7 +32,7 @@ describe('Room E2E', () => {
 
   beforeEach(async () => {
     await resetDb();
-    const res = await request(app).post('/api/v1/auth/register').send({
+    const res = await request(app).post<AuthResponse>('/api/v1/auth/register').send({
       name: 'User',
       email: 'user@example.com',
       password: 'Password123!',
@@ -38,7 +40,7 @@ describe('Room E2E', () => {
     token = res.body.token;
     userId = res.body.user.userId;
 
-    const otherRes = await request(app).post('/api/v1/auth/register').send({
+    const otherRes = await request(app).post<AuthResponse>('/api/v1/auth/register').send({
       name: 'Other User',
       email: 'other@example.com',
       password: 'Password123!',
@@ -46,7 +48,7 @@ describe('Room E2E', () => {
     otherToken = otherRes.body.token;
     otherUserId = otherRes.body.user.userId;
 
-    const thirdRes = await request(app).post('/api/v1/auth/register').send({
+    const thirdRes = await request(app).post<AuthResponse>('/api/v1/auth/register').send({
       name: 'Third User',
       email: 'third@example.com',
       password: 'Password123!',
@@ -68,7 +70,7 @@ describe('Room E2E', () => {
 
   it('should create a room', async () => {
     const res = await request(app)
-      .post('/api/v1/rooms')
+      .post<RoomResponse>('/api/v1/rooms')
       .set('Authorization', `Bearer ${token}`)
       .send({
         type: 'group',
@@ -85,7 +87,7 @@ describe('Room E2E', () => {
     // room with name = NULL.
     for (const payload of [{}, { type: 'group' }]) {
       const res = await request(app)
-        .post('/api/v1/rooms')
+        .post<RoomResponse>('/api/v1/rooms')
         .set('Authorization', `Bearer ${token}`)
         .send(payload);
 
@@ -93,14 +95,14 @@ describe('Room E2E', () => {
     }
 
     const list = await request(app)
-      .get('/api/v1/rooms')
+      .get<RoomListEntry[]>('/api/v1/rooms')
       .set('Authorization', `Bearer ${token}`);
     expect(list.body.length).toBe(0);
   });
 
   it('should list rooms', async () => {
     await request(app)
-      .post('/api/v1/rooms')
+      .post<RoomResponse>('/api/v1/rooms')
       .set('Authorization', `Bearer ${token}`)
       .send({
         type: 'group',
@@ -108,7 +110,7 @@ describe('Room E2E', () => {
       });
 
     const res = await request(app)
-      .get('/api/v1/rooms')
+      .get<RoomListEntry[]>('/api/v1/rooms')
       .set('Authorization', `Bearer ${token}`);
     expect(res.status).toBe(200);
     expect(Array.isArray(res.body)).toBe(true);
@@ -119,7 +121,7 @@ describe('Room E2E', () => {
 
   it('should create a group with avatar and generated invite code, then join by code', async () => {
     const createRes = await request(app)
-      .post('/api/v1/rooms')
+      .post<RoomResponse>('/api/v1/rooms')
       .set('Authorization', `Bearer ${token}`)
       .send({
         type: 'group',
@@ -132,7 +134,7 @@ describe('Room E2E', () => {
     expect(createRes.body.inviteCode).toEqual(expect.any(String));
 
     const joinRes = await request(app)
-      .post(`/api/v1/rooms/${createRes.body.roomId}/members`)
+      .post<RoomResponse>(`/api/v1/rooms/${createRes.body.roomId}/members`)
       .set('Authorization', `Bearer ${otherToken}`)
       .send({ inviteCode: createRes.body.inviteCode });
 
@@ -142,7 +144,7 @@ describe('Room E2E', () => {
 
   it('should preview a room by invite code without joining, then reflect membership after joining', async () => {
     const createRes = await request(app)
-      .post('/api/v1/rooms')
+      .post<RoomResponse>('/api/v1/rooms')
       .set('Authorization', `Bearer ${token}`)
       .send({
         type: 'group',
@@ -152,7 +154,7 @@ describe('Room E2E', () => {
     const inviteCode = createRes.body.inviteCode;
 
     const previewRes = await request(app)
-      .get(`/api/v1/rooms/invite/${inviteCode}`)
+      .get<RoomResponse>(`/api/v1/rooms/invite/${inviteCode}`)
       .set('Authorization', `Bearer ${otherToken}`);
 
     expect(previewRes.status).toBe(200);
@@ -166,12 +168,12 @@ describe('Room E2E', () => {
     });
 
     await request(app)
-      .post(`/api/v1/rooms/${createRes.body.roomId}/members`)
+      .post<RoomResponse>(`/api/v1/rooms/${createRes.body.roomId}/members`)
       .set('Authorization', `Bearer ${otherToken}`)
       .send({ inviteCode });
 
     const previewAfterJoinRes = await request(app)
-      .get(`/api/v1/rooms/invite/${inviteCode}`)
+      .get<RoomResponse>(`/api/v1/rooms/invite/${inviteCode}`)
       .set('Authorization', `Bearer ${otherToken}`);
 
     expect(previewAfterJoinRes.status).toBe(200);
@@ -180,7 +182,7 @@ describe('Room E2E', () => {
 
   it('should report isPending when previewing an approval-required group already requested', async () => {
     const createRes = await request(app)
-      .post('/api/v1/rooms')
+      .post<RoomResponse>('/api/v1/rooms')
       .set('Authorization', `Bearer ${token}`)
       .send({
         type: 'group',
@@ -190,12 +192,12 @@ describe('Room E2E', () => {
     const inviteCode = createRes.body.inviteCode;
 
     await request(app)
-      .post(`/api/v1/rooms/${createRes.body.roomId}/members`)
+      .post<RoomResponse>(`/api/v1/rooms/${createRes.body.roomId}/members`)
       .set('Authorization', `Bearer ${otherToken}`)
       .send({ inviteCode });
 
     const previewRes = await request(app)
-      .get(`/api/v1/rooms/invite/${inviteCode}`)
+      .get<RoomResponse>(`/api/v1/rooms/invite/${inviteCode}`)
       .set('Authorization', `Bearer ${otherToken}`);
 
     expect(previewRes.status).toBe(200);
@@ -219,11 +221,11 @@ describe('Room E2E', () => {
     await makeFriends();
 
     const first = await request(app)
-      .post('/api/v1/rooms')
+      .post<RoomResponse>('/api/v1/rooms')
       .set('Authorization', `Bearer ${token}`)
       .send({ type: 'private', target_user_id: otherUserId });
     const second = await request(app)
-      .post('/api/v1/rooms')
+      .post<RoomResponse>('/api/v1/rooms')
       .set('Authorization', `Bearer ${token}`)
       .send({ type: 'private', target_user_id: otherUserId });
 
@@ -234,13 +236,13 @@ describe('Room E2E', () => {
     expect(second.body.roomId).toBe(first.body.roomId);
     expect(second.body.roomHash).toBeUndefined();
 
-    const ownerRooms = await request(app).get('/api/v1/rooms').set('Authorization', `Bearer ${token}`);
-    const otherRooms = await request(app).get('/api/v1/rooms').set('Authorization', `Bearer ${otherToken}`);
+    const ownerRooms = await request(app).get<RoomListEntry[]>('/api/v1/rooms').set('Authorization', `Bearer ${token}`);
+    const otherRooms = await request(app).get<RoomListEntry[]>('/api/v1/rooms').set('Authorization', `Bearer ${otherToken}`);
     expect(ownerRooms.body.some((room: { roomId: string }) => room.roomId === first.body.roomId)).toBe(true);
     expect(otherRooms.body.some((room: { roomId: string }) => room.roomId === first.body.roomId)).toBe(true);
 
     const outsider = await request(app)
-      .get(`/api/v1/rooms/${first.body.roomId}`)
+      .get<RoomResponse>(`/api/v1/rooms/${first.body.roomId}`)
       .set('Authorization', `Bearer ${thirdToken}`);
     expect(outsider.status).toBe(403);
   });
@@ -254,7 +256,7 @@ describe('Room E2E', () => {
       .send({ target_user_id: otherUserId });
 
     const res = await request(app)
-      .post('/api/v1/rooms')
+      .post<RoomResponse>('/api/v1/rooms')
       .set('Authorization', `Bearer ${token}`)
       .send({ type: 'private', target_user_id: otherUserId });
 
@@ -263,7 +265,7 @@ describe('Room E2E', () => {
 
   it('should permanently delete a group room for the owner', async () => {
     const createRes = await request(app)
-      .post('/api/v1/rooms')
+      .post<RoomResponse>('/api/v1/rooms')
       .set('Authorization', `Bearer ${token}`)
       .send({
         type: 'group',
@@ -271,7 +273,7 @@ describe('Room E2E', () => {
       });
 
     await request(app)
-      .post(`/api/v1/rooms/${createRes.body.roomId}/members`)
+      .post<RoomResponse>(`/api/v1/rooms/${createRes.body.roomId}/members`)
       .set('Authorization', `Bearer ${otherToken}`)
       .send({ inviteCode: createRes.body.inviteCode });
 
@@ -282,24 +284,24 @@ describe('Room E2E', () => {
     expect(deleteRes.status).toBe(204);
 
     const ownerRooms = await request(app)
-      .get('/api/v1/rooms')
+      .get<RoomListEntry[]>('/api/v1/rooms')
       .set('Authorization', `Bearer ${token}`);
     const memberRooms = await request(app)
-      .get('/api/v1/rooms')
+      .get<RoomListEntry[]>('/api/v1/rooms')
       .set('Authorization', `Bearer ${otherToken}`);
 
     expect(ownerRooms.body.some((room: { roomId: string }) => room.roomId === createRes.body.roomId)).toBe(false);
     expect(memberRooms.body.some((room: { roomId: string }) => room.roomId === createRes.body.roomId)).toBe(false);
 
     const fetchDeleted = await request(app)
-      .get(`/api/v1/rooms/${createRes.body.roomId}`)
+      .get<RoomResponse>(`/api/v1/rooms/${createRes.body.roomId}`)
       .set('Authorization', `Bearer ${token}`);
     expect(fetchDeleted.status).toBe(404);
   });
 
   it('should upload group avatar successfully by owner', async () => {
     const createRes = await request(app)
-      .post('/api/v1/rooms')
+      .post<RoomResponse>('/api/v1/rooms')
       .set('Authorization', `Bearer ${token}`)
       .send({
         type: 'group',
@@ -310,26 +312,27 @@ describe('Room E2E', () => {
 
     const buffer = await makeRealPngBuffer();
     const uploadRes = await request(app)
-      .post(`/api/v1/rooms/${roomId}/avatar`)
+      .post<RoomResponse>(`/api/v1/rooms/${roomId}/avatar`)
       .set('Authorization', `Bearer ${token}`)
       .attach('file', buffer, 'avatar.png');
 
     expect(uploadRes.status).toBe(200);
-    expect(uploadRes.body.avatarUrl).toContain('/uploads/avatars/');
+    expect(uploadRes.body.avatarUrl).toBeDefined();
+    expect(uploadRes.body.avatarUrl!).toContain('/uploads/avatars/');
     // Stored avatars are always re-encoded to WebP regardless of upload format.
-    expect(uploadRes.body.avatarUrl.endsWith('.webp')).toBe(true);
+    expect(uploadRes.body.avatarUrl!.endsWith('.webp')).toBe(true);
 
     // Clean up uploaded file
     const fs = await import('fs/promises');
     const path = await import('path');
-    const filename = path.basename(uploadRes.body.avatarUrl);
+    const filename = path.basename(uploadRes.body.avatarUrl!);
     const filepath = path.resolve(process.cwd(), 'uploads/avatars', filename);
     await fs.unlink(filepath).catch(() => {});
   });
 
   it('should reject avatar upload by non-admin member', async () => {
     const createRes = await request(app)
-      .post('/api/v1/rooms')
+      .post<RoomResponse>('/api/v1/rooms')
       .set('Authorization', `Bearer ${token}`)
       .send({
         type: 'group',
@@ -338,7 +341,7 @@ describe('Room E2E', () => {
     const roomId = createRes.body.roomId;
 
     await request(app)
-      .post(`/api/v1/rooms/${roomId}/members`)
+      .post<RoomResponse>(`/api/v1/rooms/${roomId}/members`)
       .set('Authorization', `Bearer ${otherToken}`)
       .send({ inviteCode: createRes.body.inviteCode });
 
@@ -346,7 +349,7 @@ describe('Room E2E', () => {
     // permission check, never from image decoding failing first.
     const buffer = await makeRealPngBuffer();
     const uploadRes = await request(app)
-      .post(`/api/v1/rooms/${roomId}/avatar`)
+      .post<RoomResponse>(`/api/v1/rooms/${roomId}/avatar`)
       .set('Authorization', `Bearer ${otherToken}`)
       .attach('file', buffer, 'avatar.png');
 

--- a/backend/tests/e2e/routes/roomMembers.e2e.test.ts
+++ b/backend/tests/e2e/routes/roomMembers.e2e.test.ts
@@ -1,9 +1,11 @@
+import type { Hono } from 'hono';
 import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'bun:test';
 import { request } from '../../helpers/http';
 import { resetDb } from '../../helpers/resetDb';
+import type { AuthResponse, RoomResponse, RoomMemberResponse } from '../../helpers/responseTypes';
 import { testPool } from '../../helpers/testPool';
 
-let app: any;
+let app: Hono;
 
 beforeAll(async () => {
   process.env.DATABASE_URL = process.env.DATABASE_URL_TEST;
@@ -28,39 +30,39 @@ describe('Room Members E2E', () => {
     await resetDb();
     
     // Register owner
-    let res = await request(app).post('/api/v1/auth/register').send({
+    let res = await request(app).post<AuthResponse>('/api/v1/auth/register').send({
       name: 'Owner', email: 'owner@example.com', password: 'Password123!',
     });
     ownerToken = res.body.token;
     ownerId = res.body.user.userId;
 
     // Register admin
-    res = await request(app).post('/api/v1/auth/register').send({
+    res = await request(app).post<AuthResponse>('/api/v1/auth/register').send({
       name: 'Admin', email: 'admin@example.com', password: 'Password123!',
     });
     adminToken = res.body.token;
     adminId = res.body.user.userId;
 
     // Register member
-    res = await request(app).post('/api/v1/auth/register').send({
+    res = await request(app).post<AuthResponse>('/api/v1/auth/register').send({
       name: 'Member', email: 'member@example.com', password: 'Password123!',
     });
     memberToken = res.body.token;
     memberId = res.body.user.userId;
     
     // Register pending
-    res = await request(app).post('/api/v1/auth/register').send({
+    res = await request(app).post<AuthResponse>('/api/v1/auth/register').send({
       name: 'Pending', email: 'pending@example.com', password: 'Password123!',
     });
     pendingToken = res.body.token;
     pendingId = res.body.user.userId;
 
     // Create room
-    res = await request(app)
-      .post('/api/v1/rooms')
+    const roomRes = await request(app)
+      .post<RoomResponse>('/api/v1/rooms')
       .set('Authorization', `Bearer ${ownerToken}`)
       .send({ type: 'group', name: 'Test Room', requireApproval: true });
-    roomId = res.body.roomId;
+    roomId = roomRes.body.roomId;
 
     const adminRole = 'admin';
     const memberRole = 'member';
@@ -96,7 +98,7 @@ describe('Room Members E2E', () => {
   describe('GET /rooms/:id/members', () => {
     it('should list room members for an existing member', async () => {
       const res = await request(app)
-        .get(`/api/v1/rooms/${roomId}/members`)
+        .get<RoomMemberResponse[]>(`/api/v1/rooms/${roomId}/members`)
         .set('Authorization', `Bearer ${memberToken}`);
 
       expect(res.status).toBe(200);
@@ -110,12 +112,12 @@ describe('Room Members E2E', () => {
     });
 
     it('should reject non-members', async () => {
-      const outsider = await request(app).post('/api/v1/auth/register').send({
+      const outsider = await request(app).post<AuthResponse>('/api/v1/auth/register').send({
         name: 'Outsider', email: 'outsider@example.com', password: 'Password123!',
       });
 
       const res = await request(app)
-        .get(`/api/v1/rooms/${roomId}/members`)
+        .get<RoomMemberResponse[]>(`/api/v1/rooms/${roomId}/members`)
         .set('Authorization', `Bearer ${outsider.body.token}`);
 
       expect(res.status).toBe(403);
@@ -181,7 +183,7 @@ describe('Room Members E2E', () => {
 
     it('should transfer ownership from owner to admin', async () => {
       const res = await request(app)
-        .patch(`/api/v1/rooms/${roomId}`)
+        .patch<{ message: string; name?: string }>(`/api/v1/rooms/${roomId}`)
         .set('Authorization', `Bearer ${ownerToken}`)
         .send({ ownerId: adminId });
 
@@ -195,7 +197,7 @@ describe('Room Members E2E', () => {
 
     it('should not allow a non-owner to transfer ownership', async () => {
       const res = await request(app)
-        .patch(`/api/v1/rooms/${roomId}`)
+        .patch<{ message: string; name?: string }>(`/api/v1/rooms/${roomId}`)
         .set('Authorization', `Bearer ${adminToken}`)
         .send({ ownerId: memberId });
 
@@ -205,7 +207,7 @@ describe('Room Members E2E', () => {
 
     it('should reject transferring ownership to a pending member', async () => {
       const res = await request(app)
-        .patch(`/api/v1/rooms/${roomId}`)
+        .patch<{ message: string; name?: string }>(`/api/v1/rooms/${roomId}`)
         .set('Authorization', `Bearer ${ownerToken}`)
         .send({ ownerId: pendingId });
 
@@ -215,7 +217,7 @@ describe('Room Members E2E', () => {
 
     it('should still update room settings when no ownerId is sent', async () => {
       const res = await request(app)
-        .patch(`/api/v1/rooms/${roomId}`)
+        .patch<{ message: string; name?: string }>(`/api/v1/rooms/${roomId}`)
         .set('Authorization', `Bearer ${ownerToken}`)
         .send({ name: 'Renamed Room' });
 

--- a/backend/tests/e2e/routes/user.e2e.test.ts
+++ b/backend/tests/e2e/routes/user.e2e.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, beforeAll, beforeEach } from 'bun:test';
+import type { Hono } from 'hono';
 import { request } from '../../helpers/http';
 import { resetDb } from '../../helpers/resetDb';
+import type { AuthResponse, UserProfileResponse } from '../../helpers/responseTypes';
 
-let app: any;
+let app: Hono;
 
 beforeAll(async () => {
   process.env.DATABASE_URL = process.env.DATABASE_URL_TEST;
@@ -16,7 +18,7 @@ describe('User E2E', () => {
 
   beforeEach(async () => {
     await resetDb();
-    const res = await request(app).post('/api/v1/auth/register').send({
+    const res = await request(app).post<AuthResponse>('/api/v1/auth/register').send({
       name: 'User',
       email: 'user@example.com',
       password: 'Password123!',
@@ -27,7 +29,7 @@ describe('User E2E', () => {
 
   it('should get current user profile', async () => {
     const res = await request(app)
-      .get('/api/v1/users/me')
+      .get<UserProfileResponse>('/api/v1/users/me')
       .set('Authorization', `Bearer ${token}`);
     expect(res.status).toBe(200);
     expect(res.body.userId).toBe(userId);

--- a/backend/tests/e2e/socket/emergencyAlert.e2e.test.ts
+++ b/backend/tests/e2e/socket/emergencyAlert.e2e.test.ts
@@ -5,12 +5,13 @@ import { io as createClient, type Socket as ClientSocket } from 'socket.io-clien
 import { honoApp as app, server } from '../../../src/index';
 import { resetDb } from '../../helpers/resetDb';
 import type { ClientToServerEvents, ServerToClientEvents, Message } from '../../../../shared/types';
+import type { AuthResponse, RoomResponse } from '../../helpers/responseTypes';
 
 type TestClient = ClientSocket<ServerToClientEvents, ClientToServerEvents>;
 
-const waitFor = <T>(socket: TestClient, event: keyof ServerToClientEvents): Promise<T> =>
+const waitForMessage = (socket: TestClient): Promise<Message> =>
   new Promise((resolve) => {
-    socket.once(event, (payload: any) => resolve(payload as T));
+    socket.once('new_message', resolve);
   });
 
 describe('Emergency alert Socket.IO E2E', () => {
@@ -57,12 +58,12 @@ describe('Emergency alert Socket.IO E2E', () => {
     });
 
   it('sends real chat message to configured emergency contacts (private room)', async () => {
-    const userRes = await request(app).post('/api/v1/auth/register').send({
+    const userRes = await request(app).post<AuthResponse>('/api/v1/auth/register').send({
       name: 'Alert User',
       email: 'alert-user@example.com',
       password: 'Password123!',
     });
-    const contactRes = await request(app).post('/api/v1/auth/register').send({
+    const contactRes = await request(app).post<AuthResponse>('/api/v1/auth/register').send({
       name: 'Contact User',
       email: 'contact-user@example.com',
       password: 'Password123!',
@@ -78,7 +79,7 @@ describe('Emergency alert Socket.IO E2E', () => {
 
     // explicitly create private room
     const roomRes = await request(app)
-      .post('/api/v1/rooms')
+      .post<RoomResponse>('/api/v1/rooms')
       .set('Authorization', `Bearer ${userRes.body.token}`)
       .send({ type: 'private', targetUserId: contactRes.body.user.userId });
     expect([200, 201]).toContain(roomRes.status);
@@ -105,10 +106,7 @@ describe('Emergency alert Socket.IO E2E', () => {
     
     // Room subscriptions are derived from the contact's durable membership.
 
-    const messagePayload = waitFor<Message>(
-      contactSocket,
-      'new_message',
-    );
+    const messagePayload = waitForMessage(contactSocket);
 
     const triggerRes = await request(app)
       .post('/api/v1/users/me/emergency-alert/check-inactivity')

--- a/backend/tests/helpers/http.ts
+++ b/backend/tests/helpers/http.ts
@@ -1,6 +1,6 @@
 import type { Hono } from 'hono';
 
-export type TestResponseBody = any;
+export type TestResponseBody = unknown;
 
 export interface TestResponse<T = TestResponseBody> {
   status: number;
@@ -9,7 +9,15 @@ export interface TestResponse<T = TestResponseBody> {
   text: string;
 }
 
-type Parser = (stream: { on(event: string, listener: (chunk?: Buffer) => void): void }, callback: (error: Error | null, value?: unknown) => void) => void;
+type ResponseStream = {
+  on(event: 'data', listener: (chunk: Buffer) => void): void;
+  on(event: 'end', listener: () => void): void;
+};
+
+export type ResponseParser<T> = (
+  stream: ResponseStream,
+  callback: (error: Error | null, value?: T) => void,
+) => void;
 
 type RequestBody = BodyInit | undefined;
 
@@ -25,14 +33,14 @@ const responseHeaders = (headers: Headers): Record<string, string | string[] | u
   return result;
 };
 
-const parseResponse = async <T>(response: Response, parser?: Parser): Promise<T> => {
+const parseResponse = async <T>(response: Response, parser?: ResponseParser<T>): Promise<T> => {
   const bytes = Buffer.from(await response.arrayBuffer());
   if (parser) {
     return await new Promise<T>((resolve, reject) => {
       let onData: ((chunk: Buffer) => void) | undefined;
       let onEnd: (() => void) | undefined;
       const stream = {
-        on(event: string, listener: (chunk?: Buffer) => void) {
+        on(event: 'data' | 'end', listener: ((chunk: Buffer) => void) | (() => void)) {
           if (event === 'data') onData = listener as (chunk: Buffer) => void;
           if (event === 'end') onEnd = listener as () => void;
         },
@@ -50,12 +58,12 @@ const parseResponse = async <T>(response: Response, parser?: Parser): Promise<T>
   return bytes as T;
 };
 
-export class HttpRequest<T = TestResponse> implements PromiseLike<T> {
+export class HttpRequest<T = TestResponseBody> implements PromiseLike<TestResponse<T>> {
   private readonly headers = new Headers();
   private body: RequestBody;
-  private parser?: Parser;
+  private parser?: ResponseParser<T>;
   private expectedStatus?: number;
-  private assertion?: (response: T) => void;
+  private assertion?: (response: TestResponse<T>) => void;
 
   public constructor(
     private readonly app: Hono,
@@ -93,32 +101,32 @@ export class HttpRequest<T = TestResponse> implements PromiseLike<T> {
     return this;
   }
 
-  public parse(parser: Parser): this {
+  public parse(parser: ResponseParser<T>): this {
     this.parser = parser;
     return this;
   }
 
   public expect(expected: number): this;
-  public expect(assertion: (response: T) => void): this;
-  public expect(expectedOrAssertion: number | ((response: T) => void)): this {
+  public expect(assertion: (response: TestResponse<T>) => void): this;
+  public expect(expectedOrAssertion: number | ((response: TestResponse<T>) => void)): this {
     if (typeof expectedOrAssertion === 'number') this.expectedStatus = expectedOrAssertion;
     else this.assertion = expectedOrAssertion;
     return this;
   }
 
-  private async execute(): Promise<T> {
+  private async execute(): Promise<TestResponse<T>> {
     const response = await this.app.request(this.path, {
       method: this.method,
       headers: this.headers,
       body: this.body,
     });
     const body = await parseResponse<T>(response, this.parser);
-    const result = {
+    const result: TestResponse<T> = {
       status: response.status,
       headers: responseHeaders(response.headers),
       body,
       text: typeof body === 'string' ? body : Buffer.isBuffer(body) ? body.toString('utf8') : JSON.stringify(body),
-    } as T;
+    };
 
     if (this.expectedStatus !== undefined && response.status !== this.expectedStatus) {
       throw new Error(`Expected status ${this.expectedStatus}, received ${response.status}`);
@@ -127,8 +135,8 @@ export class HttpRequest<T = TestResponse> implements PromiseLike<T> {
     return result;
   }
 
-  public then<TResult1 = T, TResult2 = never>(
-    onFulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | null,
+  public then<TResult1 = TestResponse<T>, TResult2 = never>(
+    onFulfilled?: ((value: TestResponse<T>) => TResult1 | PromiseLike<TResult1>) | null,
     onRejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
   ): Promise<TResult1 | TResult2> {
     return this.execute().then(onFulfilled, onRejected);
@@ -136,16 +144,17 @@ export class HttpRequest<T = TestResponse> implements PromiseLike<T> {
 }
 
 export interface HttpRequestFactory {
-  get(path: string): HttpRequest;
-  options(path: string): HttpRequest;
-  post(path: string): HttpRequest;
-  put(path: string): HttpRequest;
-  patch(path: string): HttpRequest;
-  delete(path: string): HttpRequest;
+  get<T = TestResponseBody>(path: string): HttpRequest<T>;
+  options<T = TestResponseBody>(path: string): HttpRequest<T>;
+  post<T = TestResponseBody>(path: string): HttpRequest<T>;
+  put<T = TestResponseBody>(path: string): HttpRequest<T>;
+  patch<T = TestResponseBody>(path: string): HttpRequest<T>;
+  delete<T = TestResponseBody>(path: string): HttpRequest<T>;
 }
 
 export const request = (app: Hono): HttpRequestFactory => {
-  const create = (method: string) => (path: string) => new HttpRequest(app, method, path);
+  const create = (method: string) => <T = TestResponseBody>(path: string) =>
+    new HttpRequest<T>(app, method, path);
   return {
     get: create('GET'),
     options: create('OPTIONS'),

--- a/backend/tests/helpers/responseTypes.ts
+++ b/backend/tests/helpers/responseTypes.ts
@@ -1,0 +1,137 @@
+export interface AuthUser {
+  userId: string;
+  name: string;
+}
+
+export interface AuthResponse {
+  token: string;
+  accessToken?: string;
+  user: AuthUser;
+}
+
+export interface ApiErrorResponse {
+  code: string;
+  message?: string;
+}
+
+export interface AdminHealthResponse {
+  status: string;
+  code?: string;
+}
+
+export interface UserProfileResponse extends AuthUser {
+  email?: string;
+}
+
+export interface RoomResponse {
+  roomId: string;
+  type?: string;
+  name?: string;
+  avatarUrl?: string;
+  inviteCode?: string;
+  requireApproval?: boolean;
+  isMember?: boolean;
+  isPending?: boolean;
+  roomHash?: string;
+  unreadCount?: number;
+}
+
+export interface RoomListEntry extends RoomResponse {
+  roomId: string;
+}
+
+export interface MessageResponse {
+  messageId: string;
+  code?: string;
+  roomId?: string;
+  content: string;
+  messageSequence?: number;
+  changeSequence?: number;
+  revision: number;
+  isRecalled?: boolean;
+}
+
+export interface SyncResponse {
+  changes: Array<{
+    changeSequence: number;
+    messageSequence: number;
+    revision: number;
+    changeType: string;
+  }>;
+}
+
+export interface ReadPositionResponse {
+  readPosition: number;
+}
+
+export interface FriendRequestResponse {
+  status: string;
+  requester?: AuthUser;
+  requesterId?: string;
+  addressee?: AuthUser;
+  addresseeId?: string;
+}
+
+export interface PendingFriendRequestResponse extends FriendRequestResponse {
+  requester: AuthUser;
+}
+
+export interface FriendListEntry {
+  friend: AuthUser;
+}
+
+export type BlockedUser = AuthUser;
+
+export interface AttachmentResponse {
+  attachmentId: string;
+  fileType?: string;
+  originalName?: string;
+  fileUrl?: string;
+}
+
+export interface EmergencyContactResponse {
+  contactId: string;
+  message: string;
+  contact: AuthUser;
+  warningEnabled?: boolean;
+  warningDays?: number;
+}
+
+export interface FolderResponse {
+  folderId: string;
+  name: string;
+  description?: string;
+  roomIds?: string[];
+}
+
+export interface RoomMemberResponse {
+  userId: string;
+  role: string;
+}
+
+export interface AdminMetricsResponse {
+  requests: {
+    totalRequests: number;
+    statusClasses: Record<string, number>;
+    latency: Record<string, number>;
+  };
+  process: {
+    memory: { rssBytes: number };
+    uptimeSeconds: number;
+    cpu: { percent: number | null };
+  };
+  at: number;
+}
+
+export interface AdminLogsResponse {
+  retained: number;
+  capacity: number;
+  entries: Array<{ msg: string }>;
+}
+
+export interface AdminSlowQueriesResponse {
+  thresholdMs: number;
+  retained: number;
+  capacity: number;
+  queries: Array<{ query: string; durationMs: number; at: number }>;
+}

--- a/backend/tests/unit/helpers/http.test.ts
+++ b/backend/tests/unit/helpers/http.test.ts
@@ -8,12 +8,12 @@ describe('Hono HTTP test helper', () => {
     app.post('/echo', async (c) => c.json(await c.req.json(), 201));
 
     const response = await request(app)
-      .post('/echo')
+      .post<{ hello: string }>('/echo')
       .set('X-Test', 'present')
       .send({ hello: 'world' });
 
     expect(response.status).toBe(201);
-    expect(response.body).toEqual({ hello: 'world' });
+    expect(response.body.hello).toBe('world');
   });
 
   it('sends multipart uploads with the field name and filename intact', async () => {


### PR DESCRIPTION
## 摘要
- 移除 `backend/tests/e2e` HTTP request/response 路徑及 `backend/tests/helpers/http.ts` 的 unconstrained `any`。
- 將原生 Hono HTTP helper 改為泛型 response body，支援 JSON、binary 與 custom parser 的明確型別。
- 新增共用的 E2E response contracts，並保留既有 request runtime 行為；未修改 production code、API contract 或 database schema。

## 測試
- `pnpm run test:unit`：712 pass、0 fail。
- `pnpm run lint`：pass。
- `pnpm exec tsc --noEmit`：pass。
- `pnpm run build`：pass。
- Container 內 targeted E2E（13 個受影響檔案）：74 pass、0 fail。
- 完整 backend E2E：93 pass、1 fail；唯一失敗是既有的 admin log ordering race。將 `admin.e2e.test.ts` 還原至 HEAD 後單獨執行仍同樣失敗，確認不是本 PR 引入。
- Regression sabotage：暫時移除 helper `post<T>` 泛型後，compiler 以 `TS2558`/`TS18046` 失敗；恢復後 typecheck 通過。

## 風險與排除項目
- 僅變更 test helper、E2E 測試與 test-only response types，不改變 runtime implementation。
- 不包含 Supertest migration 重做、production code、API response redesign、database migration。

Closes #628