### PR TITLE
fix(realtime): aggregate typing claims across instances in Redis (#474)

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -17,6 +17,7 @@ This directory contains the Bun + Hono TypeScript API server for the chat applic
 | [src/utils/redis.ts](src/utils/redis.ts) | Redis connection manager built on Bun's native client. Redis holds derived state only, so an outage degrades realtime rather than stopping the API |
 | [src/realtime/presenceStore.ts](src/realtime/presenceStore.ts) | Cross-instance presence as per-instance leases in Redis (hash-field TTLs, Redis 7.4+). Its Redis semantics are pinned in `tests/integration/realtime/` against a real server |
 | [src/realtime/redisAdapter.ts](src/realtime/redisAdapter.ts) | Cross-instance event fan-out as a Socket.IO cluster adapter over the `near-chat-ws` Redis channel. Installed only when `REDIS_URL` is set, so without it the in-memory adapter keeps realtime single-node |
+| [src/realtime/typingStore.ts](src/realtime/typingStore.ts) | Cross-instance typing claims as per-instance leases in Redis, so a retraction is sent only once no instance claims the room member. Wired only when `REDIS_URL` is set, like the adapter above |
 | [migrations/](migrations/) | PostgreSQL migration files written in raw SQL, applied by the Bun.SQL runner in [src/models/migrate.ts](src/models/migrate.ts) |
 | [package.json](package.json) | NPM scripts (`pnpm run dev` for `bun --watch`, `pnpm run test`) and dependencies |
 

--- a/backend/src/bootstrap/realtime.ts
+++ b/backend/src/bootstrap/realtime.ts
@@ -8,6 +8,7 @@ import { attachSocketAuth } from '../realtime/authSocket';
 import { attachSockets } from '../realtime/socketServer';
 import type { RealtimePublisher } from '../realtime/publisher';
 import { createRedisAdapter } from '../realtime/redisAdapter';
+import { createRedisTypingStore } from '../realtime/typingStore';
 import type { RedisManager } from '../utils/redis';
 import { env } from '../config/env';
 
@@ -72,6 +73,17 @@ export const createRealtime = ({
     roomMemberRepository: repositories.roomMembers,
     friendRepository: repositories.friends,
     withRoomSubscriptionLock: publisher.withRoomSubscriptionLock,
+    // Gated on `REDIS_URL` for the same reason as the adapter above: without
+    // Redis there is no second instance to aggregate with, and a store over a
+    // manager that refuses every command would only warn about a Redis nobody
+    // asked for.
+    typingStore: redisUrl
+      ? createRedisTypingStore({
+          redis,
+          instanceId: config.instanceId,
+          ttlMs: realtime.typingTtlMs,
+        })
+      : undefined,
   });
 
   return { io, engine };

--- a/backend/src/realtime/redisAdapter.ts
+++ b/backend/src/realtime/redisAdapter.ts
@@ -63,9 +63,9 @@ export const realtimeChannel = (clusterId?: string): string => {
  * adapter gives, and the reason clients recover through their Sync Cursor
  * rather than by trusting the socket.
  *
- * Two consequences that a Sync Cursor cannot repair, because they are not
- * missed events but wrong local state, and that must be closed before a
- * replica count above one becomes a supported deployment:
+ * One consequence that a Sync Cursor cannot repair, because it is not a missed
+ * event but wrong local state, and that must be closed before a replica count
+ * above one becomes a supported deployment:
  *
  * - A `SOCKETS_LEAVE` lost to an outage leaves a revoked member's socket in
  *   `room_<id>` on that instance, still receiving what the room publishes
@@ -75,10 +75,12 @@ export const realtimeChannel = (clusterId?: string): string => {
  *   subscriptions from durable membership on connect; what is missing is
  *   re-running that, and leaving the rooms that are no longer permitted, after
  *   a reconnect. Tracked on #477.
- * - Typing claims are aggregated per process in `socketServer.ts`, so with the
- *   same user typing from two instances the last local claim to end retracts
- *   the indication for everyone. That is #474's remaining acceptance
- *   criterion, which this adapter unblocks rather than resolves.
+ *
+ * Typing was the other one, and is closed: widening the reach of `user_typing`
+ * left its aggregation stopped at the process boundary, so `realtime/
+ * typingStore.ts` moved the "is this the last claim anywhere" question into
+ * Redis. A lost frame still costs a retraction, which the client's own expiry
+ * timer covers.
  *
  * A Redis outage degrades rather than fails: `ClusterAdapter#broadcast`
  * publishes inside a `try`/`catch` and calls `super.broadcast` regardless, so

--- a/backend/src/realtime/socketServer.ts
+++ b/backend/src/realtime/socketServer.ts
@@ -3,6 +3,7 @@ import { ForbiddenError, ValidationError } from '../utils/AppError';
 import type { IRoomMemberRepository } from '../models/IRoomMemberRepository';
 import type { ChatServer } from './authSocket';
 import { trackUserConnection, trackUserDisconnection, type PresenceTracker } from './presence';
+import type { TypingStore } from './typingStore';
 import { mapErrorToApiShape } from '../utils/mapError';
 import { env } from '../config/env';
 
@@ -16,6 +17,11 @@ interface SocketDeps {
   ) => Promise<T>;
   /** Optional injected presence tracker (defaults to process singleton). */
   presence?: Pick<PresenceTracker, 'trackUserConnection' | 'trackUserDisconnection'>;
+  /**
+   * Optional cross-instance typing claims. Absent means single-node typing,
+   * exactly as before Redis existed; see `bootstrap/realtime.ts`.
+   */
+  typingStore?: TypingStore;
 }
 
 const maxSessionsPerUser = (): number => env().realtime.maxSessionsPerUser;
@@ -61,6 +67,67 @@ export const attachSockets = (io: ChatServer, deps: SocketDeps): void => {
     byUser.delete(userId);
     if (byUser.size === 0) typingRooms.delete(roomId);
     return true;
+  };
+
+  /** True while this process holds any typing claim for the user in the room. */
+  const heldLocally = (roomId: string, userId: string): boolean =>
+    (typingRooms.get(roomId)?.get(userId)?.size ?? 0) > 0;
+
+  /** Serialises store writes per room member; see `syncTyping`. */
+  const syncTails = new Map<string, Promise<boolean>>();
+
+  /** A sync that is queued but has not read the local state yet. */
+  const syncPending = new Map<string, Promise<boolean>>();
+
+  /**
+   * Reconcile this instance's Redis claim with the local one, and report
+   * whether the room should now be told the user stopped.
+   *
+   * Written as a reconciler rather than a claim/release pair because the two
+   * would race: `typingRooms` is mutated before the round trip and a keystroke
+   * arriving mid-flight can invert the answer, so the write has to be derived
+   * from the local state at the moment it reaches Redis, not at the moment it
+   * was requested. Per-key serialisation makes that state stable for the
+   * duration of a round trip; the queue tail is the same shape as
+   * `utils/redis.ts`'s `onChannel`, self-deleting so a room member that stops
+   * typing leaves nothing behind.
+   *
+   * A call that finds a sync still waiting joins it instead of queueing
+   * another: an unstarted sync will read exactly what this one would, so a
+   * burst of keystrokes collapses into one write per round trip rather than
+   * one per keystroke.
+   */
+  const syncTyping = (store: TypingStore, roomId: string, userId: string): Promise<boolean> => {
+    const key = `${roomId}:${userId}`;
+    const waiting = syncPending.get(key);
+    if (waiting) return waiting;
+
+    let self: Promise<boolean> | undefined;
+    const run = async (): Promise<boolean> => {
+      if (syncPending.get(key) === self) syncPending.delete(key);
+      if (heldLocally(roomId, userId)) {
+        await store.claim(roomId, userId);
+        return false;
+      }
+      const result = await store.release(roomId, userId);
+      // A claim taken while the release was in flight is the newer truth, and
+      // the sync queued behind this one restores the field it just deleted.
+      if (heldLocally(roomId, userId)) return false;
+      // An unreachable Redis retracts as this instance always did, rather than
+      // stranding an indicator nobody can clear. Same call as `presence.ts`.
+      return !result.ok || result.value === 0;
+    };
+
+    const previous = syncTails.get(key) ?? Promise.resolve(false);
+    const next = previous.then(run, run);
+    self = next;
+    syncTails.set(key, next);
+    syncPending.set(key, next);
+    void next.catch(() => undefined).then(() => {
+      if (syncTails.get(key) === next) syncTails.delete(key);
+      if (syncPending.get(key) === next) syncPending.delete(key);
+    });
+    return next;
   };
 
   // Tracks reserved handshake slots to prevent race conditions during connection setup.
@@ -137,16 +204,45 @@ export const attachSockets = (io: ChatServer, deps: SocketDeps): void => {
     };
 
     /**
-     * Retract this socket's claim on a room, telling the room only if it was the
-     * user's last one. The single exit from typing: explicit `isTyping: false`,
-     * the TTL, and disconnect all come through here.
+     * Retract this socket's claim on a room, telling the room only once no
+     * instance claims it any more. `speak` gates the broadcast for the caller
+     * that must not speak after teardown, and is read here rather than after
+     * the round trip so a disconnect arriving mid-flight cannot swallow a
+     * retraction the claim's owner was still entitled to make.
+     *
+     * Emitting after the socket is gone is safe: `socket.to(...)` captures the
+     * adapter and the excluded socket id when it is called, and never reads the
+     * socket again — which is what lets the retraction outlive an `await`.
+     */
+    const releaseClaim = (roomId: string, speak: boolean): void => {
+      if (!removeTypingSocket(roomId, userId, socket.id)) return;
+      const store = deps.typingStore;
+      if (!store) {
+        if (speak) emitTyping(roomId, false);
+        return;
+      }
+      void syncTyping(store, roomId, userId).then(
+        (retract) => {
+          if (retract && speak) emitTyping(roomId, false);
+        },
+        () => {
+          if (speak) emitTyping(roomId, false);
+        },
+      );
+    };
+
+    /**
+     * Retract this socket's claim on a room. The single exit from typing:
+     * explicit `isTyping: false`, the TTL, and disconnect all come through
+     * here. Unlike the TTL timer this one still speaks after a disconnect —
+     * losing the connection is exactly when the room has to be told.
      */
     const stopTyping = (roomId: string) => {
       const key = typingTimerKey(roomId);
       const claim = typingClaims.get(key);
       if (claim) clearTimeout(claim.expiry);
       typingClaims.delete(key);
-      if (removeTypingSocket(roomId, userId, socket.id)) emitTyping(roomId, false);
+      releaseClaim(roomId, true);
     };
 
     // Over a copy of the keys: `stopTyping` deletes from the map it walks.
@@ -247,14 +343,20 @@ export const attachSockets = (io: ChatServer, deps: SocketDeps): void => {
         const expiry: ReturnType<typeof setTimeout> = setTimeout(() => {
           if (typingClaims.get(key)?.expiry !== expiry) return;
           typingClaims.delete(key);
-          if (removeTypingSocket(roomId, userId, socket.id) && !disconnected) {
-            emitTyping(roomId, false);
-          }
+          releaseClaim(roomId, !disconnected);
         }, ttl);
         expiry.unref?.();
         typingClaims.set(key, { expiry, checkedAt });
 
         addTypingSocket(roomId, userId, socket.id);
+        // The claim is refreshed in Redis without waiting for it: the heartbeat
+        // below states local truth, which no cluster-wide count can change, and
+        // `command` has no deadline of its own — a slow Redis would otherwise
+        // stall every keystroke. Ordering against a later release is the
+        // queue's job, not this call's.
+        if (deps.typingStore) {
+          void syncTyping(deps.typingStore, roomId, userId).catch(() => undefined);
+        }
         // Broadcast typing heartbeat to the room.
         emitTyping(roomId, true);
       } catch (err) {

--- a/backend/src/realtime/typingStore.ts
+++ b/backend/src/realtime/typingStore.ts
@@ -1,0 +1,125 @@
+import type pino from 'pino';
+import type { RedisManager, RedisOutcome } from '../utils/redis';
+import { DEFAULT_TYPING_TTL_MS } from '../config/env';
+import { logger as defaultLogger } from '../utils/logger';
+
+/** Redis key prefix for typing claims: typing:room:{roomId}:user:{userId} */
+export const TYPING_KEY_PREFIX = 'typing:room:';
+
+export const typingKey = (roomId: string, userId: string): string =>
+  `${TYPING_KEY_PREFIX}${roomId}:user:${userId}`;
+
+/**
+ * Cross-instance typing claims as per-instance leases in Redis.
+ * Key schema: typing:room:{roomId}:user:{userId} -> { "{instanceId}": "1" }
+ *
+ * The field value carries no information — a claim either exists or it does
+ * not. `socketServer.ts` already collapses a user's sockets on one instance
+ * into a single claim, so a per-instance count would only add a decrement that
+ * can drift out of step with that local set, leaving a field that never reaches
+ * zero until its TTL. Existence corrects itself on the next write.
+ */
+export interface TypingStore {
+  /** Takes or refreshes this instance's claim on a user typing in a room. */
+  claim(roomId: string, userId: string): Promise<RedisOutcome<void>>;
+  /** Drops this instance's claim; returns how many instances still hold one. */
+  release(roomId: string, userId: string): Promise<RedisOutcome<number>>;
+}
+
+/**
+ * Lua script: Sets instance field with TTL using HPEXPIRE.
+ * Rolls back if HPEXPIRE fails, so a claim is never left immortal.
+ */
+const CLAIM_SCRIPT = `
+redis.call('HSET', KEYS[1], ARGV[1], '1')
+local expiry = redis.pcall('HPEXPIRE', KEYS[1], ARGV[2], 'FIELDS', 1, ARGV[1])
+if type(expiry) == 'table' and expiry.err then
+  redis.call('HDEL', KEYS[1], ARGV[1])
+  return expiry
+end
+return 1
+`.trim();
+
+/** Lua script: Deletes instance field and returns remaining holder count. */
+const RELEASE_SCRIPT = `
+redis.call('HDEL', KEYS[1], ARGV[1])
+return redis.call('HLEN', KEYS[1])
+`.trim();
+
+/** Coerces Redis reply values into a non-negative count. */
+const asCount = (value: unknown): number => {
+  const count = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(count) && count > 0 ? Math.trunc(count) : 0;
+};
+
+export interface CreateTypingStoreOptions {
+  redis: RedisManager;
+  /** This process's identity; one hash field per instance. See `AppConfig`. */
+  instanceId: string;
+  /**
+   * How long a claim survives unrefreshed.
+   *
+   * The same `TYPING_TTL_MS` the local expiry timer uses, deliberately: a
+   * longer lease would outlive the local claim it stands for, and every extra
+   * millisecond is time a crashed instance's leftover field suppresses a
+   * retraction that another instance is entitled to make.
+   */
+  ttlMs: number;
+  logger?: pino.Logger;
+}
+
+export const createRedisTypingStore = ({
+  redis,
+  instanceId,
+  ttlMs,
+  logger = defaultLogger,
+}: CreateTypingStoreOptions): TypingStore => {
+  // Sanitised for the same reason as the presence store's: a non-finite value
+  // would reach Redis as the literal `NaN` and come back as an unsupported
+  // server rather than a bad setting.
+  const ttl = String(Number.isFinite(ttlMs) ? Math.max(1, Math.trunc(ttlMs)) : DEFAULT_TYPING_TTL_MS);
+  // Hash-field TTLs need Redis 7.4+, and the error says only "unknown command".
+  // Warned once for the same reason presence warns once: a down or too-old
+  // Redis produces one failure per keystroke, and the recent-log buffer holds
+  // 200 records in total.
+  let warned = false;
+  const warnUnsupported = (operation: string, error: Error): void => {
+    if (warned) return;
+    warned = true;
+    logger.warn(
+      { operation, error: error.message, instanceId },
+      'Typing claims are not reaching Redis; typing falls back to this instance only. Cross-instance typing needs Redis 7.4 or newer for hash-field TTLs',
+    );
+  };
+
+  return {
+    async claim(roomId, userId) {
+      const result = await redis.command('EVAL', [
+        CLAIM_SCRIPT,
+        '1',
+        typingKey(roomId, userId),
+        instanceId,
+        ttl,
+      ]);
+      if (!result.ok) {
+        warnUnsupported('claim', result.error);
+        return result;
+      }
+      return { ok: true as const, value: undefined };
+    },
+
+    async release(roomId, userId) {
+      const result = await redis.command('EVAL', [
+        RELEASE_SCRIPT,
+        '1',
+        typingKey(roomId, userId),
+        instanceId,
+      ]);
+      if (!result.ok) {
+        warnUnsupported('release', result.error);
+        return result;
+      }
+      return { ok: true as const, value: asCount(result.value) };
+    },
+  };
+};

--- a/backend/tests/integration/realtime/typingStore.int.test.ts
+++ b/backend/tests/integration/realtime/typingStore.int.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { createRedisManager, type RedisManager } from '../../../src/utils/redis';
+import { createRedisTypingStore, typingKey, type TypingStore } from '../../../src/realtime/typingStore';
+
+/**
+ * The Redis semantics the unit tier cannot honestly fake.
+ *
+ * `realtime/typingStore.ts` rests on the same server promises the presence
+ * store does — that `HPEXPIRE` expires one *field* rather than the key, that
+ * `HLEN` stops counting a field whose TTL has passed, that the key disappears
+ * with its last field, and that a Lua script's read and write are one step —
+ * and one that matters more here than it does there: that the `HDEL` and the
+ * `HLEN` deciding who retracts are atomic, because whichever instance sees zero
+ * is the one that tells the room the user stopped. A `Map`-backed fake can be
+ * written to agree with all of it and still be wrong.
+ *
+ * `REDIS_URL_TEST` defaults to the dev compose mapping, so `docker compose up -d
+ * redis` from the repo root is enough to run it locally.
+ */
+const url = process.env.REDIS_URL_TEST || 'redis://localhost:6385';
+
+// Namespaced per run so a leftover key from an interrupted run cannot make a
+// later one pass or fail for the wrong reason, and so two runs can overlap.
+const run = `it-${Math.random().toString(36).slice(2, 10)}`;
+const room = (name: string): string => `${run}-${name}`;
+const USER = 'user-1';
+const ROOMS = ['shared', 'solo', 'expiring', 'refreshed'];
+
+describe('redis typing store against a real Redis', () => {
+  let redis: RedisManager;
+  let alpha: TypingStore;
+  let beta: TypingStore;
+
+  const ttlMs = 600;
+
+  beforeAll(async () => {
+    redis = createRedisManager({ url });
+    await redis.connect();
+    if (!(await redis.ping())) {
+      throw new Error(
+        `Redis is not reachable at ${url}. Start it with \`docker compose up -d redis\`, or set REDIS_URL_TEST.`,
+      );
+    }
+    alpha = createRedisTypingStore({ redis, instanceId: `${run}-alpha`, ttlMs });
+    beta = createRedisTypingStore({ redis, instanceId: `${run}-beta`, ttlMs });
+  });
+
+  afterAll(async () => {
+    for (const name of ROOMS) await redis.command('DEL', [typingKey(room(name), USER)]);
+    await redis.close();
+  });
+
+  beforeEach(async () => {
+    for (const name of ROOMS) await redis.command('DEL', [typingKey(room(name), USER)]);
+  });
+
+  it('keeps two instances claims for the same room member side by side', async () => {
+    await alpha.claim(room('shared'), USER);
+    await beta.claim(room('shared'), USER);
+
+    expect(await redis.command('HLEN', [typingKey(room('shared'), USER)])).toEqual({
+      ok: true,
+      value: 2,
+    });
+  });
+
+  it('reports the last release anywhere, and only the last', async () => {
+    await alpha.claim(room('shared'), USER);
+    await beta.claim(room('shared'), USER);
+
+    // The first instance to stop is not the one that tells the room.
+    expect(await alpha.release(room('shared'), USER)).toEqual({ ok: true, value: 1 });
+    expect(await beta.release(room('shared'), USER)).toEqual({ ok: true, value: 0 });
+  });
+
+  it('refreshes rather than duplicates a claim the same instance already holds', async () => {
+    await alpha.claim(room('solo'), USER);
+    await alpha.claim(room('solo'), USER);
+
+    expect(await alpha.release(room('solo'), USER)).toEqual({ ok: true, value: 0 });
+  });
+
+  it('deletes the key once the last claim is handed back', async () => {
+    await alpha.claim(room('solo'), USER);
+    await alpha.release(room('solo'), USER);
+
+    expect(await redis.command('EXISTS', [typingKey(room('solo'), USER)])).toEqual({
+      ok: true,
+      value: 0,
+    });
+  });
+
+  it('lets an unrefreshed claim expire, which is what bounds a crashed instance', async () => {
+    await alpha.claim(room('expiring'), USER);
+
+    // Nothing refreshes it — the instance that took it is gone. Without this
+    // the leftover field would suppress every later retraction for this room
+    // member, because no one would ever see the count reach zero.
+    await new Promise((resolve) => setTimeout(resolve, ttlMs + 300));
+
+    expect(await beta.release(room('expiring'), USER)).toEqual({ ok: true, value: 0 });
+  });
+
+  it('expires one instance claim without touching another', async () => {
+    await alpha.claim(room('shared'), USER);
+    await new Promise((resolve) => setTimeout(resolve, ttlMs / 2));
+    // beta starts typing halfway through alpha's claim and keeps refreshing.
+    await beta.claim(room('shared'), USER);
+    await new Promise((resolve) => setTimeout(resolve, ttlMs / 2 + 200));
+
+    expect(await redis.command('HLEN', [typingKey(room('shared'), USER)])).toEqual({
+      ok: true,
+      value: 1,
+    });
+  });
+
+  it('a refresh keeps a live claim past the TTL', async () => {
+    await alpha.claim(room('refreshed'), USER);
+    for (let i = 0; i < 3; i += 1) {
+      await new Promise((resolve) => setTimeout(resolve, ttlMs / 3));
+      await alpha.claim(room('refreshed'), USER);
+    }
+    await new Promise((resolve) => setTimeout(resolve, ttlMs / 2));
+
+    // beta is not the last holder, so it stays silent and alpha keeps the room.
+    expect(await beta.release(room('refreshed'), USER)).toEqual({ ok: true, value: 1 });
+  });
+
+  it('separates one room member from another under the same user', async () => {
+    await alpha.claim(room('shared'), USER);
+
+    expect(await alpha.release(room('solo'), USER)).toEqual({ ok: true, value: 0 });
+    expect(await redis.command('HLEN', [typingKey(room('shared'), USER)])).toEqual({
+      ok: true,
+      value: 1,
+    });
+  });
+});

--- a/backend/tests/unit/realtime/socketServer.test.ts
+++ b/backend/tests/unit/realtime/socketServer.test.ts
@@ -409,4 +409,212 @@ describe('attachSockets', () => {
       expect(afterDisconnect[0]).toBeUndefined();
     });
   });
+
+  /**
+   * The cluster half of what #640 fixed inside one process.
+   *
+   * With a cluster adapter installed, `socket.to(room)` reaches every instance,
+   * so `false` from this process's last claim retracts the indication for a
+   * user who is still typing on another instance. These pin that the retraction
+   * is now the store's decision, and that it stays this process's decision when
+   * no store is wired.
+   */
+  describe('with a cross-instance typing store', () => {
+    let storeHandlers: Record<string, any>;
+    let storeSocket: any;
+    let storeRoomEmit: Mock<any>;
+    let claims: Array<[string, string]>;
+    let releases: Array<[string, string]>;
+    let holdersLeft: number;
+    /** Resolves the next `release` by hand, to open a window mid-flight. */
+    let blockRelease: (() => void) | undefined;
+
+    const attachWithStore = (id = 'socket-1') => {
+      const handlers: Record<string, any> = {};
+      const emitToRoom = mock();
+      const socket = {
+        id,
+        data: { user: { userId: 'user-1', name: 'Alice' } },
+        rooms: new Set(['user_user-1', 'room_room-active']),
+        join: mock(),
+        leave: mock(),
+        emit: mock(),
+        to: mock(() => ({ emit: emitToRoom })),
+        on: mock((event: string, handler: any) => { handlers[event] = handler; }),
+      };
+      return { handlers, socket, emitToRoom };
+    };
+
+    let connect: (socket: any) => void;
+
+    beforeEach(() => {
+      claims = [];
+      releases = [];
+      holdersLeft = 0;
+      blockRelease = undefined;
+
+      const typingStore = {
+        async claim(roomId: string, userId: string) {
+          claims.push([roomId, userId]);
+          return { ok: true as const, value: undefined };
+        },
+        async release(roomId: string, userId: string) {
+          releases.push([roomId, userId]);
+          if (blockRelease) {
+            await new Promise<void>((resolve) => { blockRelease = resolve; });
+          }
+          return { ok: true as const, value: holdersLeft };
+        },
+      };
+
+      let handler: any;
+      const io = {
+        on: mock((event: string, fn: any) => { if (event === 'connection') handler = fn; }),
+        to: mock(() => ({ emit: mock() })),
+      } as unknown as ChatServer;
+
+      attachSockets(io, {
+        roomMemberRepository: {
+          findByUser: mock().mockResolvedValue([{ roomId: 'room-active', role: 'member' }]),
+          findMember: mock().mockResolvedValue({ roomId: 'room-active', role: 'member' }),
+        } as any,
+        typingStore,
+      });
+      connect = handler;
+
+      const first = attachWithStore();
+      storeHandlers = first.handlers;
+      storeSocket = first.socket;
+      storeRoomEmit = first.emitToRoom;
+      connect(storeSocket);
+    });
+
+    it('claims in Redis on every refresh, without waiting for it to answer', async () => {
+      await storeHandlers.typing({ roomId: 'room-active', isTyping: true });
+
+      // The heartbeat states local truth, so it must not sit behind a round trip.
+      expect(storeRoomEmit).toHaveBeenCalledWith('user_typing', {
+        roomId: 'room-active',
+        userId: 'user-1',
+        isTyping: true,
+      });
+      await Promise.resolve();
+      expect(claims).toEqual([['room-active', 'user-1']]);
+    });
+
+    it('retracts only once no instance holds a claim', async () => {
+      await storeHandlers.typing({ roomId: 'room-active', isTyping: true });
+      storeRoomEmit.mockClear();
+
+      holdersLeft = 0;
+      await storeHandlers.typing({ roomId: 'room-active', isTyping: false });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(releases).toEqual([['room-active', 'user-1']]);
+      expect(storeRoomEmit).toHaveBeenCalledWith('user_typing', {
+        roomId: 'room-active',
+        userId: 'user-1',
+        isTyping: false,
+      });
+    });
+
+    it('stays silent while another instance still claims the same room member', async () => {
+      await storeHandlers.typing({ roomId: 'room-active', isTyping: true });
+      storeRoomEmit.mockClear();
+
+      // The user is typing from a second instance; this one is not the last.
+      holdersLeft = 1;
+      await storeHandlers.typing({ roomId: 'room-active', isTyping: false });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(releases).toHaveLength(1);
+      expect(storeRoomEmit).not.toHaveBeenCalled();
+    });
+
+    /**
+     * The race the reconciler exists for. A keystroke landing while a release
+     * is in flight has to both suppress the retraction and put the field back —
+     * a plain claim/release pair would let the HDEL win and leave this instance
+     * holding a live local claim that Redis knows nothing about.
+     */
+    it('suppresses a retraction overtaken by a keystroke, and re-claims', async () => {
+      await storeHandlers.typing({ roomId: 'room-active', isTyping: true });
+      storeRoomEmit.mockClear();
+      claims.length = 0;
+
+      blockRelease = () => {};
+      holdersLeft = 0;
+      const stopped = storeHandlers.typing({ roomId: 'room-active', isTyping: false });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(releases).toHaveLength(1);
+
+      // Typing resumes before Redis has answered the release.
+      await storeHandlers.typing({ roomId: 'room-active', isTyping: true });
+      blockRelease?.();
+      await stopped;
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const retracted = storeRoomEmit.mock.calls.some(
+        ([, payload]: any[]) => payload?.isTyping === false,
+      );
+      expect(retracted).toBe(false);
+      expect(claims).toEqual([['room-active', 'user-1']]);
+    });
+
+    it('retracts anyway when Redis cannot answer', async () => {
+      const failing = {
+        claim: async () => ({ ok: true as const, value: undefined }),
+        release: async () => ({ ok: false as const, error: new Error('down') }),
+      };
+      let handler: any;
+      const io = {
+        on: mock((event: string, fn: any) => { if (event === 'connection') handler = fn; }),
+        to: mock(() => ({ emit: mock() })),
+      } as unknown as ChatServer;
+      attachSockets(io, {
+        roomMemberRepository: {
+          findByUser: mock().mockResolvedValue([{ roomId: 'room-active', role: 'member' }]),
+          findMember: mock().mockResolvedValue({ roomId: 'room-active', role: 'member' }),
+        } as any,
+        typingStore: failing,
+      });
+      const { handlers, socket, emitToRoom } = attachWithStore('socket-down');
+      handler(socket);
+
+      await handlers.typing({ roomId: 'room-active', isTyping: true });
+      emitToRoom.mockClear();
+      await handlers.typing({ roomId: 'room-active', isTyping: false });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      // Suppressing here would strand an indicator nobody can clear.
+      expect(emitToRoom).toHaveBeenCalledWith('user_typing', {
+        roomId: 'room-active',
+        userId: 'user-1',
+        isTyping: false,
+      });
+    });
+
+    it('still retracts when the socket disconnects', async () => {
+      await storeHandlers.typing({ roomId: 'room-active', isTyping: true });
+      storeRoomEmit.mockClear();
+      holdersLeft = 0;
+
+      storeHandlers.disconnect();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(storeRoomEmit).toHaveBeenCalledWith('user_typing', {
+        roomId: 'room-active',
+        userId: 'user-1',
+        isTyping: false,
+      });
+    });
+
+    it('asks the store nothing for a room this socket never claimed', async () => {
+      await storeHandlers.typing({ roomId: 'room-active', isTyping: false });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(releases).toEqual([]);
+      expect(storeRoomEmit).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/backend/tests/unit/realtime/typingStore.test.ts
+++ b/backend/tests/unit/realtime/typingStore.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'bun:test';
+import pino from 'pino';
+import {
+  createRedisTypingStore,
+  typingKey,
+  TYPING_KEY_PREFIX,
+} from '../../../src/realtime/typingStore';
+import type { RedisManager, RedisOutcome } from '../../../src/utils/redis';
+
+interface RecordedCommand {
+  command: string;
+  args: string[];
+}
+
+/**
+ * A `RedisManager` that records what it was asked and answers from a script.
+ *
+ * The same recorder the presence store's unit tier uses, and for the same
+ * reason: what this tier can honestly check is the *protocol* — which command,
+ * which key, which arguments, and how a reply is mapped back. Whether
+ * `HPEXPIRE` really expires one field, and whether `HLEN` really stops counting
+ * it afterwards, are Redis's promises and are pinned against a real server in
+ * `tests/integration/realtime/typingStore.int.test.ts`.
+ */
+const makeRedis = (replies: unknown[] | ((call: RecordedCommand) => unknown)) => {
+  const calls: RecordedCommand[] = [];
+  let index = 0;
+  const redis = {
+    async command<T>(command: string, args: string[] = []): Promise<RedisOutcome<T>> {
+      const call = { command, args };
+      calls.push(call);
+      const reply = typeof replies === 'function' ? replies(call) : replies[index++];
+      if (reply instanceof Error) return { ok: false, error: reply };
+      return { ok: true, value: reply as T };
+    },
+  } as unknown as RedisManager;
+  return { redis, calls };
+};
+
+const makeStore = (redis: RedisManager, logger?: pino.Logger) =>
+  createRedisTypingStore({ redis, instanceId: 'alpha', ttlMs: 3_000, logger });
+
+describe('redis typing store', () => {
+  it('keys a claim by room and user, and names this instance as the holder', async () => {
+    const { redis, calls } = makeRedis([1]);
+    const store = makeStore(redis);
+
+    expect(await store.claim('room-1', 'user-1')).toEqual({ ok: true, value: undefined });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].command).toBe('EVAL');
+    const [script, numkeys, key, instanceId, ttl] = calls[0].args;
+    expect(numkeys).toBe('1');
+    expect(key).toBe(`${TYPING_KEY_PREFIX}room-1:user:user-1`);
+    expect(instanceId).toBe('alpha');
+    expect(ttl).toBe('3000');
+    expect(script).toContain('HSET');
+    expect(script).toContain('HPEXPIRE');
+    // A script is atomic but not transactional: an `HPEXPIRE` that fails on an
+    // older server would otherwise leave the `HSET` behind as a claim that
+    // never expires, and a claim that never expires suppresses every later
+    // retraction for that room member.
+    expect(script).toContain('redis.pcall');
+    expect(script).toContain('HDEL');
+  });
+
+  it('separates one room member from another', async () => {
+    expect(typingKey('room-1', 'user-1')).not.toBe(typingKey('room-1', 'user-2'));
+    expect(typingKey('room-1', 'user-1')).not.toBe(typingKey('room-2', 'user-1'));
+  });
+
+  it('stores no count in the field, only that the claim exists', async () => {
+    const { redis, calls } = makeRedis([1]);
+    await makeStore(redis).claim('room-1', 'user-1');
+
+    // Anything else would need decrement semantics that can drift out of step
+    // with the local socket set; see the comment on `TypingStore`.
+    expect(calls[0].args[0]).toContain("'1'");
+    expect(calls[0].args).toHaveLength(5);
+  });
+
+  it('drops the claim and reports how many instances are left', async () => {
+    const { redis, calls } = makeRedis([1]);
+    const store = makeStore(redis);
+
+    expect(await store.release('room-1', 'user-1')).toEqual({ ok: true, value: 1 });
+    expect(calls[0].command).toBe('EVAL');
+    expect(calls[0].args[2]).toBe(typingKey('room-1', 'user-1'));
+    expect(calls[0].args[3]).toBe('alpha');
+    expect(calls[0].args[0]).toContain('HDEL');
+    expect(calls[0].args[0]).toContain('HLEN');
+  });
+
+  it('reports nobody left once the last instance releases', async () => {
+    const { redis } = makeRedis([0]);
+    expect(await makeStore(redis).release('room-1', 'user-1')).toEqual({ ok: true, value: 0 });
+  });
+
+  it('reads a non-numeric reply as nobody left rather than as a holder', async () => {
+    const { redis } = makeRedis([null]);
+    expect(await makeStore(redis).release('room-1', 'user-1')).toEqual({ ok: true, value: 0 });
+  });
+
+  it('reports a failed command rather than inventing a holder count', async () => {
+    const { redis } = makeRedis(() => new Error('ERR unknown command HPEXPIRE'));
+    const result = await makeStore(redis).release('room-1', 'user-1');
+
+    // `socketServer.ts` retracts on `!ok`, so a store that answered `1` here
+    // would strand the indicator instead of degrading to single-node behaviour.
+    expect(result.ok).toBe(false);
+  });
+
+  it('names the Redis version requirement once, not once per keystroke', async () => {
+    const lines: string[] = [];
+    const logger = pino(
+      { level: 'warn' },
+      { write: (line: string) => lines.push(line) } as pino.DestinationStream,
+    );
+    const { redis } = makeRedis(() => new Error('ERR unknown command HPEXPIRE'));
+    const store = makeStore(redis, logger);
+
+    await store.claim('room-1', 'user-1');
+    await store.claim('room-1', 'user-1');
+    await store.release('room-1', 'user-2');
+
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain('7.4');
+  });
+
+  it('refuses to send a non-finite TTL to Redis', async () => {
+    const { redis, calls } = makeRedis([1]);
+    const store = createRedisTypingStore({
+      redis,
+      instanceId: 'alpha',
+      ttlMs: Number.NaN,
+    });
+
+    await store.claim('room-1', 'user-1');
+    expect(calls[0].args[4]).toBe('3000');
+  });
+});

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -184,14 +184,19 @@ than over the socket. Closing that is #476. The per-user session limit and
 global rate limits also remain per-instance, so a replica count above one is not
 yet a supported deployment.
 
-Two more gaps have to close before it becomes one, both from pub/sub keeping no
+One more gap has to close before it becomes one, from pub/sub keeping no
 backlog. A membership revocation (`socketsLeave`) lost while an instance's
 subscriber is down leaves that member's socket in the room, still receiving what
 is published there afterwards — a Sync Cursor cannot repair it, because the
 problem is a stale subscription rather than a missed event; it needs a durable
-path or a reconciliation against the database on reconnect (#477). And typing
-claims are aggregated per process, so the same user typing from two instances
-has the indication retracted by whichever node's last claim ends first (#474).
+path or a reconciliation against the database on reconnect (#477).
+
+Typing is no longer one of them. `realtime/typingStore.ts` holds a claim per
+instance under `typing:room:{roomId}:user:{userId}`, so the retraction is sent
+only once no instance claims the room member any more, and a crashed instance's
+claim expires with its `TYPING_TTL_MS` field TTL rather than suppressing every
+later retraction. Without `REDIS_URL` the store is not built at all and typing
+stays exactly as single-node as it was.
 
 ### Production Ingress & Proxy Trust
 

--- a/docs/ZH-TW/DEVELOPMENT.md
+++ b/docs/ZH-TW/DEVELOPMENT.md
@@ -165,13 +165,18 @@ socket 上。
 與全域限流同樣仍是 per-instance，所以把 replica 數量調到大於 1 目前還不是受支
 援的部署方式。
 
-要讓它成為受支援的部署方式，還有兩個源自「pub/sub 不保留 backlog」的缺口必須
-先補上。其一：成員資格撤銷（`socketsLeave`）若在某個 instance 的 subscriber 斷
-線期間送出就會永久遺失，該成員的 socket 仍留在房間裡，之後房間發布的內容都收
-得到——Sync Cursor 無法修復，因為問題是過期的訂閱而非漏收的事件；需要 durable
-傳輸，或在重連後依資料庫重新校正（#477）。其二：typing claim 以行程為單位彙
-總，同一使用者從兩個 instance 輸入時，任一節點最後一個 claim 結束就會撤回整體
-的輸入提示（#474）。
+要讓它成為受支援的部署方式，還有一個源自「pub/sub 不保留 backlog」的缺口必須
+先補上：成員資格撤銷（`socketsLeave`）若在某個 instance 的 subscriber 斷線期間
+送出就會永久遺失，該成員的 socket 仍留在房間裡，之後房間發布的內容都收得到
+——Sync Cursor 無法修復，因為問題是過期的訂閱而非漏收的事件；需要 durable 傳
+輸，或在重連後依資料庫重新校正（#477）。
+
+typing 已不在其列。`realtime/typingStore.ts` 以
+`typing:room:{roomId}:user:{userId}` 為 key，替每個 instance 各存一筆 claim，
+因此只有在整個 cluster 都不再持有該房間成員的 claim 時才會送出撤回；某個
+instance 崩潰後留下的 claim 也會隨 `TYPING_TTL_MS` 的 field TTL 過期，不會從此
+壓住之後所有的撤回。未設定 `REDIS_URL` 時完全不會建立這個 store，typing 維持
+與過去相同的單節點行為。
 
 ### 正式環境入口拓撲與代理信任
 


### PR DESCRIPTION
## 變更描述 (Description)

自 #646（PR，commit `105b6d7`）安裝 Socket.IO cluster adapter 後，`user_typing` 已經會跨 instance 送達；但決定「何時撤回」的彙總仍停在行程邊界。`socketServer.ts:38` 的 `typingRooms` 是行程內的 `Map`，`removeTypingSocket`（`:56-64`）只判斷「該使用者在**本行程**的最後一個 socket」，而它所把關的 `emitTyping(roomId, false)`（`:135-137`）走的是 `socket.to(...)`——現在整個 cluster 都收得到。

結果是：同一使用者從兩個 instance 輸入時，任一節點最後一個 claim 結束就會向全 cluster 撤回輸入提示，另一節點仍在刷新的狀態被提前撤掉。這個缺口原本就寫在 `redisAdapter.ts` 的 at-most-once 說明裡，明文標記為「#474 的剩餘驗收標準，本 adapter 只是解除阻塞而非解決」。

### 做法

新增 `backend/src/realtime/typingStore.ts`：以 `typing:room:{roomId}:user:{userId}` 為 key，每個 instance 各存一個帶 field TTL 的 claim（HPEXPIRE，Redis 7.4+），只有在整個 cluster 都不再持有 claim 時才送出撤回。沿用 #472 的 `RedisManager`，未引入第二套 Redis stack；結構與 `presenceStore.ts` 對齊。

**field 不存計數，只存「claim 是否存在」**。本機那層已經把同一使用者在同一 instance 的多個 socket 收斂成單一 claim，改存計數只會多出一組 decrement 語意，並可能與本機 socket 集合失去同步，留下一個永遠到不了 0 的 field；存在與否則會在下一次寫入自我修正。

### 為什麼是 reconciler，而不是 claim/release 配對

這是本 PR 最需要 review 的一點。`typingRooms` 是在 round trip **之前**就被改動的，因此一個在飛行途中抵達的 keystroke 可以反轉答案：

1. socket 送 `false` → `removeTypingSocket` 回傳 true → `release` 在飛行中
2. 使用者又打字 → `addTypingSocket` → `claim` 在飛行中
3. 兩個 EVAL 抵達 Redis 的順序不保證。若 HDEL 後到，它會刪掉 HSET 剛寫進去的 field

此時本機持有 live claim，Redis 卻一無所知——另一個 instance 的 release 會看到 HLEN 0 而向全 cluster 撤回。generation counter 修不了這個：它能擋掉過期的 emit，但擋不掉 Redis 裡已經寫錯的值。

因此改為 `syncTyping(roomId, userId)`：**在寫入抵達 Redis 的那一刻才讀取本機狀態**，並以 (roomId, userId) 為單位序列化。佇列尾巴的形狀直接沿用 `utils/redis.ts:221-233` 的 `onChannel`（含自刪除，避免每個曾經打字過的 room member 各留一筆）。排在後面的 sync 會把被競態刪掉的 field 補回來——這正是 claim/release 配對補不起來的洞。

另外，尚未開始執行的 sync 會被後續呼叫直接沿用而不另外排隊：它讀到的狀態與新呼叫會讀到的完全相同，因此一連串 keystroke 會收斂成「每個 round trip 一次寫入」，而不是每個 keystroke 一次。

### 刻意的取捨

- **refresh 不 await。** `true` 的心跳陳述的是本機事實，cluster 的計數不會改變它；而 `RedisManager.command` 本身沒有逾時（`redis.ts:517-529` 只是 await `connection.send`），一個「連得上但很慢」的 Redis 會把每一次 keystroke 都卡住。順序問題交給佇列處理。
- **對驗收標準第 3 條的輕微削弱，此處明說。** 目前 `false` 一定立刻送出；改動後只在 cluster 計數歸零時送出。若某個 instance 崩潰而留下 field，撤回會被壓抑最多一個 `TYPING_TTL_MS`，此時由 client 自己的 3 秒計時器兜底。這也是 field TTL 必須**恰好等於** `TYPING_TTL_MS`、不可放長的原因。
- **遠端 field 因 TTL 過期時沒有人送 `false`。** 可接受：該 instance 同時也已停止送 `true`，client 在最後一次心跳後 3 秒清除提示（`ChatContext.tsx:1756-1777`），與現況同一個上界。不另外加 sweeper。
- **未設定 `REDIS_URL` 時完全不建立 store**，`releaseClaim` 在沒有 store 時同步走原路徑，單節點行為逐字不變。

### 評估後未採用的替代方案

- `socket.to(room).local.emit(...)`：機制上可行，但常見情況是「一位輸入者在一個 instance，觀察者散布在各 instance」。只送本機等於讓多數觀察者要等滿 3 秒，為了修 AC1 而破壞多數情況的 AC3，比現況更糟。
- 「對本機仍持有 claim 的使用者忽略撤回」：修不到重點。需要壓抑的不是持有 claim 的節點，而是任意第三個節點；且必須把 `user_typing` 的事件名與 payload 形狀塞進 transport adapter，違反 `redisAdapter.ts` 的分層。
- 「裝上 cluster adapter 後乾脆不送 `false`」：零程式碼即可滿足 AC1／AC2，但 AC3 失守。列此對照可以看清這個 store 買到的是什麼——**同時做到即時且 cluster 正確的撤回**。

## 相關的 Issue (Related Issue)

Closes #474

## 變更類型 (Type of Change)

- [x] `feat`: 新增功能 (Feature)
- [x] `fix`: 修復 Bug
- [x] `test`: 新增或修正測試案例
- [x] `docs`: 修改文件

## 驗證與測試計畫 (Verification & Test Plan)

本次執行環境沒有 Docker daemon，因此以本機 toolchain（bun 1.3.11）直接執行，指令與 CONTRIBUTING §5 的容器版等價。

- [x] 後端型別檢查與 lint —— `pnpm run lint`（= `eslint src && tsc --noEmit`）exit 0
- [x] 前端型別檢查 —— `pnpm exec tsc --noEmit` exit 0（本 PR 未改動 frontend）
- [x] 單元測試 —— `bun test tests/unit`：**759 pass / 0 fail**（改動前於同一環境為 743 pass，本 PR 新增 16 個案例）
- [ ] 整合測試 —— **需 reviewer 於 CI 或本機 Docker 執行**，原因見下

### 迴歸證明 (Regression proof)

新測試先在未修補的 `socketServer.ts` 上重現缺陷，再確認修好：

```
$ git stash push backend/src/realtime/socketServer.ts
$ bun test tests/unit/realtime/socketServer.test.ts -t "cross-instance"
 3 pass / 4 fail
```

失敗的包含兩個關鍵案例：`stays silent while another instance still claims the same room member`（未修補時仍會撤回）與 `suppresses a retraction overtaken by a keystroke, and re-claims`。套用本 PR 後 7 個全數通過。

### 整合測試為何無法在此環境執行

`typingStore.int.test.ts` 需要 **Redis 7.4+** 的 hash-field TTL（`HPEXPIRE`）。本環境只有 Redis 7.0.15，沒有該指令；CI 的 `ci-database.yml` 提供 `redis:8-alpine` 並設定 `REDIS_URL_TEST`，因此**該檔會在 CI 上實際執行**。

不過本次仍在真實 Redis 7.0 上驗證了兩件不需要 7.4 的事：

- `CLAIM_SCRIPT` 在缺少 `HPEXPIRE` 的伺服器上會**正確回滾**：`claim.ok === false`，且 `HLEN` 為 0——沒有留下永不過期的 claim（這正是 script 用 `redis.pcall` 包住的理由）。
- `RELEASE_SCRIPT` 的完整語意：第一個釋放者看到 `1`、最後一個看到 `0`、key 隨最後一個 field 消失、釋放未持有的 key 回 `0`。

以 `REDIS_URL_TEST` 指向本機 Redis 7.0 實跑該檔為 3 pass / 5 fail，5 個失敗全部且僅因伺服器版本沒有 `HPEXPIRE`，harness（連線、命名空間、`beforeEach` 清理）本身已驗證可用。

### 新增測試

`backend/tests/unit/realtime/typingStore.test.ts`（9 個，protocol 層，沿用 `presenceStore.test.ts` 的 `makeRedis` 記錄器）—— key 組成、instance field、TTL 參數、回滾守衛、非數值回覆、失敗不偽造計數、警告只發一次、非有限 TTL 不外送。

`backend/tests/unit/realtime/socketServer.test.ts`（7 個，新 describe）—— 心跳不等待 round trip；計數歸零才撤回；他節點仍持有時保持沉默；**被 keystroke 追上的撤回會被壓抑並重新 claim**（reconciler 的核心案例，以可手動解析的 deferred release 製造飛行視窗）；Redis 失敗時照常撤回；斷線仍會撤回；未曾 claim 的房間不打擾 store。

`backend/tests/integration/realtime/typingStore.int.test.ts`（8 個）—— 兩個 instance 的 claim 並存、只有最後一個釋放者看到 0、同 instance 重複 claim 只是 refresh、最後一個 claim 交回後 key 消失、未刷新的 claim 會自行過期、一個 instance 的 claim 過期不影響另一個、持續 refresh 可撐過 TTL、同一使用者的不同房間互不干擾。

穩定性：`bun test tests/unit/realtime` 連跑 3 次皆 92 pass / 0 fail。

### 手動測試 (Manual Verification)

未進行；本環境無法啟動 Docker stack。行為改動全部以上述自動化測試涵蓋。

## 資料庫變更 (Database Changes)

* 此變更是否包含資料庫 Schema 修改？ **否**

## API 與 WebSocket 協定一致性 (API & WebSocket Contract Check)

* 此變更是否涉及 API 路由或 WebSocket 事件的資料結構變更？ **否**
* 是否已確認與 [docs/api-documentation.md](../docs/api-documentation.md) 規範完全一致？ **是** —— `typing` 與 `user_typing` 的 payload 皆未更動（`docs/api-documentation.md:1586`），滿足驗收標準第 4 條。改變的只有 `false` 的送出**時機**：從「本行程最後一個 claim 結束」改為「整個 cluster 最後一個 claim 結束」。

### 文件同步

`docs/DEVELOPMENT.md` 與 `docs/ZH-TW/DEVELOPMENT.md` 原本把 typing 列為「replica > 1 之前必須補上的兩個缺口」之一，已改為只剩 #477 一項，並說明新的 store；`redisAdapter.ts` 內對應的 at-most-once 註解一併更新；`backend/CLAUDE.md` 的 key files 表補上 `typingStore.ts`。

## Review 重點

1. `syncTyping` 的佇列與 `self` 識別（`socketServer.ts`）—— 這是整個 PR 的正確性核心。
2. `releaseClaim` 的 `speak` 參數刻意是**布林值而非 callback**：在丟掉 claim 的當下就求值，與原本 `!disconnected` 的求值時機一致，避免飛行途中的斷線把一個本來該送出的撤回吞掉。
3. `stopTyping`（斷線時仍送出）與 TTL 計時器（`!disconnected` 才送）之間的不對稱是刻意保留的既有行為。

### 已知且未在本 PR 處理

- 前端每次 `onChange` 都送 `typing`，完全沒有節流。真要降低寫入量應該從來源處理，且不涉及協定變更——屬於另一個 PR。
- 既有競態：同一房間第一次的 `true` 與 `false` 可能同時 await `findMember`，若 `false` 先解析則變成 no-op，狀態會卡住一個 TTL。此問題在 `main` 上即已存在，修它需要把整段 handler 尾巴放進佇列，等於在 `true` 的送出前面插一個 Redis RTT。建議另開 issue。
- replica > 1 仍非受支援的部署方式：`#477` 的成員資格撤銷收斂缺口尚在。

---

Generated with Claude Code (https://claude.com/claude-code)

https://claude.ai/code/session_01MDH2WxXQ23aBVGF2KYbRhF

---
_Generated by [Claude Code](https://claude.ai/code/session_01MDH2WxXQ23aBVGF2KYbRhF)_