### PR TITLE
fix(realtime): aggregate typing state per room member (#474)

### DIFF
--- a/backend/src/realtime/socketServer.ts
+++ b/backend/src/realtime/socketServer.ts
@@ -47,7 +47,67 @@ export const attachSockets = (io: ChatServer, deps: SocketDeps): void => {
   const presence = deps.presence ?? { trackUserConnection, trackUserDisconnection };
   const sessionLimit = maxSessionsPerUser();
   const sessionCounts = new Map<string, number>();
-  const typingTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  /**
+   * One live typing claim per socket per room: the expiry that retracts it if
+   * the socket goes silent, and when this socket's membership of that room was
+   * last verified.
+   */
+  const typingClaims = new Map<string, { expiry: ReturnType<typeof setTimeout>; checkedAt: number }>();
+  /**
+   * Which sockets currently claim each `(room, user)` pair.
+   *
+   * `user_typing` is a statement about a *user*, but a user has as many sockets
+   * as open tabs, so the claim has to be aggregated before it can be broadcast.
+   * Keyed per socket — which is what this replaced — a second tab sending
+   * `isTyping: false`, or simply closing, retracts a claim the first tab is
+   * still refreshing, and every other member sees the indicator disappear while
+   * the user is still typing.
+   *
+   * Nested maps rather than one map under a composite key: `roomId` and `userId`
+   * are both opaque strings from outside this process, and there is no separator
+   * they cannot both contain.
+   *
+   * Process-local on purpose. Aggregating across instances needs the events
+   * themselves to cross first — `realtime/publisher.ts` is single-process, and
+   * closing that is the event bus's job (#475/#476), not this module's.
+   */
+  const typingRooms = new Map<string, Map<string, Set<string>>>();
+
+  /** Record a socket's claim. True only when it is the user's first in the room. */
+  const addTypingSocket = (roomId: string, userId: string, socketId: string): boolean => {
+    let byUser = typingRooms.get(roomId);
+    if (!byUser) {
+      byUser = new Map();
+      typingRooms.set(roomId, byUser);
+    }
+    let sockets = byUser.get(userId);
+    if (!sockets) {
+      sockets = new Set();
+      byUser.set(userId, sockets);
+    }
+    // Whether the set was empty *before* this socket joined it — not whether it
+    // now holds one. A socket refreshing its own claim leaves the size at one,
+    // so testing the size afterwards reports every keystroke as a fresh claim.
+    const claimed = sockets.size === 0;
+    sockets.add(socketId);
+    return claimed;
+  };
+
+  /**
+   * Drop a socket's claim. True only when it was the user's last in the room.
+   *
+   * Empty containers are deleted rather than left behind: a long-lived process
+   * would otherwise accumulate one entry per room anyone has ever typed in.
+   */
+  const removeTypingSocket = (roomId: string, userId: string, socketId: string): boolean => {
+    const byUser = typingRooms.get(roomId);
+    const sockets = byUser?.get(userId);
+    if (!byUser || !sockets || !sockets.delete(socketId)) return false;
+    if (sockets.size > 0) return false;
+    byUser.delete(userId);
+    if (byUser.size === 0) typingRooms.delete(roomId);
+    return true;
+  };
   // Handshakes whose slot was already reserved by the middleware below, so the
   // connection handler does not count the same session twice. Each reservation
   // is a lease: if the connection never arrives, the timer returns the slot.
@@ -123,18 +183,30 @@ export const attachSockets = (io: ChatServer, deps: SocketDeps): void => {
     }
     socket.join(`user_${userId}`);
 
+    const typingTimerKey = (roomId: string): string => `${socket.id}:${roomId}`;
+
+    const emitTyping = (roomId: string, isTyping: boolean) => {
+      socket.to(`room_${roomId}`).emit('user_typing', { roomId, userId, isTyping });
+    };
+
+    /**
+     * Retract this socket's claim on a room, telling the room only if it was the
+     * user's last one. The single exit from typing: explicit `isTyping: false`,
+     * the TTL, and disconnect all come through here.
+     */
+    const stopTyping = (roomId: string) => {
+      const key = typingTimerKey(roomId);
+      const claim = typingClaims.get(key);
+      if (claim) clearTimeout(claim.expiry);
+      typingClaims.delete(key);
+      if (removeTypingSocket(roomId, userId, socket.id)) emitTyping(roomId, false);
+    };
+
+    // Over a copy of the keys: `stopTyping` deletes from the map it walks.
     const clearTypingTimers = () => {
-      for (const [key, timer] of typingTimers) {
-        if (key.startsWith(`${socket.id}:`)) {
-          const roomId = key.slice(socket.id.length + 1);
-          clearTimeout(timer);
-          typingTimers.delete(key);
-          socket.to(`room_${roomId}`).emit('user_typing', {
-            roomId,
-            userId,
-            isTyping: false,
-          });
-        }
+      for (const key of [...typingClaims.keys()]) {
+        if (!key.startsWith(`${socket.id}:`)) continue;
+        stopTyping(key.slice(socket.id.length + 1));
       }
     };
 
@@ -209,30 +281,62 @@ export const attachSockets = (io: ChatServer, deps: SocketDeps): void => {
           throw new ValidationError('Invalid typing payload');
         }
         const { roomId, isTyping } = payload;
-        const member = await deps.roomMemberRepository.findMember(roomId, userId);
-        if (disconnected) return;
-        if (!member || member.role === 'pending') {
-          throw new ForbiddenError('Not a member of this room');
+        const key = typingTimerKey(roomId);
+        const ttl = typingTtlMs();
+        const prior = typingClaims.get(key);
+
+        // Membership is re-checked once per TTL rather than once per keystroke.
+        // The client sends `typing` on every input change, and `findMember` is a
+        // three-table join with a correlated `EXISTS` over `blocks`, so the old
+        // per-event check put that query on every character typed.
+        //
+        // Bounded by the TTL rather than by "this socket has a live claim":
+        // a claim is refreshed by each keystroke, so trusting a live one would
+        // let a member whose access was revoked hold the indicator open for as
+        // long as they keep typing. Revocation drops the socket from the room
+        // through the publisher, and this closes the window behind it.
+        let checkedAt = prior?.checkedAt ?? 0;
+        if (Date.now() - checkedAt >= ttl) {
+          const member = await deps.roomMemberRepository.findMember(roomId, userId);
+          if (disconnected) return;
+          if (!member || member.role === 'pending') {
+            throw new ForbiddenError('Not a member of this room');
+          }
+          checkedAt = Date.now();
         }
 
-        const key = `${socket.id}:${roomId}`;
-        const prior = typingTimers.get(key);
-        if (prior) clearTimeout(prior);
-
-        socket.to(`room_${roomId}`).emit('user_typing', { roomId, userId, isTyping });
-        if (isTyping) {
-          typingTimers.set(key, setTimeout(() => {
-            typingTimers.delete(key);
-            if (disconnected) return;
-            socket.to(`room_${roomId}`).emit('user_typing', {
-              roomId,
-              userId,
-              isTyping: false,
-            });
-          }, typingTtlMs()));
-        } else {
-          typingTimers.delete(key);
+        if (!isTyping) {
+          stopTyping(roomId);
+          return;
         }
+
+        // Re-read rather than reuse `prior`, which was captured before the
+        // membership query: a concurrent event may have armed a newer expiry in
+        // the meantime, and that is the one this replaces.
+        const live = typingClaims.get(key);
+        if (live) clearTimeout(live.expiry);
+        const expiry: ReturnType<typeof setTimeout> = setTimeout(() => {
+          // Two `typing` events can be in flight at once — each awaits the
+          // membership query — and both would arm an expiry. Only the one the
+          // map still holds may retract the claim; a superseded timer firing
+          // would stop a user who is still typing.
+          if (typingClaims.get(key)?.expiry !== expiry) return;
+          typingClaims.delete(key);
+          // Cleared before the disconnect test, never after: a claim left in
+          // the aggregate is one the room can never be told about again.
+          if (removeTypingSocket(roomId, userId, socket.id) && !disconnected) {
+            emitTyping(roomId, false);
+          }
+        }, ttl);
+        // The reservation timer above already does this; an unreffed timer here
+        // would hold `bun test` and a draining container open for a full TTL.
+        expiry.unref?.();
+        typingClaims.set(key, { expiry, checkedAt });
+
+        // Only the edge is broadcast. A second tab joining a claim the room has
+        // already been told about is not news, and re-sending `true` per
+        // keystroke made the indicator a per-keystroke fan-out to every member.
+        if (addTypingSocket(roomId, userId, socket.id)) emitTyping(roomId, true);
       } catch (err) {
         socket.emit('error', mapErrorToApiShape(err));
       }

--- a/backend/src/realtime/socketServer.ts
+++ b/backend/src/realtime/socketServer.ts
@@ -57,11 +57,14 @@ export const attachSockets = (io: ChatServer, deps: SocketDeps): void => {
    * Which sockets currently claim each `(room, user)` pair.
    *
    * `user_typing` is a statement about a *user*, but a user has as many sockets
-   * as open tabs, so the claim has to be aggregated before it can be broadcast.
-   * Keyed per socket — which is what this replaced — a second tab sending
+   * as open tabs, so retracting it takes more than one socket's say-so. Keyed
+   * per socket — which is what this replaced — a second tab sending
    * `isTyping: false`, or simply closing, retracts a claim the first tab is
    * still refreshing, and every other member sees the indicator disappear while
    * the user is still typing.
+   *
+   * Only the retraction is aggregated. `true` stays a per-refresh broadcast
+   * because the client treats it as a heartbeat; see the send site below.
    *
    * Nested maps rather than one map under a composite key: `roomId` and `userId`
    * are both opaque strings from outside this process, and there is no separator
@@ -73,8 +76,8 @@ export const attachSockets = (io: ChatServer, deps: SocketDeps): void => {
    */
   const typingRooms = new Map<string, Map<string, Set<string>>>();
 
-  /** Record a socket's claim. True only when it is the user's first in the room. */
-  const addTypingSocket = (roomId: string, userId: string, socketId: string): boolean => {
+  /** Record a socket's claim on a room. */
+  const addTypingSocket = (roomId: string, userId: string, socketId: string): void => {
     let byUser = typingRooms.get(roomId);
     if (!byUser) {
       byUser = new Map();
@@ -85,12 +88,7 @@ export const attachSockets = (io: ChatServer, deps: SocketDeps): void => {
       sockets = new Set();
       byUser.set(userId, sockets);
     }
-    // Whether the set was empty *before* this socket joined it — not whether it
-    // now holds one. A socket refreshing its own claim leaves the size at one,
-    // so testing the size afterwards reports every keystroke as a fresh claim.
-    const claimed = sockets.size === 0;
     sockets.add(socketId);
-    return claimed;
   };
 
   /**
@@ -333,10 +331,17 @@ export const attachSockets = (io: ChatServer, deps: SocketDeps): void => {
         expiry.unref?.();
         typingClaims.set(key, { expiry, checkedAt });
 
-        // Only the edge is broadcast. A second tab joining a claim the room has
-        // already been told about is not news, and re-sending `true` per
-        // keystroke made the indicator a per-keystroke fan-out to every member.
-        if (addTypingSocket(roomId, userId, socket.id)) emitTyping(roomId, true);
+        addTypingSocket(roomId, userId, socket.id);
+        // Every refresh is broadcast, not only the first claim. `true` is the
+        // heartbeat the client expiry runs on: it arms its own removal timer
+        // solely on receiving `true` (`frontend/src/context/ChatContext.tsx`),
+        // so collapsing refreshes into one edge event would hide the indicator
+        // after one client timeout while the user is still typing.
+        //
+        // Only the retraction is edge-triggered, and that asymmetry is the
+        // point: `false` is a statement that the *user* stopped, which no single
+        // socket is entitled to make on its own.
+        emitTyping(roomId, true);
       } catch (err) {
         socket.emit('error', mapErrorToApiShape(err));
       }

--- a/backend/src/realtime/socketServer.ts
+++ b/backend/src/realtime/socketServer.ts
@@ -291,10 +291,19 @@ export const attachSockets = (io: ChatServer, deps: SocketDeps): void => {
         // Bounded by the TTL rather than by "this socket has a live claim":
         // a claim is refreshed by each keystroke, so trusting a live one would
         // let a member whose access was revoked hold the indicator open for as
-        // long as they keep typing. Revocation drops the socket from the room
-        // through the publisher, and this closes the window behind it.
+        // long as they keep typing.
+        //
+        // The room subscription bounds it a second time, and that is what makes
+        // revocation take effect at once rather than within a TTL. Revocation
+        // runs `socketsLeave` (`realtime/publisher.ts`), which removes the
+        // socket from the room but does *not* stop it addressing that room:
+        // `socket.to(room)` broadcasts to a room the sender need not be in. So
+        // the subscription is not an authorization by itself — it only says
+        // whether the cached one may still be trusted. Losing it sends this
+        // straight back to the repository, which is authoritative.
         let checkedAt = prior?.checkedAt ?? 0;
-        if (Date.now() - checkedAt >= ttl) {
+        const subscribed = socket.rooms?.has(`room_${roomId}`) === true;
+        if (!subscribed || Date.now() - checkedAt >= ttl) {
           const member = await deps.roomMemberRepository.findMember(roomId, userId);
           if (disconnected) return;
           if (!member || member.role === 'pending') {

--- a/backend/tests/unit/realtime/socketEvents.test.ts
+++ b/backend/tests/unit/realtime/socketEvents.test.ts
@@ -223,14 +223,13 @@ describe('Socket.IO ephemeral events E2E', () => {
     tabA.emit('typing', { roomId: 'room-1', isTyping: true });
     await waitForExpect(() => expect(seen).toHaveLength(1));
 
-    // The second claim is not news, so it is not broadcast either.
     tabB.emit('typing', { roomId: 'room-1', isTyping: true });
-    await new Promise((resolve) => setTimeout(resolve, 150));
-    expect(seen).toHaveLength(1);
+    await waitForExpect(() => expect(seen).toHaveLength(2));
 
+    // Losing one of the two sessions must not retract the user's claim.
     tabB.disconnect();
     await new Promise((resolve) => setTimeout(resolve, 150));
-    expect(seen).toHaveLength(1);
+    expect(seen.every((event) => event.isTyping)).toBe(true);
 
     tabA.emit('typing', { roomId: 'room-1', isTyping: false });
     await waitForExpect(() => {

--- a/backend/tests/unit/realtime/socketEvents.test.ts
+++ b/backend/tests/unit/realtime/socketEvents.test.ts
@@ -173,6 +173,71 @@ describe('Socket.IO ephemeral events E2E', () => {
     }
   });
 
+  /**
+   * Two sockets for one user is the ordinary case — one browser tab each — and
+   * `user_typing` speaks about the user, not the socket. These two pin that one
+   * tab can neither cancel nor duplicate the other's claim.
+   */
+  const openTypingPair = async () => {
+    const tabA = await connectClient('user-1');
+    const tabB = await connectClient('user-1');
+    const observer = await connectClient('user-2');
+
+    await waitForExpect(() => {
+      const members = ioServer.sockets.adapter.rooms.get('room_room-1');
+      expect(members?.has(observer.id!)).toBe(true);
+      expect(members?.has(tabA.id!)).toBe(true);
+      expect(members?.has(tabB.id!)).toBe(true);
+    });
+
+    const seen: Parameters<ServerToClientEvents['user_typing']>[0][] = [];
+    observer.on('user_typing', (payload) => seen.push(payload));
+    return { tabA, tabB, seen };
+  };
+
+  it('keeps a user typing when another of their sessions stops', async () => {
+    const { tabA, tabB, seen } = await openTypingPair();
+
+    tabA.emit('typing', { roomId: 'room-1', isTyping: true });
+    await waitForExpect(() => {
+      expect(seen).toEqual([{ roomId: 'room-1', userId: 'user-1', isTyping: true }]);
+    });
+
+    // The idle tab retracting a claim it never made must not stop the user.
+    tabB.emit('typing', { roomId: 'room-1', isTyping: false });
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    expect(seen).toEqual([{ roomId: 'room-1', userId: 'user-1', isTyping: true }]);
+
+    tabA.emit('typing', { roomId: 'room-1', isTyping: false });
+    await waitForExpect(() => {
+      expect(seen).toEqual([
+        { roomId: 'room-1', userId: 'user-1', isTyping: true },
+        { roomId: 'room-1', userId: 'user-1', isTyping: false },
+      ]);
+    });
+  });
+
+  it('keeps a user typing when one of two typing sessions disconnects', async () => {
+    const { tabA, tabB, seen } = await openTypingPair();
+
+    tabA.emit('typing', { roomId: 'room-1', isTyping: true });
+    await waitForExpect(() => expect(seen).toHaveLength(1));
+
+    // The second claim is not news, so it is not broadcast either.
+    tabB.emit('typing', { roomId: 'room-1', isTyping: true });
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    expect(seen).toHaveLength(1);
+
+    tabB.disconnect();
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    expect(seen).toHaveLength(1);
+
+    tabA.emit('typing', { roomId: 'room-1', isTyping: false });
+    await waitForExpect(() => {
+      expect(seen.at(-1)).toEqual({ roomId: 'room-1', userId: 'user-1', isTyping: false });
+    });
+  });
+
   it('enforces the per-user session limit', async () => {
     process.env.MAX_SESSIONS_PER_USER = '1';
     // This server was created with the default limit; rebuild it with the test limit.

--- a/backend/tests/unit/realtime/socketServer.test.ts
+++ b/backend/tests/unit/realtime/socketServer.test.ts
@@ -26,6 +26,9 @@ describe('attachSockets', () => {
     socket = {
       id: 'socket-1',
       data: { user: { userId: 'user-1', name: 'Alice' } },
+      // A real Socket.IO socket tracks its rooms, and the typing handler reads
+      // them to decide whether its cached membership check is still good.
+      rooms: new Set(['user_user-1', 'room_room-active']),
       join: mock(),
       leave: mock(),
       emit: mock(),
@@ -158,6 +161,30 @@ describe('attachSockets', () => {
     }
   });
 
+  /**
+   * `socketsLeave` removes the socket from the room but does not stop it
+   * addressing that room, so losing the subscription has to invalidate the
+   * cached membership check immediately rather than one TTL later.
+   */
+  it('stops trusting the membership cache once the socket leaves the room', async () => {
+    await handlers.typing({ roomId: 'room-active', isTyping: true });
+    const baseline = roomMemberRepo.findMember.mock.calls.length;
+    roomEmit.mockClear();
+
+    // What room revocation does, through publisher.removeUserFromRoom.
+    socket.rooms.delete('room_room-active');
+    roomMemberRepo.findMember.mockResolvedValue(null);
+    await handlers.typing({ roomId: 'room-active', isTyping: true });
+
+    expect(roomMemberRepo.findMember.mock.calls.length - baseline).toBe(1);
+    expect(roomEmit).not.toHaveBeenCalled();
+    expect(socket.emit).toHaveBeenCalledWith('error', {
+      statusCode: 403,
+      message: 'Not a member of this room',
+      code: 'FORBIDDEN',
+    });
+  });
+
   it('rejects a typing stop from a non-member', async () => {
     roomMemberRepo.findMember.mockResolvedValue(null);
 
@@ -207,6 +234,7 @@ describe('attachSockets', () => {
       const frSocket = {
         id: 'socket-fr-1',
         data: { user: { userId: 'user-1', name: 'Alice' } },
+        rooms: new Set(['user_user-1', 'room_room-active']),
         join: mock(),
         leave: mock(),
         emit: mock(),

--- a/backend/tests/unit/realtime/socketServer.test.ts
+++ b/backend/tests/unit/realtime/socketServer.test.ts
@@ -95,7 +95,7 @@ describe('attachSockets', () => {
     });
   });
 
-  it('refreshes typing without re-checking membership or re-broadcasting', async () => {
+  it('refreshes typing without re-checking membership', async () => {
     // Let the connection's own subscription restore settle first: it calls
     // findMember once per active room, and that call is not what this pins.
     await new Promise((resolve) => setTimeout(resolve, 0));
@@ -107,8 +107,21 @@ describe('attachSockets', () => {
     await handlers.typing({ roomId: 'room-active', isTyping: true });
 
     expect(membershipChecks() - baseline).toBe(1);
-    expect(roomEmit).toHaveBeenCalledTimes(1);
-    expect(roomEmit).toHaveBeenCalledWith('user_typing', {
+  });
+
+  /**
+   * The client arms its own removal timer only when it receives `true`
+   * (`frontend/src/context/ChatContext.tsx:1593-1607`), so every refresh has to
+   * reach the room. Collapsing these into a single edge event makes the
+   * indicator vanish after one client timeout while the user is still typing.
+   */
+  it('re-broadcasts every typing refresh, which is the client heartbeat', async () => {
+    await handlers.typing({ roomId: 'room-active', isTyping: true });
+    await handlers.typing({ roomId: 'room-active', isTyping: true });
+    await handlers.typing({ roomId: 'room-active', isTyping: true });
+
+    expect(roomEmit).toHaveBeenCalledTimes(3);
+    expect(roomEmit).toHaveBeenLastCalledWith('user_typing', {
       roomId: 'room-active',
       userId: 'user-1',
       isTyping: true,

--- a/backend/tests/unit/realtime/socketServer.test.ts
+++ b/backend/tests/unit/realtime/socketServer.test.ts
@@ -95,6 +95,75 @@ describe('attachSockets', () => {
     });
   });
 
+  it('refreshes typing without re-checking membership or re-broadcasting', async () => {
+    // Let the connection's own subscription restore settle first: it calls
+    // findMember once per active room, and that call is not what this pins.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const membershipChecks = () => roomMemberRepo.findMember.mock.calls.length;
+    const baseline = membershipChecks();
+
+    await handlers.typing({ roomId: 'room-active', isTyping: true });
+    await handlers.typing({ roomId: 'room-active', isTyping: true });
+    await handlers.typing({ roomId: 'room-active', isTyping: true });
+
+    expect(membershipChecks() - baseline).toBe(1);
+    expect(roomEmit).toHaveBeenCalledTimes(1);
+    expect(roomEmit).toHaveBeenCalledWith('user_typing', {
+      roomId: 'room-active',
+      userId: 'user-1',
+      isTyping: true,
+    });
+  });
+
+  it('re-checks membership once per TTL even while a claim is refreshed', async () => {
+    const previous = process.env.TYPING_TTL_MS;
+    process.env.TYPING_TTL_MS = '10';
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      const membershipChecks = () => roomMemberRepo.findMember.mock.calls.length;
+      const baseline = membershipChecks();
+
+      await handlers.typing({ roomId: 'room-active', isTyping: true });
+      await handlers.typing({ roomId: 'room-active', isTyping: true });
+      expect(membershipChecks() - baseline).toBe(1);
+
+      // Access is revoked while the user keeps typing. The claim is refreshed
+      // continuously, so only the TTL bound forces the re-check that stops them.
+      roomMemberRepo.findMember.mockResolvedValue(null);
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      await handlers.typing({ roomId: 'room-active', isTyping: true });
+
+      expect(membershipChecks() - baseline).toBe(2);
+      expect(socket.emit).toHaveBeenCalledWith('error', {
+        statusCode: 403,
+        message: 'Not a member of this room',
+        code: 'FORBIDDEN',
+      });
+    } finally {
+      if (previous === undefined) delete process.env.TYPING_TTL_MS;
+      else process.env.TYPING_TTL_MS = previous;
+    }
+  });
+
+  it('rejects a typing stop from a non-member', async () => {
+    roomMemberRepo.findMember.mockResolvedValue(null);
+
+    await handlers.typing({ roomId: 'room-hidden', isTyping: false });
+
+    expect(roomEmit).not.toHaveBeenCalled();
+    expect(socket.emit).toHaveBeenCalledWith('error', {
+      statusCode: 403,
+      message: 'Not a member of this room',
+      code: 'FORBIDDEN',
+    });
+  });
+
+  it('does not broadcast a stop for a room this socket never claimed', async () => {
+    await handlers.typing({ roomId: 'room-active', isTyping: false });
+
+    expect(roomEmit).not.toHaveBeenCalled();
+  });
+
   it('expires typing automatically at the server TTL', async () => {
     const previous = process.env.TYPING_TTL_MS;
     process.env.TYPING_TTL_MS = '10';


### PR DESCRIPTION
## 變更描述 (Description)

`user_typing` 描述的是**使用者**，但目前 typing 狀態是以 socket 為單位保存的（`socketServer.ts:50`，key 為 `${socket.id}:${roomId}`）。同一位使用者開兩個分頁時，其中一個分頁送出 `isTyping: false` 或關閉分頁，就會撤回另一個分頁仍在刷新的狀態，房間內其他成員因此看到輸入指示在使用者還在打字時消失。

本 PR 把 typing 狀態改為以 `(roomId, userId)` 聚合。**只有撤回是聚合的**，這個不對稱是刻意的：

- `true`：每次 refresh 都照常廣播。client 只有在收到 `true` 時才會重新 arm 自己那個 3 秒的移除計時器（`frontend/src/context/ChatContext.tsx:1593-1607`），所以它是 client 過期機制依賴的 heartbeat。
- `false`：只在該使用者在此房間的**最後一個** socket 放開 claim 時廣播（明確的 stop、TTL 到期、或斷線）。`false` 是「這位使用者停止輸入」的斷言，任一單獨的 socket 都無權代表使用者做出這個斷言。

順帶處理三件在同一段程式碼中發現的問題：

1. **成員資格檢查改為每個 TTL 一次**，而非每次 keystroke 一次。前端在每次輸入變更時都會送 `typing`（`frontend/src/components/chat/Chatroom.tsx:1038`），而 `findMember` 是三表 join 併帶對 `blocks` 的 correlated `EXISTS`（`backend/src/models/roomMemberRepository.ts:36-56`），等於每打一個字就跑一次該查詢。快取受**兩個**條件約束：TTL，以及 socket 是否仍訂閱該房間。後者讓踢除／降為 pending／封鎖在下一個事件就生效，而不是等一個 TTL——room subscription 本身不作為授權，只用來判斷快取是否還能信，失去訂閱即回到 repository 查詢。
2. **過期計時器先撤回 claim，再判斷連線是否還在**。反過來寫會讓聚合表留下一筆房間永遠不會再被通知的殘留狀態。
3. **被取代的計時器不再生效**。兩個 `typing` 事件可以同時在途（各自 await 成員資格查詢）並各自安排一次過期，舊的那個一旦觸發就會停掉仍在打字的使用者。

### 不在本 PR 範圍

Issue #474 的驗收標準第一條「Typing 狀態可在不同 backend instance 間同步」**無法在本 PR 內達成**，因此本 PR 使用 `Refs` 而非 `Closes`，issue 保持開啟。原因是即使把 typing 狀態寫進 Redis，`user_typing` 事件本身仍然不會跨 instance：

- `backend/src/bootstrap/realtime.ts:43` 以 `new Server()` 建立 Socket.IO，未帶 `adapter` 選項，因此使用預設的 in-memory adapter；repo 內（含 `pnpm-lock.yaml`）不存在任何 `@socket.io/redis-adapter`。
- `backend/src/realtime/publisher.ts:11-19` 自述為 “Single-process only”。
- `backend/src/realtime/presence.ts:167-168` 明講跨 instance 投遞是 event bus（#475）的工作。

在事件本身尚未跨 instance 之前寫入共享 typing 狀態，會產生一個沒有任何 reader 的 store。相關取捨與證據另外留在 #474 的追蹤留言中，包含 #475／#476 的規格是在 #282 轉向（保留 Socket.IO）之前撰寫、目前已與實際架構不一致這一點。

本 PR 完成的是 #474 工作項目中的 key schema 前提（以 `roomId` 與 `userId` 區分）、以及驗收標準第 2、3、4 條在單一 instance 下的行為。

## 相關的 Issue (Related Issue)

Refs #474

## 變更類型 (Type of Change)

- [x] `fix`: 修復 Bug
- [x] `perf`: 效能優化
- [x] `test`: 新增或修正測試案例

## 驗證與測試計畫 (Verification & Test Plan)

### 本地測試 (Local Tests)

本次執行環境沒有 Docker，因此以本機 toolchain（bun 1.3.11）直接執行，指令與 CONTRIBUTING §5 的容器版等價：

- [x] 後端型別檢查 —— `pnpm run lint`（= `eslint src && tsc --noEmit`）exit 0
- [x] 前端型別檢查 —— `tsc --noEmit` 通過（本 PR 未改動 frontend）
- [x] 單元測試 —— `bun test tests/unit`：**720 pass / 0 fail**（改動前為 712，本 PR 新增 8 個案例）
- [x] 整合測試 —— 本機無法執行（需要 Docker 與 ephemeral `db-test`），但 CI 的 `database / database-tests` job 在本 PR 上已通過。

### 迴歸證明 (Regression proof)

兩個多分頁案例對照 `origin/main` 的 `socketServer.ts` 失敗，套用本 PR 後通過——先確認能重現缺陷，再確認修好：

```
$ git checkout origin/main -- backend/src/realtime/socketServer.ts
$ bun test tests/unit/realtime -t "keeps a user typing"
 0 pass / 2 fail
```

review 過程中補上的兩個測試也各自先在對應的 baseline 上重現失敗，詳見下方「Review 修正紀錄」。

### 新增測試

`backend/tests/unit/realtime/socketEvents.test.ts`（真實 Socket.IO server 與 client）

- `keeps a user typing when another of their sessions stops` —— 閒置分頁送出 `isTyping: false` 不得停掉另一個分頁的輸入狀態。
- `keeps a user typing when one of two typing sessions disconnects` —— 其中一個分頁斷線不得產生 `false`。

`backend/tests/unit/realtime/socketServer.test.ts`

- `refreshes typing without re-checking membership` —— 連續三次 `isTyping: true` 只查一次成員資格。
- `re-broadcasts every typing refresh, which is the client heartbeat` —— 每次 refresh 都必須廣播，因為 client 靠它重設自己的過期計時器。此測試對照 `origin/main` 是**通過**的，用途是防止再次收斂掉這個 heartbeat。
- `re-checks membership once per TTL even while a claim is refreshed` —— 持續打字的情況下，權限被撤銷後仍會在一個 TTL 內被擋下並回 `FORBIDDEN`。
- `stops trusting the membership cache once the socket leaves the room` —— 失去 room subscription 後立即重新查詢授權。
- `rejects a typing stop from a non-member` —— 確認授權沒有被放寬。
- `does not broadcast a stop for a room this socket never claimed`。

穩定性：`bun test tests/unit/realtime` 連跑 3 次皆 0 fail。

### Review 修正紀錄

Codex review bot 指出兩個問題，皆為本 PR 自身引入、且皆已修正：

- **P1（`6ef2454`）** —— `0d497ad` 最初把 `true` 收斂成單一 0→1 edge 事件，等於拿掉 client 過期機制依賴的 heartbeat，使用者連續輸入超過一個 client timeout 後提示會消失。改回每次 refresh 都廣播，只聚合撤回。
- **P2（`b2d9784`）** —— TTL 快取視窗內，被撤銷資格的 socket 仍能繼續向原房間廣播：`socketsLeave` 會把 socket 移出房間，但不阻止它用 `socket.to(room)` 指定該房間。改為在快取路徑一併確認 socket 仍訂閱該房間。修正前該測試中 `findMember` 被呼叫 0 次，亦即快取路徑完全略過授權檢查。

### 手動測試 (Manual Verification)

未進行；本環境無法啟動 Docker stack。行為改動全部以上述自動化測試涵蓋。

## 資料庫變更 (Database Changes)

* 此變更是否包含資料庫 Schema 修改？ **否**

## API 與 WebSocket 協定一致性 (API & WebSocket Contract Check)

* 此變更是否涉及 API 路由或 WebSocket 事件的資料結構變更？ **否**
* 是否已確認與 [docs/api-documentation.md](../docs/api-documentation.md) 規範完全一致？ **是** —— `typing`（`shared/types.ts:223`）與 `user_typing`（`shared/types.ts:230`）的 payload 皆未更動，`docs/api-documentation.md:1574,1583` 無需修改。`true` 的廣播時機與既有行為相同；改變的只有 `false` 的廣播時機（改為使用者最後一個 session 放開時才送）。

---

Generated with Claude Code (https://claude.com/claude-code)

https://claude.ai/code/session_01EryBQhHAsodjb3QQjm98Tm