### PR TITLE
docs: MyProfile 結構中缺失 lastActivity 欄位 (week of 2026-09-06)

### DIFF
--- a/docs/ZH-TW/api-documentation.md
+++ b/docs/ZH-TW/api-documentation.md
@@ -175,6 +175,7 @@ NEXT_PUBLIC_API_URL=http://localhost:4005
   | `email` | 字串 | 電子郵件信箱 |
   | `bio` | 字串 \| null | 個人簡介 |
   | `avatarUrl` | 字串 \| null | 使用者頭像網址 |
+  | `lastActivity` | ISO 8601 | 使用者在任何端點上最後一次活動的時間戳 |
   | `isAdmin` | 布林值 | 目前登入者是否可顯示管理員導覽；受保護的管理員路由仍會重新驗證權限 |
 - **範例**:
   ```json
@@ -184,6 +185,7 @@ NEXT_PUBLIC_API_URL=http://localhost:4005
     "email": "alex@example.com",
     "bio": "Hello, this is my bio.",
     "avatarUrl": "https://example.com/avatar.png",
+    "lastActivity": "2026-09-06T12:34:56.000Z",
     "isAdmin": false
   }
   ```

--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -176,6 +176,7 @@ All errors return the following JSON structure:
   | `email` | String | Email address |
   | `bio` | String \| null | Biography |
   | `avatarUrl` | String \| null | User avatar URL |
+  | `lastActivity` | ISO 8601 | Timestamp of the user's most recent activity on any endpoint |
   | `isAdmin` | Boolean | Whether the current user may display admin navigation; protected admin routes still re-check authorization |
 - **Example**:
   ```json
@@ -185,6 +186,7 @@ All errors return the following JSON structure:
     "email": "alex@example.com",
     "bio": "Hello, this is my bio.",
     "avatarUrl": "https://example.com/avatar.png",
+    "lastActivity": "2026-09-06T12:34:56.000Z",
     "isAdmin": false
   }
   ```


### PR DESCRIPTION
## 摘要

掃描過去 7 天內合併的 PR，發現 API 文件與實際程式碼之間的差異。`MyProfile` 型別在 `shared/types.ts` 中包含 `lastActivity: Date` 欄位，但在 API 文件中未有記載。

## 掃描範圍

過去 7 天內合併的 PR：

| 編號 | 標題 | 主要變更 |
|------|------|---------|
| #647 | fix(realtime): deliver user_status to friends on every instance | 更新 user_status 事件文件，已在 PR 中更新文件 |
| #646 | feat(realtime): carry realtime events across instances over Redis | 新增 REALTIME_CLUSTER_ID 環境變數，已在 DEVELOPMENT.md 中文件化 |
| #635 | feat(frontend): add admin monitoring page | 新增 isAdmin 欄位和管理員端點，已在 API 文件中文件化 |
| #641 | refactor(frontend): decompose ChatContext and extract modular UI components | 前端重構，無 API 變更 |
| #643 | ci(workflows): optimize ci/cd pipelines with github actions features | CI/CD 最佳化，無 API 變更 |
| #637 | chore(deps): bump the minor-and-patch group across 1 directory with 6 updates | 依賴版本更新，無 API 變更 |
| #645 | refactor(comments): simplify and clarify codebase and workflow comments | 程式碼註解重構，無 API 變更 |
| #640 | fix(realtime): aggregate typing state per room member | 即時打字狀態修複，無 API 變更 |

## 文件變更

| 檔案 | 變更內容 | 驅動 PR |
|------|---------|--------|
| docs/api-documentation.md | 在 MyProfile 結構中新增 `lastActivity` 欄位文件 | 程式碼與文件不一致 |
| docs/ZH-TW/api-documentation.md | 在 MyProfile 結構中新增 `lastActivity` 欄位文件 | 程式碼與文件不一致 |

## 未自動編輯的參考文獻

無

---
Generated with Claude Code (https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UHfvBVuXzejmrq7CRPnkbT)_