### PR TITLE
test(realtime): add dual-instance integration harness with subscriber fault injection (#650)

### DIFF
--- a/backend/tests/helpers/clusterHarness.ts
+++ b/backend/tests/helpers/clusterHarness.ts
@@ -1,0 +1,415 @@
+import path from 'path';
+import { RedisClient } from 'bun';
+import { realtimeChannel } from '../../src/realtime/redisAdapter';
+
+/**
+ * Two real backend instances, one Redis, one PostgreSQL — and a tap on the
+ * Redis link of exactly one of them.
+ *
+ * Why processes rather than two `Server`s in this one. `realtime/presence.ts`
+ * keeps its tracker in a module-level `current`, and `bootstrap/presence.ts`
+ * replaces it through `configurePresence`, stopping whatever was there before.
+ * A second in-process "instance" would therefore not get a presence tracker of
+ * its own, it would take the first one's away. `bootstrap/realtime.ts` does not
+ * pass `presence` into `attachSockets` either, so the socket layer reads that
+ * same singleton. Only separate processes give each instance its own.
+ *
+ * Why a TCP proxy rather than restarting Redis. Cutting Redis itself cuts it
+ * for everyone, which is not the failure the adapter documents — that one is a
+ * single instance losing its subscriber while another keeps publishing. It
+ * would also need Docker control from inside the test, which neither CI
+ * (`.github/workflows/ci-database.yml` mounts no Docker socket) nor the dev
+ * container guarantees. A proxy in front of one instance is precise, needs no
+ * privileges, and is deterministic about when the link is down.
+ */
+
+const backendRoot = path.resolve(__dirname, '../..');
+
+/** Poll until `check` passes, then return; throw `describe()` on timeout. */
+const until = async (
+  check: () => boolean | Promise<boolean>,
+  describe: () => string,
+  timeoutMs: number,
+  intervalMs = 50,
+): Promise<void> => {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    if (await check()) return;
+    if (Date.now() >= deadline) throw new Error(`Timed out after ${timeoutMs}ms: ${describe()}`);
+    await Bun.sleep(intervalMs);
+  }
+};
+
+/**
+ * A free localhost port.
+ *
+ * Bound and released rather than picked from a fixed range, so two runs on one
+ * machine — a developer's and CI's, or two shards — cannot collide on a
+ * hardcoded number. The child binds a moment later; the kernel does not hand
+ * the same ephemeral port out twice in that window unless something else asks
+ * for that exact port.
+ */
+const reservePort = (): number => {
+  const probe = Bun.listen({ hostname: '127.0.0.1', port: 0, socket: { data() {} } });
+  const { port } = probe;
+  probe.stop(true);
+  return port;
+};
+
+type ProxyClient = import('bun').Socket<ProxyClientContext>;
+type ProxyUpstream = import('bun').Socket<ProxyUpstreamContext>;
+
+interface ProxyClientContext {
+  upstream?: ProxyUpstream;
+  /** Frames written before the upstream socket finished connecting. */
+  pending: Uint8Array[];
+  closed: boolean;
+}
+
+interface ProxyUpstreamContext {
+  client: ProxyClient;
+}
+
+export interface RedisProxy {
+  /** What the proxied instance should use as its `REDIS_URL`. */
+  readonly url: string;
+  /** Drop every live connection and refuse new ones until `heal()`. */
+  cut(): void;
+  /** Accept connections again. */
+  heal(): void;
+  stop(): void;
+}
+
+/** A TCP proxy in front of Redis whose link can be severed on demand. */
+export const startRedisProxy = ({ target }: { target: string }): RedisProxy => {
+  const upstream = new URL(target);
+  const upstreamPort = Number(upstream.port || 6379);
+  const live = new Set<ProxyClient>();
+  let severed = false;
+
+  const listener = Bun.listen<ProxyClientContext>({
+    hostname: '127.0.0.1',
+    port: 0,
+    socket: {
+      open(client) {
+        client.data = { pending: [], closed: false };
+        if (severed) {
+          // `terminate` rather than `end`: a FIN would let the client believe
+          // the link was closed politely, where the outage being modelled is
+          // the link going away underneath it.
+          client.terminate();
+          return;
+        }
+        live.add(client);
+        void Bun.connect<ProxyUpstreamContext>({
+          hostname: upstream.hostname,
+          port: upstreamPort,
+          // Supplied up front so the upstream handlers always have their client,
+          // including for a frame that lands before `connect` resolves.
+          data: { client },
+          socket: {
+            data(socket, chunk) {
+              socket.data.client.write(chunk);
+            },
+            close(socket) {
+              socket.data.client.end();
+            },
+            error(socket) {
+              socket.data.client.end();
+            },
+          },
+        })
+          .then((connection) => {
+            if (client.data.closed) {
+              connection.end();
+              return;
+            }
+            client.data.upstream = connection;
+            for (const chunk of client.data.pending) connection.write(chunk);
+            client.data.pending = [];
+          })
+          .catch(() => client.terminate());
+      },
+      data(client, chunk) {
+        const connection = client.data.upstream;
+        // A Redis client sends its first command immediately on connect, which
+        // can be before the upstream socket exists. Buffered, not dropped.
+        if (connection) connection.write(chunk);
+        else client.data.pending.push(new Uint8Array(chunk));
+      },
+      close(client) {
+        client.data.closed = true;
+        client.data.upstream?.end();
+        live.delete(client);
+      },
+      error(client) {
+        client.data.closed = true;
+        client.data.upstream?.end();
+        live.delete(client);
+      },
+    },
+  });
+
+  return {
+    url: `redis://127.0.0.1:${listener.port}`,
+    cut() {
+      severed = true;
+      for (const client of live) client.terminate();
+      live.clear();
+    },
+    heal() {
+      severed = false;
+    },
+    stop() {
+      severed = true;
+      for (const client of live) client.terminate();
+      live.clear();
+      listener.stop(true);
+    },
+  };
+};
+
+export interface ClusterInstance {
+  readonly instanceId: string;
+  readonly port: number;
+  /** Base URL for REST calls and Socket.IO clients. */
+  readonly url: string;
+  /** Everything the process has written, for diagnosing a failure. */
+  output(): string;
+  stop(): Promise<void>;
+}
+
+interface StartInstanceOptions {
+  instanceId: string;
+  redisUrl: string;
+  databaseUrl: string;
+  jwtSecret: string;
+  clusterId: string;
+}
+
+const startInstance = async ({
+  instanceId,
+  redisUrl,
+  databaseUrl,
+  jwtSecret,
+  clusterId,
+}: StartInstanceOptions): Promise<ClusterInstance> => {
+  const port = reservePort();
+  const child = Bun.spawn(['bun', 'src/index.ts'], {
+    cwd: backendRoot,
+    env: {
+      ...process.env,
+      NODE_ENV: 'test',
+      DATABASE_URL_TEST: databaseUrl,
+      // `config/env.ts` reads `REDIS_URL` and never `REDIS_URL_TEST`, so an
+      // instance handed only the latter would silently come up with no cluster
+      // adapter and no presence store — and every cross-instance assertion here
+      // would pass by never having been cross-instance at all.
+      REDIS_URL: redisUrl,
+      REALTIME_CLUSTER_ID: clusterId,
+      JWT_SECRET: jwtSecret,
+      PORT: String(port),
+      INSTANCE_ID: instanceId,
+      // `NODE_ENV=test` would otherwise silence the process entirely; the
+      // output is buffered and only surfaced when a wait fails.
+      LOG_LEVEL: 'info',
+    },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+
+  // Drained continuously rather than read at the end: a full pipe buffer would
+  // block the child mid-write, which looks exactly like a hung instance.
+  let output = '';
+  const drain = async (stream: ReadableStream<Uint8Array>): Promise<void> => {
+    const decoder = new TextDecoder();
+    for await (const chunk of stream) output += decoder.decode(chunk, { stream: true });
+  };
+  void drain(child.stdout).catch(() => {});
+  void drain(child.stderr).catch(() => {});
+
+  const url = `http://127.0.0.1:${port}`;
+  const instance: ClusterInstance = {
+    instanceId,
+    port,
+    url,
+    output: () => output,
+    async stop() {
+      // Bounded, and always awaited to the end: a child left alive keeps a
+      // connection pool on the shared test database, and `index.ts` gives
+      // itself a 20s shutdown deadline this must not sit through.
+      child.kill('SIGTERM');
+      const exit = await Promise.race([child.exited, Bun.sleep(10_000).then(() => 'timeout' as const)]);
+      if (exit === 'timeout') {
+        child.kill('SIGKILL');
+        await child.exited;
+      }
+    },
+  };
+
+  try {
+    await until(
+      async () => {
+        // `exitCode`, not `killed`: a child that died on its own — a port taken
+        // between reservation and bind is the realistic one — was never killed,
+        // and would otherwise be waited out for the full timeout.
+        if (child.exitCode !== null) {
+          throw new Error(`${instanceId} exited (code ${child.exitCode}) during startup:\n${output}`);
+        }
+        try {
+          const response = await fetch(`${url}/api/v1/health`);
+          return response.ok;
+        } catch {
+          return false;
+        }
+      },
+      () => `${instanceId} never became healthy on ${url}:\n${output}`,
+      30_000,
+    );
+  } catch (error) {
+    await instance.stop();
+    throw error;
+  }
+
+  return instance;
+};
+
+export interface ApiCallOptions {
+  token?: string;
+  body?: unknown;
+  headers?: Record<string, string>;
+}
+
+/**
+ * One JSON call against an instance's REST API.
+ *
+ * `tests/helpers/http.ts` drives a Hono app object in this process, which a
+ * child cannot be reached through; these instances are only addressable over
+ * a real socket.
+ */
+export const call = async <T>(
+  instance: ClusterInstance,
+  method: string,
+  path: string,
+  options: ApiCallOptions = {},
+): Promise<{ status: number; body: T }> => {
+  const headers: Record<string, string> = { ...options.headers };
+  if (options.body !== undefined) headers['Content-Type'] = 'application/json';
+  if (options.token) headers.Authorization = `Bearer ${options.token}`;
+
+  const response = await fetch(`${instance.url}${path}`, {
+    method,
+    headers,
+    body: options.body === undefined ? undefined : JSON.stringify(options.body),
+  });
+  const text = await response.text();
+  return {
+    status: response.status,
+    body: (text ? JSON.parse(text) : undefined) as T,
+  };
+};
+
+export interface Cluster {
+  /** Reaches Redis directly; the instance that keeps publishing. */
+  readonly alpha: ClusterInstance;
+  /** Reaches Redis through `proxy`; the instance whose link gets cut. */
+  readonly beta: ClusterInstance;
+  readonly proxy: RedisProxy;
+  /** This run's cluster channel, isolated from any other run on the same Redis. */
+  readonly channel: string;
+  /** How many subscribers this run's channel currently has. */
+  subscriberCount(): Promise<number>;
+  /** Wait until the channel has exactly `expected` subscribers. */
+  waitForSubscribers(expected: number, timeoutMs?: number): Promise<void>;
+  stop(): Promise<void>;
+}
+
+export interface StartClusterOptions {
+  /** Defaults to `REDIS_URL_TEST`, then the dev compose host mapping. */
+  redisUrl?: string;
+  /** Defaults to `DATABASE_URL_TEST`. */
+  databaseUrl?: string;
+}
+
+/**
+ * Bring up both instances and wait until each has actually subscribed.
+ *
+ * `/api/v1/health` answering is not that moment: `index.ts` does not await
+ * `redis.connect()` before it serves, so the adapter's first `SUBSCRIBE` can
+ * fail and be replayed by the watchdog a moment later. Gating on the health
+ * endpoint alone would race the very subscription every assertion here depends
+ * on. `PUBSUB NUMSUB` on this run's own channel is the fact itself, read from
+ * the Redis both instances are talking to.
+ */
+export const startCluster = async (options: StartClusterOptions = {}): Promise<Cluster> => {
+  const redisUrl = options.redisUrl || process.env.REDIS_URL_TEST || 'redis://localhost:6385';
+  const databaseUrl = options.databaseUrl || process.env.DATABASE_URL_TEST;
+  if (!databaseUrl) {
+    throw new Error('DATABASE_URL_TEST is not set — copy .env.test.example to .env.test');
+  }
+
+  const run = `it-${Math.random().toString(36).slice(2, 10)}`;
+  const channel = realtimeChannel(run);
+  const jwtSecret = `${run}-secret`;
+
+  const observer = new RedisClient(redisUrl);
+  await observer.connect();
+  const subscriberCount = async (): Promise<number> => {
+    const reply = (await observer.send('PUBSUB', ['NUMSUB', channel])) as [string, number | string];
+    return Number(reply[1]);
+  };
+
+  const proxy = startRedisProxy({ target: redisUrl });
+  let alpha: ClusterInstance | undefined;
+  let beta: ClusterInstance | undefined;
+
+  const stop = async (): Promise<void> => {
+    await Promise.all([alpha?.stop(), beta?.stop()]);
+    proxy.stop();
+    observer.close();
+  };
+
+  try {
+    alpha = await startInstance({
+      instanceId: `${run}-alpha`,
+      redisUrl,
+      databaseUrl,
+      jwtSecret,
+      clusterId: run,
+    });
+    beta = await startInstance({
+      instanceId: `${run}-beta`,
+      redisUrl: proxy.url,
+      databaseUrl,
+      jwtSecret,
+      clusterId: run,
+    });
+
+    let seen = 0;
+    await until(
+      async () => (seen = await subscriberCount()) === 2,
+      () =>
+        `both instances to subscribe to ${channel}; last saw ${seen}\n` +
+        `alpha:\n${alpha?.output()}\nbeta:\n${beta?.output()}`,
+      30_000,
+    );
+  } catch (error) {
+    await stop();
+    throw error;
+  }
+
+  return {
+    alpha,
+    beta,
+    proxy,
+    channel,
+    subscriberCount,
+    waitForSubscribers: (expected, timeoutMs = 30_000) =>
+      until(
+        async () => (await subscriberCount()) === expected,
+        () => `${channel} to have ${expected} subscriber(s)`,
+        timeoutMs,
+      ),
+    stop,
+  };
+};

--- a/backend/tests/integration/realtime/clusterInstances.int.test.ts
+++ b/backend/tests/integration/realtime/clusterInstances.int.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
+import { io as createClient, type Socket as ClientSocket } from 'socket.io-client';
+import { startCluster, call, type Cluster } from '../../helpers/clusterHarness';
+import { testPool } from '../../helpers/testPool';
+import type {
+  ClientToServerEvents,
+  ServerToClientEvents,
+  MessageWithSender,
+  FriendRequestEvent,
+} from '../../../../shared/types';
+import type { AuthResponse, RoomResponse, MessageResponse } from '../../helpers/responseTypes';
+
+/**
+ * Two backend instances, and the one thing neither existing tier can claim.
+ *
+ * `realtime/redisAdapter.int.test.ts` already proves a frame survives a real
+ * `PUBLISH`/`SUBSCRIBE` between two `RedisManager`s — but it constructs bare
+ * `Server`s and seats stand-in sockets straight into `nsp.sockets`, so nothing
+ * between a REST call and a delivered frame is exercised. `tests/e2e` is the
+ * opposite trade: the whole stack, but imported as `src/index`'s module
+ * singleton, so there can only ever be one instance in it.
+ *
+ * What is under test here is the seam those two leave uncovered: a real HTTP
+ * request to instance A goes through the real service and publisher, crosses
+ * the cluster adapter, and arrives at a websocket client holding a session on
+ * instance B — with both instances assembled by `bootstrap/*` under the
+ * `require.main === module` gate, as a deployment assembles them.
+ *
+ * Instance B reaches Redis through a proxy the harness can sever, which is the
+ * only way to reproduce what `redisAdapter.ts` documents: one instance losing
+ * its subscriber while another keeps publishing. Redis pub/sub has no backlog,
+ * so a frame published into that gap is gone for good; the contract being
+ * pinned is that the subscription comes back, not that the frame does.
+ */
+
+type TestClient = ClientSocket<ServerToClientEvents, ClientToServerEvents>;
+
+/** Resolve on the next `event`, or reject once `timeoutMs` passes. */
+const nextEvent = <K extends keyof ServerToClientEvents>(
+  socket: TestClient,
+  event: K,
+  timeoutMs = 15_000,
+): Promise<Parameters<ServerToClientEvents[K]>[0]> =>
+  new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      socket.off(event, handler as never);
+      reject(new Error(`Timed out after ${timeoutMs}ms waiting for "${String(event)}"`));
+    }, timeoutMs);
+    const handler = (payload: unknown) => {
+      clearTimeout(timer);
+      resolve(payload as Parameters<ServerToClientEvents[K]>[0]);
+    };
+    socket.once(event, handler as never);
+  });
+
+interface Watch {
+  /** Whatever arrived on the watched event, still undefined if nothing has. */
+  received(): unknown;
+  stop(): void;
+}
+
+/**
+ * Start recording `event` now.
+ *
+ * Separate from the wait on purpose: a recorder attached *after* the call that
+ * publishes has already missed a frame that was delivered promptly, so an
+ * "it never arrived" assertion written that way can only ever pass.
+ */
+const watch = <K extends keyof ServerToClientEvents>(socket: TestClient, event: K): Watch => {
+  let seen: unknown;
+  const handler = (payload: unknown) => {
+    if (seen === undefined) seen = payload;
+  };
+  socket.on(event, handler as never);
+  return {
+    received: () => seen,
+    stop: () => socket.off(event, handler as never),
+  };
+};
+
+describe('two backend instances over a real Redis', () => {
+  // Namespaced per run so a crashed previous run's rows cannot be mistaken for
+  // this one's, and so nothing here depends on `resetDb()` — truncating the
+  // shared database while two child processes hold live pools would take out
+  // whichever suite ran before this one.
+  const run = `cluster-${Math.random().toString(36).slice(2, 10)}`;
+  const email = (name: string): string => `${run}-${name}@example.com`;
+
+  let cluster: Cluster;
+  let alice: { token: string; userId: string };
+  let bob: { token: string; userId: string };
+  let roomId: string;
+  let bobOnBeta: TestClient;
+
+  const connect = (url: string, token: string): Promise<TestClient> =>
+    new Promise((resolve, reject) => {
+      const socket: TestClient = createClient(url, {
+        auth: { token },
+        forceNew: true,
+        transports: ['websocket'],
+        // A reconnect would re-run `restoreSubscriptions` on the server and
+        // silently repair the subscription state this suite severs on purpose.
+        reconnection: false,
+      });
+      socket.once('connect', () => resolve(socket));
+      socket.once('connect_error', reject);
+    });
+
+  const register = async (name: string): Promise<{ token: string; userId: string }> => {
+    const response = await call<AuthResponse>(cluster.alpha, 'POST', '/api/v1/auth/register', {
+      body: { name, email: email(name), password: 'Password123!' },
+    });
+    expect(response.status).toBe(201);
+    return { token: response.body.token, userId: response.body.user.userId };
+  };
+
+  const sendMessage = async (content: string): Promise<void> => {
+    const response = await call<MessageResponse>(
+      cluster.alpha,
+      'POST',
+      `/api/v1/rooms/${roomId}/messages`,
+      {
+        token: alice.token,
+        body: { content },
+        // Mandatory on this route; without it the call is a 400 that would look
+        // like a delivery failure.
+        headers: { 'Idempotency-Key': `${run}-${content}` },
+      },
+    );
+    expect(response.status).toBe(201);
+  };
+
+  beforeAll(async () => {
+    cluster = await startCluster();
+
+    alice = await register('alice');
+    bob = await register('bob');
+
+    const room = await call<RoomResponse>(cluster.alpha, 'POST', '/api/v1/rooms', {
+      token: alice.token,
+      // `requireApproval` defaults to false, so joining by code makes bob a
+      // full member. A pending member is filtered out of the room subscription
+      // by `socketServer.ts`, and every room assertion here would fail with no
+      // indication that membership was the reason.
+      body: { type: 'group', name: `${run}-room` },
+    });
+    expect(room.status).toBe(201);
+    roomId = room.body.roomId;
+
+    const joined = await call<RoomResponse>(cluster.alpha, 'POST', '/api/v1/rooms/join', {
+      token: bob.token,
+      body: { inviteCode: room.body.inviteCode },
+    });
+    expect(joined.status).toBe(200);
+
+    bobOnBeta = await connect(cluster.beta.url, bob.token);
+    // Not `connect`: the server derives room subscriptions from durable
+    // membership after the handshake and announces `realtime_ready` once they
+    // are in place. Publishing before that races the join.
+    await nextEvent(bobOnBeta, 'realtime_ready');
+  }, 120_000);
+
+  afterAll(async () => {
+    bobOnBeta?.disconnect();
+    await cluster?.stop();
+    // Best effort, and scoped to this run's users; the room, membership and
+    // messages follow by cascade.
+    await testPool`DELETE FROM users WHERE email LIKE ${`${run}-%`}`.catch(() => {});
+    // Two processes draining their HTTP servers and releasing presence leases
+    // does not fit in the runner's 5s hook default.
+  }, 60_000);
+
+  it('delivers a room-targeted event published on the other instance', async () => {
+    const delivered = nextEvent(bobOnBeta, 'new_message');
+
+    await sendMessage('room event crosses');
+
+    const message = (await delivered) as MessageWithSender;
+    expect(message.content).toBe('room event crosses');
+    expect(message.roomId).toBe(roomId);
+  }, 60_000);
+
+  it('delivers a user-targeted event published on the other instance', async () => {
+    const delivered = nextEvent(bobOnBeta, 'friend_request');
+
+    const request = await call(cluster.alpha, 'POST', '/api/v1/friend-requests', {
+      token: alice.token,
+      body: { targetUserId: bob.userId },
+    });
+    expect(request.status).toBe(201);
+
+    const event = (await delivered) as FriendRequestEvent;
+    expect(event.requesterId).toBe(alice.userId);
+    expect(event.addresseeId).toBe(bob.userId);
+  }, 60_000);
+
+  it('rebuilds the subscription after its Redis link is cut and restored', async () => {
+    // The subscriber count on this run's own channel is the fact itself, rather
+    // than an inference from a delivery that could have been slow.
+    expect(await cluster.subscriberCount()).toBe(2);
+
+    cluster.proxy.cut();
+    // Dropping to one is what makes the rest of this case non-vacuous: without
+    // it, a "recovered" assertion would pass on a link that never broke.
+    await cluster.waitForSubscribers(1);
+
+    // Armed before the publish, so a frame that does arrive is caught. This is
+    // also what keeps the whole suite honest: were bob's session actually on
+    // the publishing instance, this delivery would be local, unaffected by the
+    // cut, and recorded here.
+    const duringCut = watch(bobOnBeta, 'new_message');
+    await sendMessage('published into the gap');
+    // Redis pub/sub keeps no backlog, so this frame is lost rather than
+    // deferred. Pinned so that a future replay buffer has to be a deliberate
+    // contract change rather than a silent one.
+    await Bun.sleep(1_000);
+    expect(duringCut.received()).toBeUndefined();
+    duringCut.stop();
+
+    cluster.proxy.heal();
+    await cluster.waitForSubscribers(2);
+
+    const delivered = nextEvent(bobOnBeta, 'new_message');
+    await sendMessage('published after recovery');
+    const message = (await delivered) as MessageWithSender;
+    expect(message.content).toBe('published after recovery');
+  }, 120_000);
+});
+


### PR DESCRIPTION
## 變更描述 (Description)

Closes #650

建立可重用的雙 backend instance 整合測試 harness，並涵蓋 #477 的工作項目 6（room-targeted 與 user-targeted 事件跨 instance 廣播）與工作項目 7（subscriber 中斷後重新連線）。

新增兩個檔案：

- `backend/tests/helpers/clusterHarness.ts` —— harness 本體：以 `Bun.spawn` 啟動兩個真實 backend 行程，並以 `Bun.listen` → `Bun.connect` 的 TCP proxy 擋在其中一個 instance 的 Redis 連線前面，可隨時切斷與恢復。
- `backend/tests/integration/realtime/clusterInstances.int.test.ts` —— 三個測試案例。

### 為什麼是兩個真實行程

`realtime/presence.ts` 的 tracker 存放在 module-level 的 `current`，而 `bootstrap/presence.ts` 透過 `configurePresence` 取代它並 `stop()` 掉前一個。因此行程內的第二個「instance」不會取得自己的 presence tracker，而是把第一個的搶走；`bootstrap/realtime.ts` 也未將 `presence` 傳入 `attachSockets`。只有分開的行程能讓兩個 instance 各自持有。

### 為什麼是 TCP proxy 而不是重啟 Redis

重啟 Redis 會對所有 instance 同時斷線，那並不是 `redisAdapter.ts` 所描述的失效情境（單一 instance 失去 subscriber、另一台持續發布），而且需要測試內部取得 Docker 控制權 —— CI（`ci-database.yml` 未掛載 Docker socket）與開發容器都不保證有。proxy 精準、免權限，且對「連線何時中斷」是確定性的。

### 兩個關鍵細節

1. **instance 必須拿到 `REDIS_URL` 而非 `REDIS_URL_TEST`。** `config/env.ts` 只讀前者（`grep -rn "REDIS_URL_TEST" backend/src/` 無任何結果）。若只給後者，instance 會在沒有 cluster adapter、也沒有 presence store 的狀態下啟動，於是所有「跨 instance」斷言都會在從未跨過 instance 的情況下通過。Issue #650 的內文在這點上有誤，此 PR 依實際程式碼修正。

2. **`/api/v1/health` 回應時 subscriber 尚未就緒。** `index.ts` 在開始服務前並未 await `redis.connect()`，adapter 的第一次 `SUBSCRIBE` 會失敗並由 watchdog 稍後補上。僅以 health 當就緒閘門會與每個斷言所依賴的訂閱競態。因此每次執行都會取得自己的 `REALTIME_CLUSTER_ID`，就緒與恢復都改以該 channel 上的 `PUBSUB NUMSUB` 直接讀取事實。

## 相關的 Issue (Related Issue)

Closes #650

Parent: #477。前置 #475（PR #646，已合併）。

## 變更類型 (Type of Change)

- [x] `test`: 新增或修正測試案例

## 驗證與測試計畫 (Verification & Test Plan)

### 本地測試 (Local Tests)

- [x] 後端型別檢查 (`pnpm exec tsc --noEmit`) —— 結束碼 `0`
- [x] 後端 Lint (`pnpm run lint`，即 `eslint src && tsc --noEmit`) —— 結束碼 `0`
- [x] 單元測試 (`pnpm run test:unit`) —— 767 pass / 0 fail
- [x] 整合測試 —— 新測試檔 3 pass / 0 fail，連續執行 3 次皆穩定（約 12.8 秒）

本次於本機以 PostgreSQL 16 與 Redis 7.0.15 實際執行（此環境無 Docker daemon，改以本機 binary 起服務並跑完 migrations）。完整 `bun test tests/integration` 為 **56 pass / 9 fail**；9 個失敗全部落在既有的 `presenceStore.int.test.ts`，原因是該檔需要 Redis 7.4+ 的 `HPEXPIRE`，而本機只有 7.0.15 —— 與本 PR 無關，且為改動前既有狀態（改動前為 53 pass / 9 fail，同樣 9 個）。CI 的 `redis:8-alpine` 不受此限制。

### 非空洞性驗證 (Negative Control)

為避免「測試通過但其實從未跨 instance」，將 bob 的 client 改連到發布端 instance A 後重跑：

- 第一次嘗試時三個案例**仍全數通過** —— 這揭露了一個真實缺陷：原本的「中斷期間不應收到訊息」斷言是在 publish **之後**才掛上 listener，因此永遠攔不到已送達的訊框，該斷言是空洞的。
- 修正為在 publish **之前**開始錄製後，同樣的 negative control 會如預期失敗（`rebuilds the subscription after its Redis link is cut and restored` 失敗），而正常設定 3 pass。

因此第三個案例同時擔任整個測試檔的守門員：若 client 實際上與發布端同機，該筆訊息會在中斷期間本機送達並被記錄，測試即失敗。

## 驗收標準對照

| 驗收標準 | 狀態 |
| --- | --- |
| 新測試檔存在且 `bun test tests/integration` 通過 | 通過（本機 9 個既有 presenceStore 失敗為 Redis 版本限制，見上） |
| harness 提供可切斷單一 instance subscriber 的 proxy，且有案例在切斷期間發布、恢復後斷言訂閱已重建 | 通過（`NUMSUB` 2 → cut → 1 → heal → 2，再實際送達一則訊息） |
| instance A 發出的 room event 與 user event，instance B 的 client 皆收到，各至少一個斷言 | 通過（`new_message`、`friend_request`） |
| 可在既有 CI Redis service 下執行，不需 Docker 控制權 | 通過 |
| `pnpm exec tsc --noEmit` 結束碼 `0` | 通過 |
| `pnpm run lint` 結束碼 `0` | 通過 |

### 一項刻意的偏離

驗收標準寫的是「新測試檔中 `grep -c "Bun.spawn" <新測試檔>` 大於 `0`」，但工作項目同時要求「harness 需可被後續子項重用」。兩者互相拉扯，此 PR 選擇了可重用：`Bun.spawn` 位於 `backend/tests/helpers/clusterHarness.ts`（由測試檔 import），因此成立的是

```
grep -c "Bun.spawn" backend/tests/helpers/clusterHarness.ts   # 1
grep -c "Bun.listen" backend/tests/helpers/clusterHarness.ts  # 2
```

而在測試檔上為 `0`。該標準的用意（測試確實以真實行程啟動，而非行程內的 server）已滿足，只是位置不同。#651 可直接沿用 `startCluster()`。

## 資料庫變更 (Database Changes)

* 此變更是否包含資料庫 Schema 修改？ **否**

## API 與 WebSocket 協定一致性 (API & WebSocket Contract Check)

* 此變更是否涉及 API 路由或 WebSocket 事件的資料結構變更？ **否**（僅新增測試，未更動任何契約）

## Advisor 主要提醒與採納

- 房間訂閱是握手後才由 durable membership 推導的，`realtime_ready` 之後才算就緒；已改為等待 `realtime_ready` 而非 `connect`。
- socket.io client 設為 `reconnection: false` —— 重連會重跑 `restoreSubscriptions`，等於默默修好本測試刻意弄壞的訂閱狀態。
- 房間以 `requireApproval: false` 建立：pending 成員會被 `socketServer.ts` 排除在房間訂閱之外，否則所有 room 斷言都會失敗且看不出原因。
- 不呼叫 `resetDb()`：在兩個子行程持有連線池時 truncate 共用資料庫，會波及前一個 suite；改為每次執行以獨立 token 命名 fixture，並在 `afterAll` 依 token 刪除。
- 子行程一律 SIGTERM → 最多等 10 秒 → SIGKILL 並 await，避免殘留連線池。

## 已知限制

- 本機無 Redis 7.4+，因此 `presenceStore.int.test.ts` 的 9 個既有案例無法在此環境驗證；請 reviewer 在具備 `redis:8-alpine` 的環境（或 CI）確認整包 `test:integration` 全綠。
- 本 PR 使用 `process.env.REDIS_URL_TEST`，預設值與既有整合測試一致（`redis://localhost:6385`）。#652（PR #662）正在補齊 compose 與 env 範本的 `REDIS_URL_TEST` 傳遞，兩者方向一致、無衝突。

Generated with Claude Code (https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpaT5m3Zs4uBJ4K3ZkyeuE)_