### PR TITLE
fix(frontend): publish a stable room realtime readiness contract (#620)

### DIFF
--- a/frontend/src/components/chat/Chatroom.tsx
+++ b/frontend/src/components/chat/Chatroom.tsx
@@ -742,13 +742,24 @@ export default function Chatroom({ roomId, onOpenGroupSettings }: ChatroomProps)
       // usable while its channel is not joined — ready for REST, not for
       // realtime.
       //
+      // Pending is read from both sources because each is stale in a
+      // different situation, and either one saying pending means this socket
+      // is not in the room's channel. `myRole` arrives with the room summary,
+      // so it is the only one available on first paint — but a live demotion
+      // reaches the client as MEMBER_UPDATED, whose member reload rewrites
+      // `activeRoom.members` and leaves `myRole` untouched. `currentMember`
+      // is the mirror image: current across a role change, absent until the
+      // members have loaded.
+      //
       // Carries the room id rather than a boolean, so a waiter names the room
       // it means and cannot be satisfied by a previous room still mounted.
       // `undefined` and not `false` is load-bearing: React renders
       // `data-room-ready="false"` for a boolean, which `[data-room-ready]`
       // would still match.
       data-room-ready={
-        realtimeReady && activeRoom.myRole !== "pending" ? activeRoom.id : undefined
+        realtimeReady && activeRoom.myRole !== "pending" && !isPending
+          ? activeRoom.id
+          : undefined
       }
     >
       {/* Chat Panel Header */}

--- a/frontend/src/components/chat/Chatroom.tsx
+++ b/frontend/src/components/chat/Chatroom.tsx
@@ -4,6 +4,7 @@ import React, { useCallback, useState, useEffect, useLayoutEffect, useRef } from
 import { useRouter } from "next/navigation";
 import {
   useChat,
+  useRealtimeReady,
   useRightPanel,
   useTypingUsers,
   getAvatarForUser,
@@ -276,6 +277,7 @@ export default function Chatroom({ roomId, onOpenGroupSettings }: ChatroomProps)
     markRoomAsRead,
   } = useChat();
   const { showRightPanel, setShowRightPanel } = useRightPanel();
+  const realtimeReady = useRealtimeReady();
 
   const [inputText, setInputText] = useState("");
   const [mentionDraft, setMentionDraft] = useState<MentionDraft | null>(null);
@@ -730,7 +732,25 @@ export default function Chatroom({ roomId, onOpenGroupSettings }: ChatroomProps)
   };
 
   return (
-    <div className="flex-1 flex flex-col bg-background h-full overflow-hidden">
+    <div
+      className="flex-1 flex flex-col bg-background h-full overflow-hidden"
+      // Room-level realtime readiness, the browser-observable contract the
+      // full-stack lane waits on (issue #620). It joins the session-level fact
+      // from `useRealtimeReady` to this room's own subscription status: the
+      // server excludes `pending` members when restoring subscriptions
+      // (socketServer.ts), so a pending room is rendered and its composer is
+      // usable while its channel is not joined — ready for REST, not for
+      // realtime.
+      //
+      // Carries the room id rather than a boolean, so a waiter names the room
+      // it means and cannot be satisfied by a previous room still mounted.
+      // `undefined` and not `false` is load-bearing: React renders
+      // `data-room-ready="false"` for a boolean, which `[data-room-ready]`
+      // would still match.
+      data-room-ready={
+        realtimeReady && activeRoom.myRole !== "pending" ? activeRoom.id : undefined
+      }
+    >
       {/* Chat Panel Header */}
       <div className="h-14 border-b border-border-primary px-3 md:px-6 flex items-center justify-between select-none shrink-0 bg-surface-card z-10 gap-2">
         <div className="flex items-center gap-1 md:gap-3 min-w-0">

--- a/frontend/src/components/layout/ChatList.tsx
+++ b/frontend/src/components/layout/ChatList.tsx
@@ -808,6 +808,11 @@ function RoomItem({
         draggable={draggable}
         onDragStart={onDragStart}
         onDragEnd={onDragEnd}
+        // On the button rather than the row: this is the element that owns the
+        // in-app `router.push`, so a test clicking it exercises a real soft
+        // navigation instead of relying on where the row's centre happens to
+        // fall (issue #620).
+        data-room-id={room.id}
         className="flex min-w-0 flex-1 items-center gap-2.5 text-left select-none cursor-pointer"
       >
         <Avatar name={room.name} src={avatarSrc} size="sm" isOnline={room.isOnline} />

--- a/frontend/src/context/ChatContext.tsx
+++ b/frontend/src/context/ChatContext.tsx
@@ -1172,6 +1172,11 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
     // again and report readiness for a connection whose subscriptions have not
     // been restored yet.
     let connectionGeneration = 0;
+    // Serial number of the most recent `realtime_ready`. Only the newest may
+    // publish readiness: older signals keep their own `.then` on the earlier
+    // sync they were served by, and that sync says nothing about the recovery
+    // a newer signal is still waiting on.
+    let readinessSignalSerial = 0;
     let retryTimer: ReturnType<typeof setTimeout> | undefined;
     const socket = createChatSocket(token);
     socketRef.current = socket;
@@ -1849,21 +1854,36 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
       // a waiter pass during exactly the window in which this client is known
       // to be missing durable changes.
       const generation = connectionGeneration;
+      const signal = ++readinessSignalSerial;
       setRealtimeReady(false);
 
       // `synchronize` resolves only after the buffered realtime events have
       // been flushed, so this is the first moment the client is both caught up
       // on durable changes and applying live ones directly.
       //
-      // Both gates keep that a claim about *now*. A sync awaits `/sync`
-      // paging, a rooms refresh, a debounced social refresh and a member load;
-      // if the socket drops in that window `socket.connected` rejects the
-      // resolving sync, and if it drops *and reconnects* in that window the
-      // generation check rejects it — the new connection has to earn readiness
-      // through its own `realtime_ready`. The failure path needs no separate
-      // branch: it disconnects before resolving, so the first gate catches it.
+      // The gates together keep that a claim about *now*. A sync awaits
+      // `/sync` paging, a rooms refresh, a debounced social refresh and a
+      // member load, and several things can happen inside that window:
+      //
+      // - the socket drops, so `socket.connected` rejects the resolving sync;
+      // - it drops *and reconnects*, so the connection generation rejects it —
+      //   the new connection must earn readiness through its own signal;
+      // - another `realtime_ready` arrives, so the signal serial rejects it.
+      //   That last one matters because an overlapping signal is served by a
+      //   queued follow-up while this handler still holds its own `.then` on
+      //   the earlier sync: without the serial, the earlier sync completing
+      //   would publish readiness while the follow-up the newer signal asked
+      //   for is still running.
+      //
+      // The failure path needs no separate branch: it disconnects before
+      // resolving, so `socket.connected` catches it.
       void resynchronize().then(() => {
-        if (!disposed && socket.connected && connectionGeneration === generation) {
+        if (
+          !disposed &&
+          socket.connected &&
+          connectionGeneration === generation &&
+          readinessSignalSerial === signal
+        ) {
           setRealtimeReady(true);
         }
       });

--- a/frontend/src/context/ChatContext.tsx
+++ b/frontend/src/context/ChatContext.tsx
@@ -1164,6 +1164,14 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
     replayedWithoutUnreadRef.current.clear();
     syncingRef.current = true;
     let disposed = false;
+    // Readiness generation: bumped on every connect and disconnect, so a
+    // `/sync` can tell whether the connection it was started for is still the
+    // current one. `socket.connected` alone cannot: Socket.IO reconnects this
+    // same instance automatically (`reconnection` defaults to true), so a sync
+    // outliving a transport drop would otherwise find `connected === true`
+    // again and report readiness for a connection whose subscriptions have not
+    // been restored yet.
+    let connectionGeneration = 0;
     let retryTimer: ReturnType<typeof setTimeout> | undefined;
     const socket = createChatSocket(token);
     socketRef.current = socket;
@@ -1631,6 +1639,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
     const cleanupDisconnect = onSocketDisconnect(socket, (reason) => {
       // Unconditional, and before the retry branch: a dropped socket is not
       // ready by any definition, whatever reconnect path follows.
+      connectionGeneration += 1;
       setRealtimeReady(false);
       if (!disposed && reason === 'io server disconnect') {
         retryTimer = setTimeout(() => {
@@ -1646,6 +1655,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
       syncingRef.current = true;
       // A fresh connection has not synced yet: readiness is re-earned by the
       // `realtime_ready` handler below, never inherited from the last session.
+      connectionGeneration += 1;
       setRealtimeReady(false);
     });
     const cleanupFriendRequest = onFriendRequest(socket, (payload) => {
@@ -1794,19 +1804,32 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
     });
 
     const cleanupRealtimeReady = onRealtimeReady(socket, () => {
+      // Not once per connection: the server also re-sends this mid-session
+      // after it restores a subscription it had revoked (a kick that lost its
+      // conditional delete — roomService), and a restored subscription replays
+      // nothing that was published while it was gone. That makes this the
+      // client's standing recovery signal, so readiness has to be withdrawn
+      // for the duration of the recovery it starts. Leaving it true would let
+      // a waiter pass during exactly the window in which this client is known
+      // to be missing durable changes.
+      const generation = connectionGeneration;
+      setRealtimeReady(false);
+
       // `synchronize` resolves only after the buffered realtime events have
       // been flushed, so this is the first moment the client is both caught up
       // on durable changes and applying live ones directly.
       //
-      // The `socket.connected` gate is what keeps this a claim about *now*
-      // rather than about when the sync started. A sync awaits `/sync` paging,
-      // a rooms refresh, a debounced social refresh and a member load; if the
-      // socket drops anywhere in that window the disconnect handler clears the
-      // flag, and without this gate the resolving sync would set it back to
-      // true over a dead socket. The failure path needs no separate branch:
-      // it disconnects before resolving, so the same gate rejects it.
+      // Both gates keep that a claim about *now*. A sync awaits `/sync`
+      // paging, a rooms refresh, a debounced social refresh and a member load;
+      // if the socket drops in that window `socket.connected` rejects the
+      // resolving sync, and if it drops *and reconnects* in that window the
+      // generation check rejects it — the new connection has to earn readiness
+      // through its own `realtime_ready`. The failure path needs no separate
+      // branch: it disconnects before resolving, so the first gate catches it.
       void synchronize().then(() => {
-        if (!disposed && socket.connected) setRealtimeReady(true);
+        if (!disposed && socket.connected && connectionGeneration === generation) {
+          setRealtimeReady(true);
+        }
       });
     });
     socket.connect();
@@ -2952,6 +2975,12 @@ export function useProfilePopover() {
  *
  * It returns to `false` on connect, on disconnect, on logout and on provider
  * teardown, so it is a claim about the present moment and never a latch.
+ *
+ * It also returns to `false` on every `realtime_ready`, not only the first of
+ * a connection. The server re-sends that event mid-session whenever it
+ * restores a subscription it had revoked, and a restored subscription replays
+ * nothing published while it was gone — so each one opens a fresh window in
+ * which this client is missing durable changes until its `/sync` completes.
  *
  * Note what it deliberately does not cover: it is a *session*-level fact, not
  * a per-room one. A room is additionally unready while the user's membership

--- a/frontend/src/context/ChatContext.tsx
+++ b/frontend/src/context/ChatContext.tsx
@@ -374,6 +374,15 @@ interface RightPanelContextType {
 
 const RightPanelContext = createContext<RightPanelContextType | undefined>(undefined);
 
+// Realtime readiness (issue #620). A leaf context rather than a field on
+// ChatContextType for the same reason as the four above: it flips on every
+// connect, disconnect and reconnect, and putting it in the main value would
+// re-render every useChat() consumer on each of those. Keeping it separate
+// also leaves the readiness contract as one self-contained unit for the
+// ChatContext split in #622, which must preserve these semantics rather than
+// absorb them.
+const RealtimeReadyContext = createContext<boolean | undefined>(undefined);
+
 // Static key list for the stable handler proxies built in ChatProvider. Kept
 // at module level so building the proxies never reads a ref during render.
 // The `NoMissingHandlerKey` check below fails to compile if a handler is
@@ -776,6 +785,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
   const [isMounted, setIsMounted] = useState(false);
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [roomsInitialized, setRoomsInitialized] = useState(false);
+  const [realtimeReady, setRealtimeReady] = useState(false);
   const [token, setToken] = useState<string | null>(null);
   const [currentUserId, setCurrentUserId] = useState<string | undefined>(undefined);
   const [user, setUser] = useState<User>({ username: "", email: "", avatar: "" });
@@ -897,6 +907,9 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
     setCurrentUserId(undefined);
     setIsAuthenticated(false);
     setRoomsInitialized(false);
+    // The socket effect returns early on a null token rather than reaching the
+    // successor of its own cleanup, so readiness has to be cleared here too.
+    setRealtimeReady(false);
     setRooms([]);
     setFolders([]);
     setMessages([]);
@@ -1616,6 +1629,9 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
       console.error("Socket error", error);
     });
     const cleanupDisconnect = onSocketDisconnect(socket, (reason) => {
+      // Unconditional, and before the retry branch: a dropped socket is not
+      // ready by any definition, whatever reconnect path follows.
+      setRealtimeReady(false);
       if (!disposed && reason === 'io server disconnect') {
         retryTimer = setTimeout(() => {
           retryTimer = undefined;
@@ -1628,6 +1644,9 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
     });
     const cleanupConnect = onSocketConnect(socket, () => {
       syncingRef.current = true;
+      // A fresh connection has not synced yet: readiness is re-earned by the
+      // `realtime_ready` handler below, never inherited from the last session.
+      setRealtimeReady(false);
     });
     const cleanupFriendRequest = onFriendRequest(socket, (payload) => {
       const activeTok = tokenRef.current;
@@ -1775,12 +1794,26 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
     });
 
     const cleanupRealtimeReady = onRealtimeReady(socket, () => {
-      void synchronize();
+      // `synchronize` resolves only after the buffered realtime events have
+      // been flushed, so this is the first moment the client is both caught up
+      // on durable changes and applying live ones directly.
+      //
+      // The `socket.connected` gate is what keeps this a claim about *now*
+      // rather than about when the sync started. A sync awaits `/sync` paging,
+      // a rooms refresh, a debounced social refresh and a member load; if the
+      // socket drops anywhere in that window the disconnect handler clears the
+      // flag, and without this gate the resolving sync would set it back to
+      // true over a dead socket. The failure path needs no separate branch:
+      // it disconnects before resolving, so the same gate rejects it.
+      void synchronize().then(() => {
+        if (!disposed && socket.connected) setRealtimeReady(true);
+      });
     });
     socket.connect();
 
     return () => {
       disposed = true;
+      setRealtimeReady(false);
       if (retryTimer) clearTimeout(retryTimer);
       clearInterval(checkpointTimer);
       cleanupNewMessage();
@@ -2846,22 +2879,24 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
         <TypingUsersContext.Provider value={typingUsers}>
           <ProfilePopoverContext.Provider value={profilePopoverValue}>
             <RightPanelContext.Provider value={rightPanelValue}>
-              {children}
-              {messageNoticeKey && (
-                <div
-                  role="status"
-                  className="fixed bottom-6 left-1/2 z-50 flex -translate-x-1/2 items-center gap-3 rounded-lg bg-red-600 px-4 py-3 text-sm text-white shadow-lg"
-                >
-                  <span>{translate(uiLanguage, messageNoticeKey)}</span>
-                  <button
-                    type="button"
-                    className="font-semibold underline"
-                    onClick={() => setMessageNoticeKey(null)}
+              <RealtimeReadyContext.Provider value={realtimeReady}>
+                {children}
+                {messageNoticeKey && (
+                  <div
+                    role="status"
+                    className="fixed bottom-6 left-1/2 z-50 flex -translate-x-1/2 items-center gap-3 rounded-lg bg-red-600 px-4 py-3 text-sm text-white shadow-lg"
                   >
-                    {translate(uiLanguage, "chatroom.dismissNotice")}
-                  </button>
-                </div>
-              )}
+                    <span>{translate(uiLanguage, messageNoticeKey)}</span>
+                    <button
+                      type="button"
+                      className="font-semibold underline"
+                      onClick={() => setMessageNoticeKey(null)}
+                    >
+                      {translate(uiLanguage, "chatroom.dismissNotice")}
+                    </button>
+                  </div>
+                )}
+              </RealtimeReadyContext.Provider>
             </RightPanelContext.Provider>
           </ProfilePopoverContext.Provider>
         </TypingUsersContext.Provider>
@@ -2901,6 +2936,34 @@ export function useProfilePopover() {
   const context = useContext(ProfilePopoverContext);
   if (context === undefined) {
     throw new Error("useProfilePopover must be used within a ChatProvider");
+  }
+  return context;
+}
+
+/**
+ * Whether this browser's realtime session is live and caught up (issue #620).
+ *
+ * The contract, which the ChatContext split in #622 must preserve rather than
+ * redefine: `true` means the socket is connected, the server has finished
+ * restoring every room subscription for this user (it emits `realtime_ready`
+ * only after that, and only on the success path), the durable `/sync` that
+ * follows has completed, and the events buffered during it have been flushed.
+ * In other words, changes now arrive live rather than being replayed later.
+ *
+ * It returns to `false` on connect, on disconnect, on logout and on provider
+ * teardown, so it is a claim about the present moment and never a latch.
+ *
+ * Note what it deliberately does not cover: it is a *session*-level fact, not
+ * a per-room one. A room is additionally unready while the user's membership
+ * is `pending`, because the server excludes pending members when restoring
+ * subscriptions — see the `data-room-ready` attribute in Chatroom.tsx, which
+ * combines the two into the room-level signal the full-stack browser lane
+ * waits on.
+ */
+export function useRealtimeReady() {
+  const context = useContext(RealtimeReadyContext);
+  if (context === undefined) {
+    throw new Error("useRealtimeReady must be used within a ChatProvider");
   }
   return context;
 }

--- a/frontend/src/context/ChatContext.tsx
+++ b/frontend/src/context/ChatContext.tsx
@@ -1366,6 +1366,42 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
       return track(request);
     };
 
+    // What `realtime_ready` needs, which plain coalescing cannot give it.
+    //
+    // A signal that lands while a full sync is already running cannot be
+    // satisfied by that sync: `runSynchronization` pages `/sync` first and
+    // only then awaits the rooms refresh, the debounced social refresh and the
+    // member load, so its paging can already be finished — while the changes
+    // this signal exists to recover were committed just before it was sent,
+    // during the revoked-subscription window. Handing back the in-flight
+    // request would leave those changes unfetched until some later recovery,
+    // and would report readiness as if they had been.
+    //
+    // So an overlapping signal queues exactly one follow-up pass rather than
+    // reusing the request. Any number of signals arriving during a sync
+    // collapse into that single pass, which keeps the reconnect-race collapse
+    // this chain was built for while still guaranteeing one `/sync` that
+    // starts strictly after the most recent signal.
+    let queuedResync: Promise<void> | null = null;
+
+    const resynchronize = (): Promise<void> => {
+      const inFlight = outstandingFullSync;
+      if (!inFlight) return synchronize();
+      if (queuedResync) return queuedResync;
+      const request = (async () => {
+        // Never rejects, for the same reason `synchronize` does not: a failed
+        // predecessor must not stop the recovery this signal asked for.
+        await inFlight.catch(() => undefined);
+        if (disposed) return;
+        // Cleared before starting, so a signal arriving during the follow-up
+        // opens a new window rather than being folded into a finished one.
+        queuedResync = null;
+        await synchronize();
+      })();
+      queuedResync = request;
+      return request;
+    };
+
     // Opportunistic, unlike `synchronize`: if anything is already talking to
     // `/sync` there is nothing to checkpoint behind it, and the next tick will
     // come round again.
@@ -1826,7 +1862,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
       // generation check rejects it — the new connection has to earn readiness
       // through its own `realtime_ready`. The failure path needs no separate
       // branch: it disconnects before resolving, so the first gate catches it.
-      void synchronize().then(() => {
+      void resynchronize().then(() => {
         if (!disposed && socket.connected && connectionGeneration === generation) {
           setRealtimeReady(true);
         }

--- a/frontend/tests-fullstack/private-chat.spec.ts
+++ b/frontend/tests-fullstack/private-chat.spec.ts
@@ -50,34 +50,20 @@ test.describe("two-user private chat", () => {
       const bobPage = await bobContext.newPage();
 
       await test.step("both users sign in and open the private room", async () => {
-        // `realtime_ready` starts the initial durable `/sync`. Register these
-        // waiters before login so a fast socket cannot finish its sync before
-        // the test starts observing responses. A visible composer alone is not
-        // enough: it can render before the socket has joined its room channels.
-        const aliceRealtimeReady = waitForInitialRealtimeSync(alicePage);
-        const bobRealtimeReady = waitForInitialRealtimeSync(bobPage);
-
         await signInThroughUi(alicePage, alice);
         await signInThroughUi(bobPage, bob);
-
-        await aliceRealtimeReady;
-        await bobRealtimeReady;
-
-        // Navigation remounts ChatProvider, so the sync/session observed during
-        // login does not belong to the room pages below. Register new waiters
-        // before navigating to prove both room sessions complete their own
-        // realtime bootstrap before either browser sends a message.
-        const aliceRoomRealtimeReady = waitForInitialRealtimeSync(alicePage);
-        const bobRoomRealtimeReady = waitForInitialRealtimeSync(bobPage);
 
         await alicePage.goto(`/chat/${roomId}`);
         await bobPage.goto(`/chat/${roomId}`);
 
-        await aliceRoomRealtimeReady;
-        await bobRoomRealtimeReady;
+        // No waiter has to be armed before navigating any more: readiness is a
+        // state the page publishes and holds, not an event that can be missed
+        // by observing too late.
+        await waitForRoomRealtimeReady(alicePage, roomId);
+        await waitForRoomRealtimeReady(bobPage, roomId);
 
-        // The sync gates above prove both realtime sessions are ready; these
-        // assertions additionally prove both room pages are usable.
+        // The readiness gates above prove both realtime sessions are live for
+        // this room; these assertions additionally prove both pages are usable.
         await expect(alicePage.getByPlaceholder("Type a message...")).toBeVisible();
         await expect(bobPage.getByPlaceholder("Type a message...")).toBeVisible();
       });
@@ -135,6 +121,95 @@ test.describe("two-user private chat", () => {
       await bobContext.close();
     }
   });
+
+  /**
+   * The navigation case, as its own test rather than another step of the one
+   * above (issue #620).
+   *
+   * Every navigation in the first test is `page.goto`, a document load that
+   * tears down and rebuilds `ChatProvider` and its socket. This one enters the
+   * room the way a user actually does — clicking it in the sidebar, an in-app
+   * `router.push` — where the provider does *not* remount: the socket effect is
+   * keyed on `[currentUserId, token]`, so no reconnect happens, no
+   * `realtime_ready` is re-emitted and no second `/sync` is issued. That is
+   * precisely the shape the deleted `/sync` waiter could not express, and it is
+   * the shape the readiness attribute exists to cover.
+   *
+   * Separate rather than appended because the suite budgets 60s per test and
+   * the first one already spans roughly eight round trips; sharing that budget
+   * would surface a slow runner as a flake in the assertions above.
+   */
+  test("stays realtime-ready when the room is entered by in-app navigation", async ({
+    browser,
+    request,
+  }, testInfo) => {
+    const [alice, bob] = await Promise.all([
+      registerUser(request, "alice"),
+      registerUser(request, "bob"),
+    ]);
+    await makeFriends(request, alice, bob);
+    const roomId = await createPrivateRoom(request, alice, bob);
+
+    const aliceContext = await newIsolatedContext(browser);
+    const bobContext = await newIsolatedContext(browser);
+
+    try {
+      const alicePage = await aliceContext.newPage();
+      const bobPage = await bobContext.newPage();
+
+      await test.step("bob opens the room directly and alice stops at the room list", async () => {
+        await signInThroughUi(bobPage, bob);
+        await bobPage.goto(`/chat/${roomId}`);
+        await waitForRoomRealtimeReady(bobPage, roomId);
+
+        // Login lands on `/`, so Alice's socket connects and completes its
+        // bootstrap here, before the room is ever opened. Whatever readiness
+        // the room page reports below is therefore inherited across a
+        // navigation rather than produced by one.
+        await signInThroughUi(alicePage, alice);
+      });
+
+      await test.step("alice enters the room by clicking it in the sidebar", async () => {
+        // The sidebar entry's own button, which owns the `router.push`.
+        await alicePage.locator(`[data-room-id="${roomId}"]`).click();
+
+        await expect(alicePage).toHaveURL(`/chat/${roomId}`);
+        await waitForRoomRealtimeReady(alicePage, roomId);
+        await expect(alicePage.getByPlaceholder("Type a message...")).toBeVisible();
+      });
+
+      const fromAlice = `soft-nav hello from alice ${randomUUID()}`;
+
+      await test.step("she can send from the room she navigated into", async () => {
+        // Sending, not just receiving, is the assertion that matters here.
+        // Alice's `new_message` listener is registered once on the provider's
+        // socket, so she would receive Bob's messages whether or not the
+        // navigation worked; the composer, by contrast, is bound to the room id
+        // derived from the pathname, so this is what proves the in-app route
+        // change actually rebound the room.
+        await alicePage.getByPlaceholder("Type a message...").fill(fromAlice);
+        await alicePage.getByRole("button", { name: "Send" }).click();
+
+        await expect(messageBubble(bobPage, fromAlice)).toBeVisible();
+      });
+
+      await test.step("and still receives on the same connection", async () => {
+        const fromBob = `soft-nav reply from bob ${randomUUID()}`;
+
+        await bobPage.getByPlaceholder("Type a message...").fill(fromBob);
+        await bobPage.getByRole("button", { name: "Send" }).click();
+
+        await expect(messageBubble(alicePage, fromBob)).toBeVisible();
+      });
+    } catch (error) {
+      await attachScreenshots(aliceContext, "alice", testInfo);
+      await attachScreenshots(bobContext, "bob", testInfo);
+      throw error;
+    } finally {
+      await aliceContext.close();
+      await bobContext.close();
+    }
+  });
 });
 
 /**
@@ -151,14 +226,35 @@ test.describe("two-user private chat", () => {
 const messageBubble = (page: import("@playwright/test").Page, text: string) =>
   page.locator("[data-msg-id]").filter({ hasText: text });
 
-/** Wait for the initial sync that the app starts after `realtime_ready`. */
-const waitForInitialRealtimeSync = async (page: import("@playwright/test").Page): Promise<void> => {
-  const response = await page.waitForResponse(
-    (candidate) =>
-      new URL(candidate.url()).pathname === "/api/v1/sync" &&
-      candidate.request().method() === "GET",
-  );
-  expect(response.ok(), `initial realtime sync returned ${response.status()}`).toBeTruthy();
+/**
+ * Wait until the browser itself reports that this room is ready for realtime.
+ *
+ * `Chatroom` publishes `data-room-ready="<roomId>"` once the socket is
+ * connected, every room subscription has been restored server-side, the
+ * durable `/sync` behind `realtime_ready` has completed and its buffered
+ * events have flushed — and once this particular room is one the socket
+ * actually joined. See `useRealtimeReady` in ChatContext for the full contract.
+ *
+ * This replaces waiting on a `GET /api/v1/sync` response (issue #620). That
+ * waiter read an internal endpoint's request ordering to infer readiness,
+ * which contradicted this file's own scope discipline above, and it only
+ * worked because every navigation here is a document load: an in-app
+ * `router.push` re-renders the room without reconnecting the socket, so no
+ * second `/sync` is issued and such a waiter would hang until the timeout.
+ * The attribute holds for both, which is what makes it a stable contract.
+ */
+const waitForRoomRealtimeReady = async (
+  page: import("@playwright/test").Page,
+  roomId: string,
+): Promise<void> => {
+  // `toBeAttached`, not `toBeVisible`: this asserts a contract, not pixels.
+  // The message keeps a backend failure legible — the deleted waiter reported
+  // a bad `/sync` status by name, and without it a broken bootstrap would
+  // present only as an anonymous locator timeout.
+  await expect(
+    page.locator(`[data-room-ready="${roomId}"]`),
+    `room ${roomId} never reported realtime readiness`,
+  ).toBeAttached();
 };
 
 /** Attach every still-open page before raw contexts bypass fixture teardown. */

--- a/frontend/tests/realtime-readiness.test.tsx
+++ b/frontend/tests/realtime-readiness.test.tsx
@@ -18,6 +18,7 @@ import { describe, expect, test } from "vitest";
 import { act } from "@testing-library/react";
 import { mountChatApp } from "./harness";
 import { __gateNextSync, __getApiCallLog } from "./mocks/api";
+import { ME_ID, membersByRoom } from "./fixtures";
 
 /** The attribute as a test would query it: named for one room, or absent. */
 const roomReady = (container: HTMLElement, roomId: string): boolean =>
@@ -245,5 +246,34 @@ describe("room realtime readiness", () => {
     await app.settle();
 
     expect(roomReady(app.view.container, "room-1")).toBe(true);
+  });
+
+  test("withdraws room readiness when a live role change demotes to pending", async () => {
+    // The server drops a demoted member's room subscription and reports the
+    // change as MEMBER_UPDATED, whose handler reloads `activeRoom.members`
+    // and leaves `myRole` untouched. Readiness therefore cannot be decided on
+    // `myRole` alone, or the room would keep claiming realtime while the
+    // socket is no longer in its channel.
+    const app = await mountChatApp("/chat/room-1");
+    expect(roomReady(app.view.container, "room-1")).toBe(true);
+
+    const members = membersByRoom["room-1"]!;
+    const previous = members[0]!;
+    members[0] = { ...previous, role: "pending" };
+    try {
+      act(() => {
+        app.socket().serverEmit("room_update", {
+          type: "MEMBER_UPDATED",
+          roomId: "room-1",
+          data: { userId: ME_ID, role: "pending" },
+        });
+      });
+      await app.settle();
+
+      expect(roomReady(app.view.container, "room-1")).toBe(false);
+    } finally {
+      // Shared module-level fixture: `__resetApiMock` does not restore it.
+      members[0] = previous;
+    }
   });
 });

--- a/frontend/tests/realtime-readiness.test.tsx
+++ b/frontend/tests/realtime-readiness.test.tsx
@@ -104,4 +104,73 @@ describe("room realtime readiness", () => {
 
     expect(roomReady(app.view.container, "room-1")).toBe(false);
   });
+
+  test("withdraws readiness for a mid-session realtime_ready", async () => {
+    // `realtime_ready` is not once-per-connection. The server re-sends it
+    // after restoring a subscription it had revoked, and that restore replays
+    // nothing published while the subscription was gone — so the client is
+    // missing durable changes until the sync it triggers completes. Readiness
+    // must drop for that window rather than staying true across it.
+    const app = await mountChatApp("/chat/room-1");
+    expect(roomReady(app.view.container, "room-1")).toBe(true);
+
+    const gate = __gateNextSync();
+    act(() => {
+      app.socket().serverEmit("realtime_ready");
+    });
+    await app.settle();
+
+    expect(roomReady(app.view.container, "room-1")).toBe(false);
+
+    await act(async () => {
+      gate.succeed();
+      await Promise.resolve();
+    });
+    await app.settle();
+
+    expect(roomReady(app.view.container, "room-1")).toBe(true);
+  });
+
+  test("does not let a previous connection's sync restore readiness", async () => {
+    // Socket.IO reconnects the same instance automatically, so a sync started
+    // before a transport drop can resolve after the reconnect, when
+    // `socket.connected` is true again. It must not report readiness for that
+    // new connection: the server restores subscriptions and re-emits
+    // `realtime_ready` per connection, and none of that has happened yet.
+    const app = await mountChatApp("/chat/room-1");
+    const socket = app.socket();
+    const connection = socket as unknown as { connected: boolean };
+
+    // Start a sync on the current connection and leave it in flight.
+    const gate = __gateNextSync();
+    act(() => {
+      socket.serverEmit("realtime_ready");
+    });
+    await app.settle();
+    expect(roomReady(app.view.container, "room-1")).toBe(false);
+
+    // The transport drops and Socket.IO brings the same instance back up. The
+    // events are emitted directly, and `connected` set by hand, because the
+    // mock's own `connect()` also emits `realtime_ready` — which is precisely
+    // the step this test must exclude: the new connection has not restored its
+    // subscriptions, so it has not earned readiness.
+    act(() => {
+      connection.connected = false;
+      socket.serverEmit("disconnect", "transport close");
+    });
+    act(() => {
+      connection.connected = true;
+      socket.serverEmit("connect");
+    });
+    await app.settle();
+
+    // The previous connection's sync now completes, with the socket connected.
+    await act(async () => {
+      gate.succeed();
+      await Promise.resolve();
+    });
+    await app.settle();
+
+    expect(roomReady(app.view.container, "room-1")).toBe(false);
+  });
 });

--- a/frontend/tests/realtime-readiness.test.tsx
+++ b/frontend/tests/realtime-readiness.test.tsx
@@ -17,7 +17,7 @@
 import { describe, expect, test } from "vitest";
 import { act } from "@testing-library/react";
 import { mountChatApp } from "./harness";
-import { __gateNextSync } from "./mocks/api";
+import { __gateNextSync, __getApiCallLog } from "./mocks/api";
 
 /** The attribute as a test would query it: named for one room, or absent. */
 const roomReady = (container: HTMLElement, roomId: string): boolean =>
@@ -172,5 +172,39 @@ describe("room realtime readiness", () => {
     await app.settle();
 
     expect(roomReady(app.view.container, "room-1")).toBe(false);
+  });
+
+  test("runs a fresh sync for a realtime_ready that overlaps one in flight", async () => {
+    // The in-flight sync cannot answer a later signal: its `/sync` paging may
+    // already be finished, while the changes the signal exists to recover were
+    // committed during the revoked-subscription window just before it was
+    // sent. Reusing that request would leave them unfetched and still report
+    // readiness, so an overlapping signal must get its own pass.
+    const app = await mountChatApp("/chat/room-1");
+
+    const gate = __gateNextSync();
+    act(() => {
+      app.socket().serverEmit("realtime_ready");
+    });
+    await app.settle();
+
+    // A second signal, while the first sync is still held open.
+    act(() => {
+      app.socket().serverEmit("realtime_ready");
+    });
+    await app.settle();
+
+    const before = __getApiCallLog("syncChanges").length;
+
+    await act(async () => {
+      gate.succeed();
+      await Promise.resolve();
+    });
+    await app.settle();
+
+    // A `/sync` that started after the second signal, not just the one it
+    // arrived during.
+    expect(__getApiCallLog("syncChanges").length).toBeGreaterThan(before);
+    expect(roomReady(app.view.container, "room-1")).toBe(true);
   });
 });

--- a/frontend/tests/realtime-readiness.test.tsx
+++ b/frontend/tests/realtime-readiness.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * Realtime readiness contract tests (issue #620).
+ *
+ * `Chatroom` publishes `data-room-ready="<roomId>"` as the browser-observable
+ * signal the full-stack lane waits on, in place of watching for a `GET
+ * /api/v1/sync` response. These tests pin the state transitions behind it at
+ * the level the full-stack lane cannot reach: it needs Docker, a real backend
+ * and a real database, so a socket that drops midway through a sync is not
+ * something it can stage. Here the mock socket makes each transition directly
+ * reachable.
+ *
+ * The contract, stated once in the `useRealtimeReady` JSDoc: ready means the
+ * socket is connected, the server has restored every room subscription, the
+ * durable sync that follows `realtime_ready` has completed, and its buffered
+ * events have been flushed.
+ */
+import { describe, expect, test } from "vitest";
+import { act } from "@testing-library/react";
+import { mountChatApp } from "./harness";
+import { __gateNextSync } from "./mocks/api";
+
+/** The attribute as a test would query it: named for one room, or absent. */
+const roomReady = (container: HTMLElement, roomId: string): boolean =>
+  container.querySelector(`[data-room-ready="${roomId}"]`) !== null;
+
+describe("room realtime readiness", () => {
+  test("publishes the active room's id once the initial sync completes", async () => {
+    const app = await mountChatApp("/chat/room-1");
+
+    expect(roomReady(app.view.container, "room-1")).toBe(true);
+    // Named for the room it means, so a waiter cannot be satisfied by a
+    // different room that happens to be ready.
+    expect(roomReady(app.view.container, "room-2")).toBe(false);
+  });
+
+  test("withdraws readiness while a reconnect's sync is still in flight", async () => {
+    const app = await mountChatApp("/chat/room-1");
+    expect(roomReady(app.view.container, "room-1")).toBe(true);
+
+    // Reconnect with the sync held open: the socket is connected again but has
+    // not caught up, which is exactly the window a `/sync`-response waiter
+    // would have treated as ready.
+    const gate = __gateNextSync();
+    act(() => {
+      app.socket().disconnect();
+      app.socket().connect();
+    });
+    await app.settle();
+
+    expect(roomReady(app.view.container, "room-1")).toBe(false);
+
+    await act(async () => {
+      gate.succeed();
+      await Promise.resolve();
+    });
+    await app.settle();
+
+    expect(roomReady(app.view.container, "room-1")).toBe(true);
+  });
+
+  test("does not report ready when the sync fails", async () => {
+    const app = await mountChatApp("/chat/room-1");
+
+    const failing = __gateNextSync();
+    act(() => {
+      app.socket().disconnect();
+      app.socket().connect();
+    });
+    await act(async () => {
+      failing.fail();
+      await Promise.resolve();
+    });
+    await app.settle();
+
+    // The failure path disconnects and schedules a retry; nothing about that
+    // is ready.
+    expect(roomReady(app.view.container, "room-1")).toBe(false);
+  });
+
+  test("does not report ready when the socket drops mid-sync", async () => {
+    // Regression guard for the subtlest false-ready this contract can produce.
+    // A sync awaits `/sync` paging, a rooms refresh, a debounced social refresh
+    // and a member load. If the socket drops anywhere in that window, the sync
+    // still resolves *successfully* afterwards — and readiness must not come
+    // back with it, because the connection it describes is gone.
+    const app = await mountChatApp("/chat/room-1");
+
+    const gate = __gateNextSync();
+    act(() => {
+      app.socket().disconnect();
+      app.socket().connect();
+    });
+    await app.settle();
+    expect(roomReady(app.view.container, "room-1")).toBe(false);
+
+    act(() => {
+      app.socket().disconnect();
+    });
+    await act(async () => {
+      gate.succeed();
+      await Promise.resolve();
+    });
+    await app.settle();
+
+    expect(roomReady(app.view.container, "room-1")).toBe(false);
+  });
+});

--- a/frontend/tests/realtime-readiness.test.tsx
+++ b/frontend/tests/realtime-readiness.test.tsx
@@ -207,4 +207,43 @@ describe("room realtime readiness", () => {
     expect(__getApiCallLog("syncChanges").length).toBeGreaterThan(before);
     expect(roomReady(app.view.container, "room-1")).toBe(true);
   });
+
+  test("only the newest realtime_ready may publish readiness", async () => {
+    // The overlapping case again, but asserted *during* the follow-up rather
+    // than after it. The earlier signal keeps its own `.then` on the sync it
+    // was served by, and that sync finishing says nothing about the recovery
+    // the newer signal is still waiting on — so it must not publish readiness.
+    const app = await mountChatApp("/chat/room-1");
+
+    const first = __gateNextSync();
+    act(() => {
+      app.socket().serverEmit("realtime_ready");
+    });
+    await app.settle();
+
+    act(() => {
+      app.socket().serverEmit("realtime_ready");
+    });
+    await app.settle();
+
+    // Hold the queued follow-up open so the window between the two syncs is
+    // observable at all.
+    const followUp = __gateNextSync();
+    await act(async () => {
+      first.succeed();
+      await Promise.resolve();
+    });
+    await app.settle();
+
+    // The first sync is done and the follow-up is still running.
+    expect(roomReady(app.view.container, "room-1")).toBe(false);
+
+    await act(async () => {
+      followUp.succeed();
+      await Promise.resolve();
+    });
+    await app.settle();
+
+    expect(roomReady(app.view.container, "room-1")).toBe(true);
+  });
 });


### PR DESCRIPTION
## 變更描述 (Description)

`frontend/tests-fullstack/private-chat.spec.ts` 原本在導向房間後，等待第一個 `GET /api/v1/sync` response 來推論 room realtime bootstrap 已完成。這有兩個問題：

1. 它用一個 internal endpoint 的 request ordering 去推導使用者可觀察的事實，與這個 spec 檔案自己在開頭宣告的 scope discipline（「No Socket.IO event name, no event ordering, no service or repository call is referenced」）直接衝突。該宣告的用意是讓 #282 / #540 的 transport 工作可以自由變更而不必動這個 spec。
2. 它之所以目前會通過，只是因為該 spec 的每次導向都是 `page.goto`（document load，會重建 `ChatProvider` 與 socket）。

### 對 issue 前提的修正（本次於 `main` 重新驗證）

Issue #620 的敘述指出該 waiter「可能一直等到 Playwright timeout」。**以目前 `main` 的 spec 而言這個因果並不成立**：`private-chat.spec.ts:73-74` 用的是 `page.goto()`，屬於 hard navigation，`ChatProvider` 確實會 remount 並重新觸發 `realtime_ready` → `/sync`。

但該 issue 指出的耦合是真的，而且底層風險確實存在：socket effect 的 deps 是 `[currentUserId, token]`（`ChatContext.tsx`），因此**在 app 內以 `router.push` 切換房間時不會重連、不會重發 `realtime_ready`、也不會產生第二次 `/sync`**。換言之，只要有人把這個 spec 改成比較貼近真實使用者的 in-app navigation，舊 waiter 就會真的卡到 timeout。本 PR 同時修正耦合並補上該 navigation 案例。

因此本 PR 處理的是 #620 驗收標準中仍未達成的部分；其中「雙向即時傳遞」與「reload durability」兩項在 `main` 上已由既有步驟涵蓋，未重複實作。

### 變更內容

- 新增 `useRealtimeReady`：與 #383 既有四個 leaf context 同一模式的 leaf context。
- `Chatroom` 的根元素輸出 `data-room-ready` 屬性，值為該房間的 room id。屬性值帶 room id 而非 boolean，waiter 才能指名它等的是哪一間；未 ready 時輸出 `undefined` 而非 `false`（React 會把 boolean 算繪成字串 `"false"`，屬性仍會存在）。
- `RoomItem` 在實際持有 `router.push` 的那顆 button 元素上輸出 `data-room-id`，提供 sidebar 穩定的點擊目標。
- 刻意**不**放進 `ChatContextType`：它在每次重連都會翻轉，加進主 value 會讓所有 `useChat()` consumer 每次都重新 render，方向與 #383 相反，也與 #622 要收斂 `ChatContextType` 的目標衝突。

### readiness contract 的不變式

經過五輪 review 收斂後，`data-room-ready` 只在下列條件同時成立時輸出：

**Session 層級**（`useRealtimeReady`）——四項全部成立才發布，且它等待的那輪 `/sync` 必定開始於該訊號之後：

1. provider 未 teardown；
2. socket 目前確實連線中；
3. connection generation 未變（Socket.IO 會自動重連同一個實例，僅檢查 `socket.connected` 無法分辨世代）；
4. 這是最新的 `realtime_ready` 訊號。

它在 connect、disconnect、logout、provider teardown，以及**每一次** `realtime_ready` 時回到 `false`。最後一項很關鍵：`realtime_ready` 並非 once-per-connection，server 在還原曾被撤銷的 subscription 後會 mid-session 重送（`docs/api-documentation.md` L1589、`roomService.ts` L329／L495／L550），而 restore 不會補送期間發生的事件——那正是 client 已知漏接 durable change 的時刻。

**房間層級**：該房間的成員身分不是 `pending`。server 在還原 subscription 時排除 `pending` 成員（`socketServer.ts`），這種房間對 REST 可用、對 realtime 卻尚未 join。判斷同時參考 `activeRoom.myRole` 與 `currentMember.role`，因為兩者在相反情境下過期：`myRole` 是首次繪製時唯一可用的來源，`currentMember` 則是 live 角色變更後唯一即時的來源。

## 相關的 Issue (Related Issue)

Closes #620

## 變更類型 (Type of Change)

- [ ] `feat`: 新增功能 (Feature)
- [x] `fix`: 修復 Bug
- [x] `refactor`: 重構代碼
- [ ] `docs`: 修改文件
- [x] `test`: 新增或修正測試案例
- [ ] `chore`: 建置流程或輔助工具變更
- [ ] `perf`: 效能優化
- [ ] `ci`: CI 設定變更

## 驗證與測試計畫 (Verification & Test Plan)

### CI（head `3bce3ec`，全綠）

五個 commit 各自跑過完整 CI 並全綠，其中包含最關鍵的 **`browser / fullstack-browser-tests`** —— 在真實 PostgreSQL 18 + Bun backend + Chromium 上執行，涵蓋改寫後的既有測試與新增的 in-app navigation 測試。`required-checks` 亦為 success。`backend`、`database` lane 因 paths filter 而 skipped（本 PR 僅動 frontend）。

### 本地測試 (Local Tests)

實作環境**沒有 Docker daemon**，因此以下均以 workspace 內既有 toolchain 直接執行（非 `docker compose exec`）：

- [x] 前端型別檢查 — `pnpm exec tsc --noEmit`，exit 0
- [x] 前端 Linter 檢查 — `pnpm run lint`，0 errors（1 個既有 warning，位於 `tests/chat-memoization.test.tsx:90`，與本 PR 無關）
- [x] 前端單元測試 — `pnpm run test`，**48 passed**（本 PR 前為 39 passed，新增 9 個）
- [x] Production build — `pnpm exec next build`，exit 0
- [ ] 後端型別檢查、後端 unit / integration 測試 — 本 PR 未觸及 backend，未執行

### 新增測試

新增 `frontend/tests/realtime-readiness.test.tsx`（9 個），直接針對 state transition 驗證。full-stack lane 無法製造「sync 進行中斷線／重連」「重疊訊號」「live 角色降級」這類情境，因此放在 vitest：

1. initial sync 完成後輸出 active room 的 id，且不會誤配其他房間。
2. 重連但 sync 尚未完成時 readiness 收回，sync 成功後恢復。
3. sync 失敗時不報 ready。
4. sync 進行中 socket 斷線時不報 ready。
5. mid-session `realtime_ready` 期間撤回 readiness。
6. 舊連線的 sync 不得在重連後恢復 readiness。
7. 重疊的 `realtime_ready` 會真的跑一輪新的 `/sync`（以 `__getApiCallLog("syncChanges")` 計數）。
8. 只有最新的 `realtime_ready` 能發布 readiness（斷言兩輪 sync 之間的中間窗口）。
9. live 角色降級為 `pending` 時撤回 readiness。

**每一項守門測試都經過反向驗證**：逐一暫時移除對應的修正後，該測試確實失敗，還原後全數通過。第 6、7 項的第一版寫法曾是空過的（沒有真正讓 sync 在進行中），已重寫並確認會失敗。

### 仍未執行的驗收項目

- [ ] #620 驗收標準中的「連續執行 full-stack browser lane 至少 10 次，沒有 timeout 或 flaky failure」**尚未執行**。CI 已完整跑過該 lane 五次（每個 commit 一次）並全數通過，但 10 次連續執行需要另行安排，未自行勾選。

### 手動測試 (Manual Verification)

無 UI 外觀變更：本 PR 只新增兩個 `data-*` 屬性與一個 context，未更動任何 class 或版面。

## 資料庫變更 (Database Changes)

* 此變更是否包含資料庫 Schema 修改？ **否**
* 若為是，請寫明 Migration 檔案名稱：`不適用`
* 是否已確認遷移與 docs/database-design.md 設計一致？ **不適用**

## API 與 WebSocket 協定一致性 (API & WebSocket Contract Check)

* 此變更是否涉及 API 路由或 WebSocket 事件的資料結構變更？ **否**
* 是否已確認與 docs/api-documentation.md 規範完全一致？ **是** — 未新增或修改任何 route 與 event。本 PR 反而是讓 client 更貼合既有文件：原實作忽略了 L1589 已載明的 mid-session 重送語意。

## Review 歷程

實作前先以 architect sub-agent 檢視草案，其中四點改變了實作方式：把 true-transition 從 `runSynchronization` 的 `finally` 移到 `synchronize().then()` 並以 `socket.connected` 把關、旗標改放 leaf context、`data-room-id` 放在 button 而非外層 row、navigation 案例獨立成 `test()`。

其後 Codex review 提出六項發現，**六項均經逐一對照原始碼確認為真**。前五項已在本 PR 修正，各自附帶會失敗的迴歸測試；第六項經討論後移交 #622：

| # | 發現 | 狀態 |
|---|---|---|
| 1 | 每次 `realtime_ready` 都應撤回 readiness（非 once-per-connection） | 已修 `b3028d8` |
| 2 | 需以 connection generation 防止舊 sync 恢復 readiness | 已修 `b3028d8` |
| 3 | 重疊的 `realtime_ready` 需排入新的 sync，而非沿用 in-flight promise | 已修 `85dc7cb` |
| 4 | 只有最新的 `realtime_ready` 能發布 readiness | 已修 `3ec04d6` |
| 5 | 房間 readiness 需依最新成員角色，`myRole` 不會被 live 角色變更更新 | 已修 `3bce3ec` |
| 6 | pending 降級應同步套用事件 payload，不必等 `GET /members` 回應 | 移交 #622 |

其中第 3 項的「漏抓 durable change」一半是 `main` 上既有問題（原 handler 即為裸的 `void synchronize()`，coalescing 行為相同），本 PR 一併修掉，因為修好 readiness 必然需要真的跑一次 post-signal sync；第 4 項則是第 3 項修正所衍生。

### 關於第 6 項（已移交 #622）

該問題並非本 PR 引入，且**不比既有 UI 更寬鬆**——composer／pending 橫幅用的是同一個 `isPending`（`Chatroom.tsx` L929 on `main`），在 `GET /members` 往返期間與請求失敗時同樣會過期。而建議的做法要讓 `room_update` handler 樂觀寫入共享的 room 成員狀態（該狀態同時被 composer、group settings、member panel 與 read-state 邏輯消費），正好落在 #622 預計重整的責任區塊。

經討論確認後移交 #622，並已於該 issue 留下含可執行驗收標準的補充說明：https://github.com/nearcsie/near-chat/issues/622#issuecomment-5474476297

Generated with Claude Code (https://claude.com/claude-code)